### PR TITLE
add `hotReloadCapable` to exec commands

### DIFF
--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -283,9 +283,7 @@ spec:
                             description: "Whatever the command needs to be restarted
                               when files changed. It should be set to \"false\" if
                               command is capable to do automatic hotreload. \n Default
-                              value: \n   - \"true\" for group.kind: build, test.
-                              \n   - \"false\" for group.kind: run, debug. \n   -
-                              \"false\" for all commands without group.kind"
+                              value is `true`"
                             type: boolean
                           workingDir:
                             description: Working directory where the command should
@@ -1017,11 +1015,8 @@ spec:
                                       description: "Whatever the command needs to
                                         be restarted when files changed. It should
                                         be set to \"false\" if command is capable
-                                        to do automatic hotreload. \n Default value:
-                                        \n   - \"true\" for group.kind: build, test.
-                                        \n   - \"false\" for group.kind: run, debug.
-                                        \n   - \"false\" for all commands without
-                                        group.kind"
+                                        to do automatic hotreload. \n Default value
+                                        is `true`"
                                       type: boolean
                                     workingDir:
                                       description: Working directory where the command
@@ -1854,10 +1849,7 @@ spec:
                                 description: "Whatever the command needs to be restarted
                                   when files changed. It should be set to \"false\"
                                   if command is capable to do automatic hotreload.
-                                  \n Default value: \n   - \"true\" for group.kind:
-                                  build, test. \n   - \"false\" for group.kind: run,
-                                  debug. \n   - \"false\" for all commands without
-                                  group.kind"
+                                  \n Default value is `true`"
                                 type: boolean
                               workingDir:
                                 description: Working directory where the command should
@@ -2609,10 +2601,7 @@ spec:
                                             to be restarted when files changed. It
                                             should be set to \"false\" if command
                                             is capable to do automatic hotreload.
-                                            \n Default value: \n   - \"true\" for
-                                            group.kind: build, test. \n   - \"false\"
-                                            for group.kind: run, debug. \n   - \"false\"
-                                            for all commands without group.kind"
+                                            \n Default value is `true`"
                                           type: boolean
                                         workingDir:
                                           description: Working directory where the

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -231,6 +231,16 @@ spec:
                             description: Optional map of free-form additional command
                               attributes
                             type: object
+                          background:
+                            description: 'Whatever the command needs should be executed
+                              on background. If "false" the controller should wait
+                              for command to finish and report its status. If "false"
+                              the controller won''t wait for it to finish (command
+                              can run indefinitely or until it is manually stopped).
+                              Default value is "true" for group.kind: run, debug.
+                              Default value is "false" for group.kind: build, test.
+                              Default value is "false" for all commands without group.kind'
+                            type: boolean
                           commandLine:
                             description: The actual command-line string
                             type: string
@@ -279,6 +289,14 @@ spec:
                             description: Optional label that provides a label for
                               this command to be used in Editor UI menus for example
                             type: string
+                          restartOnChange:
+                            description: 'Whatever the command needs be restarted
+                              when files changed. It should be set to "false" if command
+                              is capable to do automatic hotreload. Default value
+                              is "true" for group.kind: build, test. Default value
+                              is "false" for group.kind: run, debug. Default value
+                              is "false" for all commands without group.kind'
+                            type: boolean
                           workingDir:
                             description: Working directory where the command should
                               be executed
@@ -954,6 +972,18 @@ spec:
                                       description: Optional map of free-form additional
                                         command attributes
                                       type: object
+                                    background:
+                                      description: 'Whatever the command needs should
+                                        be executed on background. If "false" the
+                                        controller should wait for command to finish
+                                        and report its status. If "false" the controller
+                                        won''t wait for it to finish (command can
+                                        run indefinitely or until it is manually stopped).
+                                        Default value is "true" for group.kind: run,
+                                        debug. Default value is "false" for group.kind:
+                                        build, test. Default value is "false" for
+                                        all commands without group.kind'
+                                      type: boolean
                                     commandLine:
                                       description: The actual command-line string
                                       type: string
@@ -1005,6 +1035,16 @@ spec:
                                         label for this command to be used in Editor
                                         UI menus for example
                                       type: string
+                                    restartOnChange:
+                                      description: 'Whatever the command needs be
+                                        restarted when files changed. It should be
+                                        set to "false" if command is capable to do
+                                        automatic hotreload. Default value is "true"
+                                        for group.kind: build, test. Default value
+                                        is "false" for group.kind: run, debug. Default
+                                        value is "false" for all commands without
+                                        group.kind'
+                                      type: boolean
                                     workingDir:
                                       description: Working directory where the command
                                         should be executed
@@ -1781,6 +1821,17 @@ spec:
                                 description: Optional map of free-form additional
                                   command attributes
                                 type: object
+                              background:
+                                description: 'Whatever the command needs should be
+                                  executed on background. If "false" the controller
+                                  should wait for command to finish and report its
+                                  status. If "false" the controller won''t wait for
+                                  it to finish (command can run indefinitely or until
+                                  it is manually stopped). Default value is "true"
+                                  for group.kind: run, debug. Default value is "false"
+                                  for group.kind: build, test. Default value is "false"
+                                  for all commands without group.kind'
+                                type: boolean
                               commandLine:
                                 description: The actual command-line string
                                 type: string
@@ -1832,6 +1883,15 @@ spec:
                                   for this command to be used in Editor UI menus for
                                   example
                                 type: string
+                              restartOnChange:
+                                description: 'Whatever the command needs be restarted
+                                  when files changed. It should be set to "false"
+                                  if command is capable to do automatic hotreload.
+                                  Default value is "true" for group.kind: build, test.
+                                  Default value is "false" for group.kind: run, debug.
+                                  Default value is "false" for all commands without
+                                  group.kind'
+                                type: boolean
                               workingDir:
                                 description: Working directory where the command should
                                   be executed
@@ -2525,6 +2585,19 @@ spec:
                                           description: Optional map of free-form additional
                                             command attributes
                                           type: object
+                                        background:
+                                          description: 'Whatever the command needs
+                                            should be executed on background. If "false"
+                                            the controller should wait for command
+                                            to finish and report its status. If "false"
+                                            the controller won''t wait for it to finish
+                                            (command can run indefinitely or until
+                                            it is manually stopped). Default value
+                                            is "true" for group.kind: run, debug.
+                                            Default value is "false" for group.kind:
+                                            build, test. Default value is "false"
+                                            for all commands without group.kind'
+                                          type: boolean
                                         commandLine:
                                           description: The actual command-line string
                                           type: string
@@ -2577,6 +2650,16 @@ spec:
                                             a label for this command to be used in
                                             Editor UI menus for example
                                           type: string
+                                        restartOnChange:
+                                          description: 'Whatever the command needs
+                                            be restarted when files changed. It should
+                                            be set to "false" if command is capable
+                                            to do automatic hotreload. Default value
+                                            is "true" for group.kind: build, test.
+                                            Default value is "false" for group.kind:
+                                            run, debug. Default value is "false" for
+                                            all commands without group.kind'
+                                          type: boolean
                                         workingDir:
                                           description: Working directory where the
                                             command should be executed

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -270,6 +270,13 @@ spec:
                             required:
                             - kind
                             type: object
+                          hotReloadCapable:
+                            description: "Whatever the command it capable to reload
+                              itself when source code changes. If set to \"true\"
+                              the command won't be restarted and it is expected to
+                              handle file changes on its own. \n Default value is
+                              `false`"
+                            type: boolean
                           id:
                             description: Mandatory identifier that allows referencing
                               this command in composite commands, from a parent, or
@@ -279,12 +286,6 @@ spec:
                             description: Optional label that provides a label for
                               this command to be used in Editor UI menus for example
                             type: string
-                          restartOnChange:
-                            description: "Whatever the command needs to be restarted
-                              when files changed. It should be set to \"false\" if
-                              command is capable to do automatic hotreload. \n Default
-                              value is `true`"
-                            type: boolean
                           workingDir:
                             description: Working directory where the command should
                               be executed
@@ -1001,6 +1002,13 @@ spec:
                                       required:
                                       - kind
                                       type: object
+                                    hotReloadCapable:
+                                      description: "Whatever the command it capable
+                                        to reload itself when source code changes.
+                                        If set to \"true\" the command won't be restarted
+                                        and it is expected to handle file changes
+                                        on its own. \n Default value is `false`"
+                                      type: boolean
                                     id:
                                       description: Mandatory identifier that allows
                                         referencing this command in composite commands,
@@ -1011,13 +1019,6 @@ spec:
                                         label for this command to be used in Editor
                                         UI menus for example
                                       type: string
-                                    restartOnChange:
-                                      description: "Whatever the command needs to
-                                        be restarted when files changed. It should
-                                        be set to \"false\" if command is capable
-                                        to do automatic hotreload. \n Default value
-                                        is `true`"
-                                      type: boolean
                                     workingDir:
                                       description: Working directory where the command
                                         should be executed
@@ -1835,6 +1836,13 @@ spec:
                                 required:
                                 - kind
                                 type: object
+                              hotReloadCapable:
+                                description: "Whatever the command it capable to reload
+                                  itself when source code changes. If set to \"true\"
+                                  the command won't be restarted and it is expected
+                                  to handle file changes on its own. \n Default value
+                                  is `false`"
+                                type: boolean
                               id:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
@@ -1845,12 +1853,6 @@ spec:
                                   for this command to be used in Editor UI menus for
                                   example
                                 type: string
-                              restartOnChange:
-                                description: "Whatever the command needs to be restarted
-                                  when files changed. It should be set to \"false\"
-                                  if command is capable to do automatic hotreload.
-                                  \n Default value is `true`"
-                                type: boolean
                               workingDir:
                                 description: Working directory where the command should
                                   be executed
@@ -2586,6 +2588,14 @@ spec:
                                           required:
                                           - kind
                                           type: object
+                                        hotReloadCapable:
+                                          description: "Whatever the command it capable
+                                            to reload itself when source code changes.
+                                            If set to \"true\" the command won't be
+                                            restarted and it is expected to handle
+                                            file changes on its own. \n Default value
+                                            is `false`"
+                                          type: boolean
                                         id:
                                           description: Mandatory identifier that allows
                                             referencing this command in composite
@@ -2596,13 +2606,6 @@ spec:
                                             a label for this command to be used in
                                             Editor UI menus for example
                                           type: string
-                                        restartOnChange:
-                                          description: "Whatever the command needs
-                                            to be restarted when files changed. It
-                                            should be set to \"false\" if command
-                                            is capable to do automatic hotreload.
-                                            \n Default value is `true`"
-                                          type: boolean
                                         workingDir:
                                           description: Working directory where the
                                             command should be executed

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -231,16 +231,6 @@ spec:
                             description: Optional map of free-form additional command
                               attributes
                             type: object
-                          background:
-                            description: 'Whatever the command needs should be executed
-                              on background. If "false" the controller should wait
-                              for command to finish and report its status. If "false"
-                              the controller won''t wait for it to finish (command
-                              can run indefinitely or until it is manually stopped).
-                              Default value is "true" for group.kind: run, debug.
-                              Default value is "false" for group.kind: build, test.
-                              Default value is "false" for all commands without group.kind'
-                            type: boolean
                           commandLine:
                             description: The actual command-line string
                             type: string
@@ -290,7 +280,7 @@ spec:
                               this command to be used in Editor UI menus for example
                             type: string
                           restartOnChange:
-                            description: 'Whatever the command needs be restarted
+                            description: 'Whatever the command needs to be restarted
                               when files changed. It should be set to "false" if command
                               is capable to do automatic hotreload. Default value
                               is "true" for group.kind: build, test. Default value
@@ -972,18 +962,6 @@ spec:
                                       description: Optional map of free-form additional
                                         command attributes
                                       type: object
-                                    background:
-                                      description: 'Whatever the command needs should
-                                        be executed on background. If "false" the
-                                        controller should wait for command to finish
-                                        and report its status. If "false" the controller
-                                        won''t wait for it to finish (command can
-                                        run indefinitely or until it is manually stopped).
-                                        Default value is "true" for group.kind: run,
-                                        debug. Default value is "false" for group.kind:
-                                        build, test. Default value is "false" for
-                                        all commands without group.kind'
-                                      type: boolean
                                     commandLine:
                                       description: The actual command-line string
                                       type: string
@@ -1036,10 +1014,10 @@ spec:
                                         UI menus for example
                                       type: string
                                     restartOnChange:
-                                      description: 'Whatever the command needs be
-                                        restarted when files changed. It should be
-                                        set to "false" if command is capable to do
-                                        automatic hotreload. Default value is "true"
+                                      description: 'Whatever the command needs to
+                                        be restarted when files changed. It should
+                                        be set to "false" if command is capable to
+                                        do automatic hotreload. Default value is "true"
                                         for group.kind: build, test. Default value
                                         is "false" for group.kind: run, debug. Default
                                         value is "false" for all commands without
@@ -1821,17 +1799,6 @@ spec:
                                 description: Optional map of free-form additional
                                   command attributes
                                 type: object
-                              background:
-                                description: 'Whatever the command needs should be
-                                  executed on background. If "false" the controller
-                                  should wait for command to finish and report its
-                                  status. If "false" the controller won''t wait for
-                                  it to finish (command can run indefinitely or until
-                                  it is manually stopped). Default value is "true"
-                                  for group.kind: run, debug. Default value is "false"
-                                  for group.kind: build, test. Default value is "false"
-                                  for all commands without group.kind'
-                                type: boolean
                               commandLine:
                                 description: The actual command-line string
                                 type: string
@@ -1884,7 +1851,7 @@ spec:
                                   example
                                 type: string
                               restartOnChange:
-                                description: 'Whatever the command needs be restarted
+                                description: 'Whatever the command needs to be restarted
                                   when files changed. It should be set to "false"
                                   if command is capable to do automatic hotreload.
                                   Default value is "true" for group.kind: build, test.
@@ -2585,19 +2552,6 @@ spec:
                                           description: Optional map of free-form additional
                                             command attributes
                                           type: object
-                                        background:
-                                          description: 'Whatever the command needs
-                                            should be executed on background. If "false"
-                                            the controller should wait for command
-                                            to finish and report its status. If "false"
-                                            the controller won''t wait for it to finish
-                                            (command can run indefinitely or until
-                                            it is manually stopped). Default value
-                                            is "true" for group.kind: run, debug.
-                                            Default value is "false" for group.kind:
-                                            build, test. Default value is "false"
-                                            for all commands without group.kind'
-                                          type: boolean
                                         commandLine:
                                           description: The actual command-line string
                                           type: string
@@ -2652,11 +2606,11 @@ spec:
                                           type: string
                                         restartOnChange:
                                           description: 'Whatever the command needs
-                                            be restarted when files changed. It should
-                                            be set to "false" if command is capable
-                                            to do automatic hotreload. Default value
-                                            is "true" for group.kind: build, test.
-                                            Default value is "false" for group.kind:
+                                            to be restarted when files changed. It
+                                            should be set to "false" if command is
+                                            capable to do automatic hotreload. Default
+                                            value is "true" for group.kind: build,
+                                            test. Default value is "false" for group.kind:
                                             run, debug. Default value is "false" for
                                             all commands without group.kind'
                                           type: boolean

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -280,12 +280,12 @@ spec:
                               this command to be used in Editor UI menus for example
                             type: string
                           restartOnChange:
-                            description: 'Whatever the command needs to be restarted
-                              when files changed. It should be set to "false" if command
-                              is capable to do automatic hotreload. Default value
-                              is "true" for group.kind: build, test. Default value
-                              is "false" for group.kind: run, debug. Default value
-                              is "false" for all commands without group.kind'
+                            description: "Whatever the command needs to be restarted
+                              when files changed. It should be set to \"false\" if
+                              command is capable to do automatic hotreload. \n Default
+                              value: \n   - \"true\" for group.kind: build, test.
+                              \n   - \"false\" for group.kind: run, debug. \n   -
+                              \"false\" for all commands without group.kind"
                             type: boolean
                           workingDir:
                             description: Working directory where the command should
@@ -1014,14 +1014,14 @@ spec:
                                         UI menus for example
                                       type: string
                                     restartOnChange:
-                                      description: 'Whatever the command needs to
+                                      description: "Whatever the command needs to
                                         be restarted when files changed. It should
-                                        be set to "false" if command is capable to
-                                        do automatic hotreload. Default value is "true"
-                                        for group.kind: build, test. Default value
-                                        is "false" for group.kind: run, debug. Default
-                                        value is "false" for all commands without
-                                        group.kind'
+                                        be set to \"false\" if command is capable
+                                        to do automatic hotreload. \n Default value:
+                                        \n   - \"true\" for group.kind: build, test.
+                                        \n   - \"false\" for group.kind: run, debug.
+                                        \n   - \"false\" for all commands without
+                                        group.kind"
                                       type: boolean
                                     workingDir:
                                       description: Working directory where the command
@@ -1851,13 +1851,13 @@ spec:
                                   example
                                 type: string
                               restartOnChange:
-                                description: 'Whatever the command needs to be restarted
-                                  when files changed. It should be set to "false"
+                                description: "Whatever the command needs to be restarted
+                                  when files changed. It should be set to \"false\"
                                   if command is capable to do automatic hotreload.
-                                  Default value is "true" for group.kind: build, test.
-                                  Default value is "false" for group.kind: run, debug.
-                                  Default value is "false" for all commands without
-                                  group.kind'
+                                  \n Default value: \n   - \"true\" for group.kind:
+                                  build, test. \n   - \"false\" for group.kind: run,
+                                  debug. \n   - \"false\" for all commands without
+                                  group.kind"
                                 type: boolean
                               workingDir:
                                 description: Working directory where the command should
@@ -2605,14 +2605,14 @@ spec:
                                             Editor UI menus for example
                                           type: string
                                         restartOnChange:
-                                          description: 'Whatever the command needs
+                                          description: "Whatever the command needs
                                             to be restarted when files changed. It
-                                            should be set to "false" if command is
-                                            capable to do automatic hotreload. Default
-                                            value is "true" for group.kind: build,
-                                            test. Default value is "false" for group.kind:
-                                            run, debug. Default value is "false" for
-                                            all commands without group.kind'
+                                            should be set to \"false\" if command
+                                            is capable to do automatic hotreload.
+                                            \n Default value: \n   - \"true\" for
+                                            group.kind: build, test. \n   - \"false\"
+                                            for group.kind: run, debug. \n   - \"false\"
+                                            for all commands without group.kind"
                                           type: boolean
                                         workingDir:
                                           description: Working directory where the

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -271,11 +271,10 @@ spec:
                             - kind
                             type: object
                           hotReloadCapable:
-                            description: "Whatever the command it capable to reload
-                              itself when source code changes. If set to \"true\"
-                              the command won't be restarted and it is expected to
-                              handle file changes on its own. \n Default value is
-                              `false`"
+                            description: "Whether the command it capable to reload
+                              itself when source code changes. If set to `true` the
+                              command won't be restarted and it is expected to handle
+                              file changes on its own. \n Default value is `false`"
                             type: boolean
                           id:
                             description: Mandatory identifier that allows referencing
@@ -1003,9 +1002,9 @@ spec:
                                       - kind
                                       type: object
                                     hotReloadCapable:
-                                      description: "Whatever the command it capable
+                                      description: "Whether the command it capable
                                         to reload itself when source code changes.
-                                        If set to \"true\" the command won't be restarted
+                                        If set to `true` the command won't be restarted
                                         and it is expected to handle file changes
                                         on its own. \n Default value is `false`"
                                       type: boolean
@@ -1837,8 +1836,8 @@ spec:
                                 - kind
                                 type: object
                               hotReloadCapable:
-                                description: "Whatever the command it capable to reload
-                                  itself when source code changes. If set to \"true\"
+                                description: "Whether the command it capable to reload
+                                  itself when source code changes. If set to `true`
                                   the command won't be restarted and it is expected
                                   to handle file changes on its own. \n Default value
                                   is `false`"
@@ -2589,9 +2588,9 @@ spec:
                                           - kind
                                           type: object
                                         hotReloadCapable:
-                                          description: "Whatever the command it capable
+                                          description: "Whether the command it capable
                                             to reload itself when source code changes.
-                                            If set to \"true\" the command won't be
+                                            If set to `true` the command won't be
                                             restarted and it is expected to handle
                                             file changes on its own. \n Default value
                                             is `false`"

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -271,7 +271,7 @@ spec:
                             - kind
                             type: object
                           hotReloadCapable:
-                            description: "Whether the command it capable to reload
+                            description: "Whether the command is capable to reload
                               itself when source code changes. If set to `true` the
                               command won't be restarted and it is expected to handle
                               file changes on its own. \n Default value is `false`"
@@ -1002,7 +1002,7 @@ spec:
                                       - kind
                                       type: object
                                     hotReloadCapable:
-                                      description: "Whether the command it capable
+                                      description: "Whether the command is capable
                                         to reload itself when source code changes.
                                         If set to `true` the command won't be restarted
                                         and it is expected to handle file changes
@@ -1836,7 +1836,7 @@ spec:
                                 - kind
                                 type: object
                               hotReloadCapable:
-                                description: "Whether the command it capable to reload
+                                description: "Whether the command is capable to reload
                                   itself when source code changes. If set to `true`
                                   the command won't be restarted and it is expected
                                   to handle file changes on its own. \n Default value
@@ -2588,7 +2588,7 @@ spec:
                                           - kind
                                           type: object
                                         hotReloadCapable:
-                                          description: "Whether the command it capable
+                                          description: "Whether the command is capable
                                             to reload itself when source code changes.
                                             If set to `true` the command won't be
                                             restarted and it is expected to handle

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -257,10 +257,8 @@ spec:
                       restartOnChange:
                         description: "Whatever the command needs to be restarted when
                           files changed. It should be set to \"false\" if command
-                          is capable to do automatic hotreload. \n Default value:
-                          \n   - \"true\" for group.kind: build, test. \n   - \"false\"
-                          for group.kind: run, debug. \n   - \"false\" for all commands
-                          without group.kind"
+                          is capable to do automatic hotreload. \n Default value is
+                          `true`"
                         type: boolean
                       workingDir:
                         description: Working directory where the command should be
@@ -972,10 +970,7 @@ spec:
                                   description: "Whatever the command needs to be restarted
                                     when files changed. It should be set to \"false\"
                                     if command is capable to do automatic hotreload.
-                                    \n Default value: \n   - \"true\" for group.kind:
-                                    build, test. \n   - \"false\" for group.kind:
-                                    run, debug. \n   - \"false\" for all commands
-                                    without group.kind"
+                                    \n Default value is `true`"
                                   type: boolean
                                 workingDir:
                                   description: Working directory where the command
@@ -1775,9 +1770,7 @@ spec:
                             description: "Whatever the command needs to be restarted
                               when files changed. It should be set to \"false\" if
                               command is capable to do automatic hotreload. \n Default
-                              value: \n   - \"true\" for group.kind: build, test.
-                              \n   - \"false\" for group.kind: run, debug. \n   -
-                              \"false\" for all commands without group.kind"
+                              value is `true`"
                             type: boolean
                           workingDir:
                             description: Working directory where the command should
@@ -2509,11 +2502,8 @@ spec:
                                       description: "Whatever the command needs to
                                         be restarted when files changed. It should
                                         be set to \"false\" if command is capable
-                                        to do automatic hotreload. \n Default value:
-                                        \n   - \"true\" for group.kind: build, test.
-                                        \n   - \"false\" for group.kind: run, debug.
-                                        \n   - \"false\" for all commands without
-                                        group.kind"
+                                        to do automatic hotreload. \n Default value
+                                        is `true`"
                                       type: boolean
                                     workingDir:
                                       description: Working directory where the command

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -246,10 +246,10 @@ spec:
                         - kind
                         type: object
                       hotReloadCapable:
-                        description: "Whatever the command it capable to reload itself
-                          when source code changes. If set to \"true\" the command
-                          won't be restarted and it is expected to handle file changes
-                          on its own. \n Default value is `false`"
+                        description: "Whether the command it capable to reload itself
+                          when source code changes. If set to `true` the command won't
+                          be restarted and it is expected to handle file changes on
+                          its own. \n Default value is `false`"
                         type: boolean
                       id:
                         description: Mandatory identifier that allows referencing
@@ -957,10 +957,10 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whatever the command it capable to
+                                  description: "Whether the command it capable to
                                     reload itself when source code changes. If set
-                                    to \"true\" the command won't be restarted and
-                                    it is expected to handle file changes on its own.
+                                    to `true` the command won't be restarted and it
+                                    is expected to handle file changes on its own.
                                     \n Default value is `false`"
                                   type: boolean
                                 id:
@@ -1759,11 +1759,10 @@ spec:
                             - kind
                             type: object
                           hotReloadCapable:
-                            description: "Whatever the command it capable to reload
-                              itself when source code changes. If set to \"true\"
-                              the command won't be restarted and it is expected to
-                              handle file changes on its own. \n Default value is
-                              `false`"
+                            description: "Whether the command it capable to reload
+                              itself when source code changes. If set to `true` the
+                              command won't be restarted and it is expected to handle
+                              file changes on its own. \n Default value is `false`"
                             type: boolean
                           id:
                             description: Mandatory identifier that allows referencing
@@ -2491,9 +2490,9 @@ spec:
                                       - kind
                                       type: object
                                     hotReloadCapable:
-                                      description: "Whatever the command it capable
+                                      description: "Whether the command it capable
                                         to reload itself when source code changes.
-                                        If set to \"true\" the command won't be restarted
+                                        If set to `true` the command won't be restarted
                                         and it is expected to handle file changes
                                         on its own. \n Default value is `false`"
                                       type: boolean

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -207,16 +207,6 @@ spec:
                         description: Optional map of free-form additional command
                           attributes
                         type: object
-                      background:
-                        description: 'Whatever the command needs should be executed
-                          on background. If "false" the controller should wait for
-                          command to finish and report its status. If "false" the
-                          controller won''t wait for it to finish (command can run
-                          indefinitely or until it is manually stopped). Default value
-                          is "true" for group.kind: run, debug. Default value is "false"
-                          for group.kind: build, test. Default value is "false" for
-                          all commands without group.kind'
-                        type: boolean
                       commandLine:
                         description: The actual command-line string
                         type: string
@@ -265,7 +255,7 @@ spec:
                           command to be used in Editor UI menus for example
                         type: string
                       restartOnChange:
-                        description: 'Whatever the command needs be restarted when
+                        description: 'Whatever the command needs to be restarted when
                           files changed. It should be set to "false" if command is
                           capable to do automatic hotreload. Default value is "true"
                           for group.kind: build, test. Default value is "false" for
@@ -927,18 +917,6 @@ spec:
                                   description: Optional map of free-form additional
                                     command attributes
                                   type: object
-                                background:
-                                  description: 'Whatever the command needs should
-                                    be executed on background. If "false" the controller
-                                    should wait for command to finish and report its
-                                    status. If "false" the controller won''t wait
-                                    for it to finish (command can run indefinitely
-                                    or until it is manually stopped). Default value
-                                    is "true" for group.kind: run, debug. Default
-                                    value is "false" for group.kind: build, test.
-                                    Default value is "false" for all commands without
-                                    group.kind'
-                                  type: boolean
                                 commandLine:
                                   description: The actual command-line string
                                   type: string
@@ -991,7 +969,7 @@ spec:
                                     for example
                                   type: string
                                 restartOnChange:
-                                  description: 'Whatever the command needs be restarted
+                                  description: 'Whatever the command needs to be restarted
                                     when files changed. It should be set to "false"
                                     if command is capable to do automatic hotreload.
                                     Default value is "true" for group.kind: build,
@@ -1745,16 +1723,6 @@ spec:
                             description: Optional map of free-form additional command
                               attributes
                             type: object
-                          background:
-                            description: 'Whatever the command needs should be executed
-                              on background. If "false" the controller should wait
-                              for command to finish and report its status. If "false"
-                              the controller won''t wait for it to finish (command
-                              can run indefinitely or until it is manually stopped).
-                              Default value is "true" for group.kind: run, debug.
-                              Default value is "false" for group.kind: build, test.
-                              Default value is "false" for all commands without group.kind'
-                            type: boolean
                           commandLine:
                             description: The actual command-line string
                             type: string
@@ -1804,7 +1772,7 @@ spec:
                               this command to be used in Editor UI menus for example
                             type: string
                           restartOnChange:
-                            description: 'Whatever the command needs be restarted
+                            description: 'Whatever the command needs to be restarted
                               when files changed. It should be set to "false" if command
                               is capable to do automatic hotreload. Default value
                               is "true" for group.kind: build, test. Default value
@@ -2486,18 +2454,6 @@ spec:
                                       description: Optional map of free-form additional
                                         command attributes
                                       type: object
-                                    background:
-                                      description: 'Whatever the command needs should
-                                        be executed on background. If "false" the
-                                        controller should wait for command to finish
-                                        and report its status. If "false" the controller
-                                        won''t wait for it to finish (command can
-                                        run indefinitely or until it is manually stopped).
-                                        Default value is "true" for group.kind: run,
-                                        debug. Default value is "false" for group.kind:
-                                        build, test. Default value is "false" for
-                                        all commands without group.kind'
-                                      type: boolean
                                     commandLine:
                                       description: The actual command-line string
                                       type: string
@@ -2550,10 +2506,10 @@ spec:
                                         UI menus for example
                                       type: string
                                     restartOnChange:
-                                      description: 'Whatever the command needs be
-                                        restarted when files changed. It should be
-                                        set to "false" if command is capable to do
-                                        automatic hotreload. Default value is "true"
+                                      description: 'Whatever the command needs to
+                                        be restarted when files changed. It should
+                                        be set to "false" if command is capable to
+                                        do automatic hotreload. Default value is "true"
                                         for group.kind: build, test. Default value
                                         is "false" for group.kind: run, debug. Default
                                         value is "false" for all commands without

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -245,6 +245,12 @@ spec:
                         required:
                         - kind
                         type: object
+                      hotReloadCapable:
+                        description: "Whatever the command it capable to reload itself
+                          when source code changes. If set to \"true\" the command
+                          won't be restarted and it is expected to handle file changes
+                          on its own. \n Default value is `false`"
+                        type: boolean
                       id:
                         description: Mandatory identifier that allows referencing
                           this command in composite commands, from a parent, or in
@@ -254,12 +260,6 @@ spec:
                         description: Optional label that provides a label for this
                           command to be used in Editor UI menus for example
                         type: string
-                      restartOnChange:
-                        description: "Whatever the command needs to be restarted when
-                          files changed. It should be set to \"false\" if command
-                          is capable to do automatic hotreload. \n Default value is
-                          `true`"
-                        type: boolean
                       workingDir:
                         description: Working directory where the command should be
                           executed
@@ -956,6 +956,13 @@ spec:
                                   required:
                                   - kind
                                   type: object
+                                hotReloadCapable:
+                                  description: "Whatever the command it capable to
+                                    reload itself when source code changes. If set
+                                    to \"true\" the command won't be restarted and
+                                    it is expected to handle file changes on its own.
+                                    \n Default value is `false`"
+                                  type: boolean
                                 id:
                                   description: Mandatory identifier that allows referencing
                                     this command in composite commands, from a parent,
@@ -966,12 +973,6 @@ spec:
                                     for this command to be used in Editor UI menus
                                     for example
                                   type: string
-                                restartOnChange:
-                                  description: "Whatever the command needs to be restarted
-                                    when files changed. It should be set to \"false\"
-                                    if command is capable to do automatic hotreload.
-                                    \n Default value is `true`"
-                                  type: boolean
                                 workingDir:
                                   description: Working directory where the command
                                     should be executed
@@ -1757,6 +1758,13 @@ spec:
                             required:
                             - kind
                             type: object
+                          hotReloadCapable:
+                            description: "Whatever the command it capable to reload
+                              itself when source code changes. If set to \"true\"
+                              the command won't be restarted and it is expected to
+                              handle file changes on its own. \n Default value is
+                              `false`"
+                            type: boolean
                           id:
                             description: Mandatory identifier that allows referencing
                               this command in composite commands, from a parent, or
@@ -1766,12 +1774,6 @@ spec:
                             description: Optional label that provides a label for
                               this command to be used in Editor UI menus for example
                             type: string
-                          restartOnChange:
-                            description: "Whatever the command needs to be restarted
-                              when files changed. It should be set to \"false\" if
-                              command is capable to do automatic hotreload. \n Default
-                              value is `true`"
-                            type: boolean
                           workingDir:
                             description: Working directory where the command should
                               be executed
@@ -2488,6 +2490,13 @@ spec:
                                       required:
                                       - kind
                                       type: object
+                                    hotReloadCapable:
+                                      description: "Whatever the command it capable
+                                        to reload itself when source code changes.
+                                        If set to \"true\" the command won't be restarted
+                                        and it is expected to handle file changes
+                                        on its own. \n Default value is `false`"
+                                      type: boolean
                                     id:
                                       description: Mandatory identifier that allows
                                         referencing this command in composite commands,
@@ -2498,13 +2507,6 @@ spec:
                                         label for this command to be used in Editor
                                         UI menus for example
                                       type: string
-                                    restartOnChange:
-                                      description: "Whatever the command needs to
-                                        be restarted when files changed. It should
-                                        be set to \"false\" if command is capable
-                                        to do automatic hotreload. \n Default value
-                                        is `true`"
-                                      type: boolean
                                     workingDir:
                                       description: Working directory where the command
                                         should be executed

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -246,7 +246,7 @@ spec:
                         - kind
                         type: object
                       hotReloadCapable:
-                        description: "Whether the command it capable to reload itself
+                        description: "Whether the command is capable to reload itself
                           when source code changes. If set to `true` the command won't
                           be restarted and it is expected to handle file changes on
                           its own. \n Default value is `false`"
@@ -957,7 +957,7 @@ spec:
                                   - kind
                                   type: object
                                 hotReloadCapable:
-                                  description: "Whether the command it capable to
+                                  description: "Whether the command is capable to
                                     reload itself when source code changes. If set
                                     to `true` the command won't be restarted and it
                                     is expected to handle file changes on its own.
@@ -1759,7 +1759,7 @@ spec:
                             - kind
                             type: object
                           hotReloadCapable:
-                            description: "Whether the command it capable to reload
+                            description: "Whether the command is capable to reload
                               itself when source code changes. If set to `true` the
                               command won't be restarted and it is expected to handle
                               file changes on its own. \n Default value is `false`"
@@ -2490,7 +2490,7 @@ spec:
                                       - kind
                                       type: object
                                     hotReloadCapable:
-                                      description: "Whether the command it capable
+                                      description: "Whether the command is capable
                                         to reload itself when source code changes.
                                         If set to `true` the command won't be restarted
                                         and it is expected to handle file changes

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -255,12 +255,12 @@ spec:
                           command to be used in Editor UI menus for example
                         type: string
                       restartOnChange:
-                        description: 'Whatever the command needs to be restarted when
-                          files changed. It should be set to "false" if command is
-                          capable to do automatic hotreload. Default value is "true"
-                          for group.kind: build, test. Default value is "false" for
-                          group.kind: run, debug. Default value is "false" for all
-                          commands without group.kind'
+                        description: "Whatever the command needs to be restarted when
+                          files changed. It should be set to \"false\" if command
+                          is capable to do automatic hotreload. \n Default value:
+                          \n   - \"true\" for group.kind: build, test. \n   - \"false\"
+                          for group.kind: run, debug. \n   - \"false\" for all commands
+                          without group.kind"
                         type: boolean
                       workingDir:
                         description: Working directory where the command should be
@@ -969,13 +969,13 @@ spec:
                                     for example
                                   type: string
                                 restartOnChange:
-                                  description: 'Whatever the command needs to be restarted
-                                    when files changed. It should be set to "false"
+                                  description: "Whatever the command needs to be restarted
+                                    when files changed. It should be set to \"false\"
                                     if command is capable to do automatic hotreload.
-                                    Default value is "true" for group.kind: build,
-                                    test. Default value is "false" for group.kind:
-                                    run, debug. Default value is "false" for all commands
-                                    without group.kind'
+                                    \n Default value: \n   - \"true\" for group.kind:
+                                    build, test. \n   - \"false\" for group.kind:
+                                    run, debug. \n   - \"false\" for all commands
+                                    without group.kind"
                                   type: boolean
                                 workingDir:
                                   description: Working directory where the command
@@ -1772,12 +1772,12 @@ spec:
                               this command to be used in Editor UI menus for example
                             type: string
                           restartOnChange:
-                            description: 'Whatever the command needs to be restarted
-                              when files changed. It should be set to "false" if command
-                              is capable to do automatic hotreload. Default value
-                              is "true" for group.kind: build, test. Default value
-                              is "false" for group.kind: run, debug. Default value
-                              is "false" for all commands without group.kind'
+                            description: "Whatever the command needs to be restarted
+                              when files changed. It should be set to \"false\" if
+                              command is capable to do automatic hotreload. \n Default
+                              value: \n   - \"true\" for group.kind: build, test.
+                              \n   - \"false\" for group.kind: run, debug. \n   -
+                              \"false\" for all commands without group.kind"
                             type: boolean
                           workingDir:
                             description: Working directory where the command should
@@ -2506,14 +2506,14 @@ spec:
                                         UI menus for example
                                       type: string
                                     restartOnChange:
-                                      description: 'Whatever the command needs to
+                                      description: "Whatever the command needs to
                                         be restarted when files changed. It should
-                                        be set to "false" if command is capable to
-                                        do automatic hotreload. Default value is "true"
-                                        for group.kind: build, test. Default value
-                                        is "false" for group.kind: run, debug. Default
-                                        value is "false" for all commands without
-                                        group.kind'
+                                        be set to \"false\" if command is capable
+                                        to do automatic hotreload. \n Default value:
+                                        \n   - \"true\" for group.kind: build, test.
+                                        \n   - \"false\" for group.kind: run, debug.
+                                        \n   - \"false\" for all commands without
+                                        group.kind"
                                       type: boolean
                                     workingDir:
                                       description: Working directory where the command

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -207,6 +207,16 @@ spec:
                         description: Optional map of free-form additional command
                           attributes
                         type: object
+                      background:
+                        description: 'Whatever the command needs should be executed
+                          on background. If "false" the controller should wait for
+                          command to finish and report its status. If "false" the
+                          controller won''t wait for it to finish (command can run
+                          indefinitely or until it is manually stopped). Default value
+                          is "true" for group.kind: run, debug. Default value is "false"
+                          for group.kind: build, test. Default value is "false" for
+                          all commands without group.kind'
+                        type: boolean
                       commandLine:
                         description: The actual command-line string
                         type: string
@@ -254,6 +264,14 @@ spec:
                         description: Optional label that provides a label for this
                           command to be used in Editor UI menus for example
                         type: string
+                      restartOnChange:
+                        description: 'Whatever the command needs be restarted when
+                          files changed. It should be set to "false" if command is
+                          capable to do automatic hotreload. Default value is "true"
+                          for group.kind: build, test. Default value is "false" for
+                          group.kind: run, debug. Default value is "false" for all
+                          commands without group.kind'
+                        type: boolean
                       workingDir:
                         description: Working directory where the command should be
                           executed
@@ -909,6 +927,18 @@ spec:
                                   description: Optional map of free-form additional
                                     command attributes
                                   type: object
+                                background:
+                                  description: 'Whatever the command needs should
+                                    be executed on background. If "false" the controller
+                                    should wait for command to finish and report its
+                                    status. If "false" the controller won''t wait
+                                    for it to finish (command can run indefinitely
+                                    or until it is manually stopped). Default value
+                                    is "true" for group.kind: run, debug. Default
+                                    value is "false" for group.kind: build, test.
+                                    Default value is "false" for all commands without
+                                    group.kind'
+                                  type: boolean
                                 commandLine:
                                   description: The actual command-line string
                                   type: string
@@ -960,6 +990,15 @@ spec:
                                     for this command to be used in Editor UI menus
                                     for example
                                   type: string
+                                restartOnChange:
+                                  description: 'Whatever the command needs be restarted
+                                    when files changed. It should be set to "false"
+                                    if command is capable to do automatic hotreload.
+                                    Default value is "true" for group.kind: build,
+                                    test. Default value is "false" for group.kind:
+                                    run, debug. Default value is "false" for all commands
+                                    without group.kind'
+                                  type: boolean
                                 workingDir:
                                   description: Working directory where the command
                                     should be executed
@@ -1706,6 +1745,16 @@ spec:
                             description: Optional map of free-form additional command
                               attributes
                             type: object
+                          background:
+                            description: 'Whatever the command needs should be executed
+                              on background. If "false" the controller should wait
+                              for command to finish and report its status. If "false"
+                              the controller won''t wait for it to finish (command
+                              can run indefinitely or until it is manually stopped).
+                              Default value is "true" for group.kind: run, debug.
+                              Default value is "false" for group.kind: build, test.
+                              Default value is "false" for all commands without group.kind'
+                            type: boolean
                           commandLine:
                             description: The actual command-line string
                             type: string
@@ -1754,6 +1803,14 @@ spec:
                             description: Optional label that provides a label for
                               this command to be used in Editor UI menus for example
                             type: string
+                          restartOnChange:
+                            description: 'Whatever the command needs be restarted
+                              when files changed. It should be set to "false" if command
+                              is capable to do automatic hotreload. Default value
+                              is "true" for group.kind: build, test. Default value
+                              is "false" for group.kind: run, debug. Default value
+                              is "false" for all commands without group.kind'
+                            type: boolean
                           workingDir:
                             description: Working directory where the command should
                               be executed
@@ -2429,6 +2486,18 @@ spec:
                                       description: Optional map of free-form additional
                                         command attributes
                                       type: object
+                                    background:
+                                      description: 'Whatever the command needs should
+                                        be executed on background. If "false" the
+                                        controller should wait for command to finish
+                                        and report its status. If "false" the controller
+                                        won''t wait for it to finish (command can
+                                        run indefinitely or until it is manually stopped).
+                                        Default value is "true" for group.kind: run,
+                                        debug. Default value is "false" for group.kind:
+                                        build, test. Default value is "false" for
+                                        all commands without group.kind'
+                                      type: boolean
                                     commandLine:
                                       description: The actual command-line string
                                       type: string
@@ -2480,6 +2549,16 @@ spec:
                                         label for this command to be used in Editor
                                         UI menus for example
                                       type: string
+                                    restartOnChange:
+                                      description: 'Whatever the command needs be
+                                        restarted when files changed. It should be
+                                        set to "false" if command is capable to do
+                                        automatic hotreload. Default value is "true"
+                                        for group.kind: build, test. Default value
+                                        is "false" for group.kind: run, debug. Default
+                                        value is "false" for all commands without
+                                        group.kind'
+                                      type: boolean
                                     workingDir:
                                       description: Working directory where the command
                                         should be executed

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -117,12 +117,13 @@ type ExecCommand struct {
 	// Working directory where the command should be executed
 	WorkingDir string `json:"workingDir,omitempty"`
 
+	// +optional
 	// Optional list of environment variables that have to be set
 	// before running the command
 	Env []EnvVar `json:"env,omitempty"`
 
 	// +optional
-	// Whatever the command it capable to reload itself when source code changes.
+	// Whether the command it capable to reload itself when source code changes.
 	// If set to `true` the command won't be restarted and it is expected to handle file changes on its own.
 	//
 	// Default value is `false`

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -123,16 +123,7 @@ type ExecCommand struct {
 	Env []EnvVar `json:"env,omitempty"`
 
 	// +optional
-	// Whatever the command needs should be executed on background.
-	// If "false" the controller should wait for command to finish and report its status.
-	// If "true" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped).
-	// Default value is "true" for group.kind: run, debug.
-	// Default value is "false" for group.kind: build, test.
-	// Default value is "false" for all commands without group.kind
-	Background bool `json:"background,omitempty"`
-
-	// +optional
-	// Whatever the command needs should be restarted when files changed.
+	// Whatever the command needs to be restarted when files changed.
 	// It should be set to "false" if command is capable to do automatic hotreload.
 	// Default value is "true" for group.kind: build, test.
 	// Default value is "false" for group.kind: run, debug.

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -117,7 +117,6 @@ type ExecCommand struct {
 	// Working directory where the command should be executed
 	WorkingDir string `json:"workingDir,omitempty"`
 
-	// +optional
 	// Optional list of environment variables that have to be set
 	// before running the command
 	Env []EnvVar `json:"env,omitempty"`
@@ -125,9 +124,14 @@ type ExecCommand struct {
 	// +optional
 	// Whatever the command needs to be restarted when files changed.
 	// It should be set to "false" if command is capable to do automatic hotreload.
-	// Default value is "true" for group.kind: build, test.
-	// Default value is "false" for group.kind: run, debug.
-	// Default value is "false" for all commands without group.kind
+	//
+	// Default value:
+	//
+	//   - "true" for group.kind: build, test.
+	//
+	//   - "false" for group.kind: run, debug.
+	//
+	//   - "false" for all commands without group.kind
 	RestartOnChange bool `json:"restartOnChange,omitempty"`
 }
 

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -121,6 +121,23 @@ type ExecCommand struct {
 	// Optional list of environment variables that have to be set
 	// before running the command
 	Env []EnvVar `json:"env,omitempty"`
+
+	// +optional
+	// Whatever the command needs should be executed on background.
+	// If "false" the controller should wait for command to finish and report its status.
+	// If "false" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped).
+	// Default value is "true" for group.kind: run, debug.
+	// Default value is "false" for group.kind: build, test.
+	// Default value is "false" for all commands without group.kind
+	Background bool `json:"background,omitempty"`
+
+	// +optional
+	// Whatever the command needs be restarted when files changed.
+	// It should be set to "false" if command is capable to do automatic hotreload.
+	// Default value is "true" for group.kind: build, test.
+	// Default value is "false" for group.kind: run, debug.
+	// Default value is "false" for all commands without group.kind
+	RestartOnChange bool `json:"restartOnChange,omitempty"`
 }
 
 type ApplyCommand struct {

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -123,7 +123,7 @@ type ExecCommand struct {
 
 	// +optional
 	// Whatever the command it capable to reload itself when source code changes.
-	// If set to "true" the command won't be restarted and it is expected to handle file changes on its own.
+	// If set to `true` the command won't be restarted and it is expected to handle file changes on its own.
 	//
 	// Default value is `false`
 	HotReloadCapable bool `json:"hotReloadCapable,omitempty"`

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -122,11 +122,11 @@ type ExecCommand struct {
 	Env []EnvVar `json:"env,omitempty"`
 
 	// +optional
-	// Whatever the command needs to be restarted when files changed.
-	// It should be set to "false" if command is capable to do automatic hotreload.
+	// Whatever the command it capable to reload itself when source code changes.
+	// If set to "true" the command won't be restarted and it is expected to handle file changes on its own.
 	//
-	// Default value is `true`
-	RestartOnChange bool `json:"restartOnChange,omitempty"`
+	// Default value is `false`
+	HotReloadCapable bool `json:"hotReloadCapable,omitempty"`
 }
 
 type ApplyCommand struct {

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -125,7 +125,7 @@ type ExecCommand struct {
 	// +optional
 	// Whatever the command needs should be executed on background.
 	// If "false" the controller should wait for command to finish and report its status.
-	// If "false" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped).
+	// If "true" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped).
 	// Default value is "true" for group.kind: run, debug.
 	// Default value is "false" for group.kind: build, test.
 	// Default value is "false" for all commands without group.kind

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -125,13 +125,7 @@ type ExecCommand struct {
 	// Whatever the command needs to be restarted when files changed.
 	// It should be set to "false" if command is capable to do automatic hotreload.
 	//
-	// Default value:
-	//
-	//   - "true" for group.kind: build, test.
-	//
-	//   - "false" for group.kind: run, debug.
-	//
-	//   - "false" for all commands without group.kind
+	// Default value is `true`
 	RestartOnChange bool `json:"restartOnChange,omitempty"`
 }
 

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -123,7 +123,7 @@ type ExecCommand struct {
 	Env []EnvVar `json:"env,omitempty"`
 
 	// +optional
-	// Whether the command it capable to reload itself when source code changes.
+	// Whether the command is capable to reload itself when source code changes.
 	// If set to `true` the command won't be restarted and it is expected to handle file changes on its own.
 	//
 	// Default value is `false`

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -132,7 +132,7 @@ type ExecCommand struct {
 	Background bool `json:"background,omitempty"`
 
 	// +optional
-	// Whatever the command needs be restarted when files changed.
+	// Whatever the command needs should be restarted when files changed.
 	// It should be set to "false" if command is capable to do automatic hotreload.
 	// Default value is "true" for group.kind: build, test.
 	// Default value is "false" for group.kind: run, debug.

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -205,9 +205,9 @@
                 "additionalProperties": false
               },
               "hotReloadCapable": {
-                "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                 "type": "boolean",
-                "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -951,9 +951,9 @@
                           "additionalProperties": false
                         },
                         "hotReloadCapable": {
-                          "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                          "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                           "type": "boolean",
-                          "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                          "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1896,9 +1896,9 @@
                     "additionalProperties": false
                   },
                   "hotReloadCapable": {
-                    "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                     "type": "boolean",
-                    "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                    "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2639,9 +2639,9 @@
                               "additionalProperties": false
                             },
                             "hotReloadCapable": {
-                              "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                               "type": "boolean",
-                              "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                              "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -146,11 +146,6 @@
                 "type": "object",
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
-              "background": {
-                "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                "type": "boolean",
-                "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-              },
               "commandLine": {
                 "description": "The actual command-line string",
                 "type": "string",
@@ -220,9 +215,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "restartOnChange": {
-                "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -897,11 +892,6 @@
                           "type": "object",
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
-                        "background": {
-                          "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                          "type": "boolean",
-                          "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                        },
                         "commandLine": {
                           "description": "The actual command-line string",
                           "type": "string",
@@ -971,9 +961,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "restartOnChange": {
-                          "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -1847,11 +1837,6 @@
                     "type": "object",
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
-                  "background": {
-                    "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                    "type": "boolean",
-                    "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                  },
                   "commandLine": {
                     "description": "The actual command-line string",
                     "type": "string",
@@ -1921,9 +1906,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2595,11 +2580,6 @@
                               "type": "object",
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
-                            "background": {
-                              "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                              "type": "boolean",
-                              "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                            },
                             "commandLine": {
                               "description": "The actual command-line string",
                               "type": "string",
@@ -2669,9 +2649,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -215,9 +215,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "restartOnChange": {
-                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -961,9 +961,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "restartOnChange": {
-                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -1906,9 +1906,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2649,9 +2649,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -146,6 +146,11 @@
                 "type": "object",
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
+              "background": {
+                "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                "type": "boolean",
+                "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+              },
               "commandLine": {
                 "description": "The actual command-line string",
                 "type": "string",
@@ -213,6 +218,11 @@
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                 "type": "string",
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+              },
+              "restartOnChange": {
+                "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                "type": "boolean",
+                "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -887,6 +897,11 @@
                           "type": "object",
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
+                        "background": {
+                          "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                          "type": "boolean",
+                          "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                        },
                         "commandLine": {
                           "description": "The actual command-line string",
                           "type": "string",
@@ -954,6 +969,11 @@
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                           "type": "string",
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                        },
+                        "restartOnChange": {
+                          "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                          "type": "boolean",
+                          "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -1827,6 +1847,11 @@
                     "type": "object",
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
+                  "background": {
+                    "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                  },
                   "commandLine": {
                     "description": "The actual command-line string",
                     "type": "string",
@@ -1894,6 +1919,11 @@
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                     "type": "string",
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                  },
+                  "restartOnChange": {
+                    "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2565,6 +2595,11 @@
                               "type": "object",
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
+                            "background": {
+                              "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                            },
                             "commandLine": {
                               "description": "The actual command-line string",
                               "type": "string",
@@ -2632,6 +2667,11 @@
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                               "type": "string",
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                            },
+                            "restartOnChange": {
+                              "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -215,9 +215,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "restartOnChange": {
-                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -961,9 +961,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "restartOnChange": {
-                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -1906,9 +1906,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2649,9 +2649,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -205,9 +205,9 @@
                 "additionalProperties": false
               },
               "hotReloadCapable": {
-                "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -951,9 +951,9 @@
                           "additionalProperties": false
                         },
                         "hotReloadCapable": {
-                          "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                          "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                          "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1896,9 +1896,9 @@
                     "additionalProperties": false
                   },
                   "hotReloadCapable": {
-                    "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                    "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2639,9 +2639,9 @@
                               "additionalProperties": false
                             },
                             "hotReloadCapable": {
-                              "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                              "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -204,6 +204,11 @@
                 "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
+              "hotReloadCapable": {
+                "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "type": "boolean",
+                "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+              },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
@@ -213,11 +218,6 @@
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                 "type": "string",
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-              },
-              "restartOnChange": {
-                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                "type": "boolean",
-                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -950,6 +950,11 @@
                           "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
+                        "hotReloadCapable": {
+                          "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                          "type": "boolean",
+                          "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                        },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
@@ -959,11 +964,6 @@
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                           "type": "string",
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                        },
-                        "restartOnChange": {
-                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                          "type": "boolean",
-                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -1895,6 +1895,11 @@
                     "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
+                  "hotReloadCapable": {
+                    "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                  },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
@@ -1904,11 +1909,6 @@
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                     "type": "string",
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                  },
-                  "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                    "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2638,6 +2638,11 @@
                               "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
+                            "hotReloadCapable": {
+                              "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                            },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
@@ -2647,11 +2652,6 @@
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                               "type": "string",
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                            },
-                            "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                              "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -283,9 +283,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "restartOnChange": {
-                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -1130,9 +1130,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "restartOnChange": {
-                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -2153,9 +2153,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2997,9 +2997,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -214,11 +214,6 @@
                 "type": "object",
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
-              "background": {
-                "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                "type": "boolean",
-                "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-              },
               "commandLine": {
                 "description": "The actual command-line string",
                 "type": "string",
@@ -288,9 +283,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "restartOnChange": {
-                "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -1066,11 +1061,6 @@
                           "type": "object",
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
-                        "background": {
-                          "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                          "type": "boolean",
-                          "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                        },
                         "commandLine": {
                           "description": "The actual command-line string",
                           "type": "string",
@@ -1140,9 +1130,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "restartOnChange": {
-                          "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -2094,11 +2084,6 @@
                     "type": "object",
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
-                  "background": {
-                    "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                    "type": "boolean",
-                    "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                  },
                   "commandLine": {
                     "description": "The actual command-line string",
                     "type": "string",
@@ -2168,9 +2153,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2943,11 +2928,6 @@
                               "type": "object",
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
-                            "background": {
-                              "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                              "type": "boolean",
-                              "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                            },
                             "commandLine": {
                               "description": "The actual command-line string",
                               "type": "string",
@@ -3017,9 +2997,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -283,9 +283,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "restartOnChange": {
-                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -1130,9 +1130,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "restartOnChange": {
-                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -2153,9 +2153,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2997,9 +2997,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -214,6 +214,11 @@
                 "type": "object",
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
+              "background": {
+                "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                "type": "boolean",
+                "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+              },
               "commandLine": {
                 "description": "The actual command-line string",
                 "type": "string",
@@ -281,6 +286,11 @@
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                 "type": "string",
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+              },
+              "restartOnChange": {
+                "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                "type": "boolean",
+                "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -1056,6 +1066,11 @@
                           "type": "object",
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
+                        "background": {
+                          "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                          "type": "boolean",
+                          "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                        },
                         "commandLine": {
                           "description": "The actual command-line string",
                           "type": "string",
@@ -1123,6 +1138,11 @@
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                           "type": "string",
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                        },
+                        "restartOnChange": {
+                          "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                          "type": "boolean",
+                          "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -2074,6 +2094,11 @@
                     "type": "object",
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
+                  "background": {
+                    "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                  },
                   "commandLine": {
                     "description": "The actual command-line string",
                     "type": "string",
@@ -2141,6 +2166,11 @@
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                     "type": "string",
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                  },
+                  "restartOnChange": {
+                    "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2913,6 +2943,11 @@
                               "type": "object",
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
+                            "background": {
+                              "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                            },
                             "commandLine": {
                               "description": "The actual command-line string",
                               "type": "string",
@@ -2980,6 +3015,11 @@
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                               "type": "string",
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                            },
+                            "restartOnChange": {
+                              "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -273,9 +273,9 @@
                 "additionalProperties": false
               },
               "hotReloadCapable": {
-                "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                 "type": "boolean",
-                "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1120,9 +1120,9 @@
                           "additionalProperties": false
                         },
                         "hotReloadCapable": {
-                          "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                          "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                           "type": "boolean",
-                          "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                          "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2143,9 +2143,9 @@
                     "additionalProperties": false
                   },
                   "hotReloadCapable": {
-                    "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                     "type": "boolean",
-                    "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                    "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2987,9 +2987,9 @@
                               "additionalProperties": false
                             },
                             "hotReloadCapable": {
-                              "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                               "type": "boolean",
-                              "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                              "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -273,9 +273,9 @@
                 "additionalProperties": false
               },
               "hotReloadCapable": {
-                "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                 "type": "boolean",
-                "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1120,9 +1120,9 @@
                           "additionalProperties": false
                         },
                         "hotReloadCapable": {
-                          "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                          "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                           "type": "boolean",
-                          "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                          "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2143,9 +2143,9 @@
                     "additionalProperties": false
                   },
                   "hotReloadCapable": {
-                    "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                    "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2987,9 +2987,9 @@
                               "additionalProperties": false
                             },
                             "hotReloadCapable": {
-                              "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                              "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -272,6 +272,11 @@
                 "markdownDescription": "Defines the group this command is part of",
                 "additionalProperties": false
               },
+              "hotReloadCapable": {
+                "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "type": "boolean",
+                "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+              },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
@@ -281,11 +286,6 @@
                 "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                 "type": "string",
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-              },
-              "restartOnChange": {
-                "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                "type": "boolean",
-                "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
               },
               "workingDir": {
                 "description": "Working directory where the command should be executed",
@@ -1119,6 +1119,11 @@
                           "markdownDescription": "Defines the group this command is part of",
                           "additionalProperties": false
                         },
+                        "hotReloadCapable": {
+                          "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                          "type": "boolean",
+                          "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                        },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
@@ -1128,11 +1133,6 @@
                           "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                           "type": "string",
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                        },
-                        "restartOnChange": {
-                          "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                          "type": "boolean",
-                          "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                         },
                         "workingDir": {
                           "description": "Working directory where the command should be executed",
@@ -2142,6 +2142,11 @@
                     "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
+                  "hotReloadCapable": {
+                    "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                  },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
@@ -2151,11 +2156,6 @@
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                     "type": "string",
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                  },
-                  "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                    "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -2986,6 +2986,11 @@
                               "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
+                            "hotReloadCapable": {
+                              "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                            },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
@@ -2995,11 +3000,6 @@
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                               "type": "string",
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                            },
-                            "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                              "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -231,6 +231,11 @@
                     "type": "object",
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
+                  "background": {
+                    "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                  },
                   "commandLine": {
                     "description": "The actual command-line string",
                     "type": "string",
@@ -298,6 +303,11 @@
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                     "type": "string",
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                  },
+                  "restartOnChange": {
+                    "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -1073,6 +1083,11 @@
                               "type": "object",
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
+                            "background": {
+                              "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                            },
                             "commandLine": {
                               "description": "The actual command-line string",
                               "type": "string",
@@ -1140,6 +1155,11 @@
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                               "type": "string",
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                            },
+                            "restartOnChange": {
+                              "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
@@ -2091,6 +2111,11 @@
                         "type": "object",
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
+                      "background": {
+                        "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                        "type": "boolean",
+                        "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                      },
                       "commandLine": {
                         "description": "The actual command-line string",
                         "type": "string",
@@ -2158,6 +2183,11 @@
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                         "type": "string",
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                      },
+                      "restartOnChange": {
+                        "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                        "type": "boolean",
+                        "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -2930,6 +2960,11 @@
                                   "type": "object",
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
+                                "background": {
+                                  "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                                  "type": "boolean",
+                                  "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                                },
                                 "commandLine": {
                                   "description": "The actual command-line string",
                                   "type": "string",
@@ -2997,6 +3032,11 @@
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                                   "type": "string",
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                                },
+                                "restartOnChange": {
+                                  "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                  "type": "boolean",
+                                  "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -289,6 +289,11 @@
                     "markdownDescription": "Defines the group this command is part of",
                     "additionalProperties": false
                   },
+                  "hotReloadCapable": {
+                    "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "type": "boolean",
+                    "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                  },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
@@ -298,11 +303,6 @@
                     "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                     "type": "string",
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                  },
-                  "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                    "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -1136,6 +1136,11 @@
                               "markdownDescription": "Defines the group this command is part of",
                               "additionalProperties": false
                             },
+                            "hotReloadCapable": {
+                              "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "type": "boolean",
+                              "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                            },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
@@ -1145,11 +1150,6 @@
                               "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                               "type": "string",
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                            },
-                            "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                              "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
@@ -2159,6 +2159,11 @@
                         "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
+                      "hotReloadCapable": {
+                        "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                        "type": "boolean",
+                        "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                      },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                         "type": "string",
@@ -2168,11 +2173,6 @@
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                         "type": "string",
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                      },
-                      "restartOnChange": {
-                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                        "type": "boolean",
-                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -3003,6 +3003,11 @@
                                   "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
+                                "hotReloadCapable": {
+                                  "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                  "type": "boolean",
+                                  "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                                   "type": "string",
@@ -3012,11 +3017,6 @@
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                                   "type": "string",
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                                },
-                                "restartOnChange": {
-                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                                  "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -290,9 +290,9 @@
                     "additionalProperties": false
                   },
                   "hotReloadCapable": {
-                    "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                    "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1137,9 +1137,9 @@
                               "additionalProperties": false
                             },
                             "hotReloadCapable": {
-                              "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                              "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2160,9 +2160,9 @@
                         "additionalProperties": false
                       },
                       "hotReloadCapable": {
-                        "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                        "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                        "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -3004,9 +3004,9 @@
                                   "additionalProperties": false
                                 },
                                 "hotReloadCapable": {
-                                  "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                  "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                  "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -300,9 +300,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -1147,9 +1147,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
@@ -2170,9 +2170,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "restartOnChange": {
-                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -3014,9 +3014,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "restartOnChange": {
-                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -300,9 +300,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -1147,9 +1147,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
@@ -2170,9 +2170,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "restartOnChange": {
-                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -3014,9 +3014,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "restartOnChange": {
-                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -231,11 +231,6 @@
                     "type": "object",
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
-                  "background": {
-                    "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                    "type": "boolean",
-                    "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                  },
                   "commandLine": {
                     "description": "The actual command-line string",
                     "type": "string",
@@ -305,9 +300,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "restartOnChange": {
-                    "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                    "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                     "type": "boolean",
-                    "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                    "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                   },
                   "workingDir": {
                     "description": "Working directory where the command should be executed",
@@ -1083,11 +1078,6 @@
                               "type": "object",
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
-                            "background": {
-                              "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                              "type": "boolean",
-                              "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                            },
                             "commandLine": {
                               "description": "The actual command-line string",
                               "type": "string",
@@ -1157,9 +1147,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "restartOnChange": {
-                              "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                              "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                               "type": "boolean",
-                              "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                              "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                             },
                             "workingDir": {
                               "description": "Working directory where the command should be executed",
@@ -2111,11 +2101,6 @@
                         "type": "object",
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
-                      "background": {
-                        "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                        "type": "boolean",
-                        "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                      },
                       "commandLine": {
                         "description": "The actual command-line string",
                         "type": "string",
@@ -2185,9 +2170,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "restartOnChange": {
-                        "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -2960,11 +2945,6 @@
                                   "type": "object",
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
-                                "background": {
-                                  "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                                  "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                                },
                                 "commandLine": {
                                   "description": "The actual command-line string",
                                   "type": "string",
@@ -3034,9 +3014,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "restartOnChange": {
-                                  "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -290,9 +290,9 @@
                     "additionalProperties": false
                   },
                   "hotReloadCapable": {
-                    "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                     "type": "boolean",
-                    "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                    "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1137,9 +1137,9 @@
                               "additionalProperties": false
                             },
                             "hotReloadCapable": {
-                              "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                               "type": "boolean",
-                              "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                              "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2160,9 +2160,9 @@
                         "additionalProperties": false
                       },
                       "hotReloadCapable": {
-                        "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                        "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                         "type": "boolean",
-                        "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                        "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -3004,9 +3004,9 @@
                                   "additionalProperties": false
                                 },
                                 "hotReloadCapable": {
-                                  "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                  "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                                   "type": "boolean",
-                                  "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                  "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -299,9 +299,9 @@
                         "additionalProperties": false
                       },
                       "hotReloadCapable": {
-                        "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                        "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                        "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1146,9 +1146,9 @@
                                   "additionalProperties": false
                                 },
                                 "hotReloadCapable": {
-                                  "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                  "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                  "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2169,9 +2169,9 @@
                             "additionalProperties": false
                           },
                           "hotReloadCapable": {
-                            "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                            "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                             "type": "boolean",
-                            "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                            "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -3013,9 +3013,9 @@
                                       "additionalProperties": false
                                     },
                                     "hotReloadCapable": {
-                                      "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                      "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                                       "type": "boolean",
-                                      "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                      "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -298,6 +298,11 @@
                         "markdownDescription": "Defines the group this command is part of",
                         "additionalProperties": false
                       },
+                      "hotReloadCapable": {
+                        "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                        "type": "boolean",
+                        "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                      },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                         "type": "string",
@@ -307,11 +312,6 @@
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                         "type": "string",
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                      },
-                      "restartOnChange": {
-                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                        "type": "boolean",
-                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -1145,6 +1145,11 @@
                                   "markdownDescription": "Defines the group this command is part of",
                                   "additionalProperties": false
                                 },
+                                "hotReloadCapable": {
+                                  "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                  "type": "boolean",
+                                  "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                                   "type": "string",
@@ -1154,11 +1159,6 @@
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                                   "type": "string",
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                                },
-                                "restartOnChange": {
-                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                                  "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",
@@ -2168,6 +2168,11 @@
                             "markdownDescription": "Defines the group this command is part of",
                             "additionalProperties": false
                           },
+                          "hotReloadCapable": {
+                            "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                            "type": "boolean",
+                            "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                          },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                             "type": "string",
@@ -2177,11 +2182,6 @@
                             "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                             "type": "string",
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                          },
-                          "restartOnChange": {
-                            "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                            "type": "boolean",
-                            "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                           },
                           "workingDir": {
                             "description": "Working directory where the command should be executed",
@@ -3012,6 +3012,11 @@
                                       "markdownDescription": "Defines the group this command is part of",
                                       "additionalProperties": false
                                     },
+                                    "hotReloadCapable": {
+                                      "description": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                      "type": "boolean",
+                                      "markdownDescription": "Whatever the command it capable to reload itself when source code changes. If set to \"true\" the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                    },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                                       "type": "string",
@@ -3021,11 +3026,6 @@
                                       "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                                       "type": "string",
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
-                                    },
-                                    "restartOnChange": {
-                                      "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
-                                      "type": "boolean",
-                                      "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                                     },
                                     "workingDir": {
                                       "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -309,9 +309,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "restartOnChange": {
-                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -1156,9 +1156,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "restartOnChange": {
-                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",
@@ -2179,9 +2179,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "restartOnChange": {
-                            "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                            "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                             "type": "boolean",
-                            "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                            "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                           },
                           "workingDir": {
                             "description": "Working directory where the command should be executed",
@@ -3023,9 +3023,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "restartOnChange": {
-                                      "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                      "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
                                       "type": "boolean",
-                                      "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                                      "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
                                     },
                                     "workingDir": {
                                       "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -240,6 +240,11 @@
                         "type": "object",
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
+                      "background": {
+                        "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                        "type": "boolean",
+                        "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                      },
                       "commandLine": {
                         "description": "The actual command-line string",
                         "type": "string",
@@ -307,6 +312,11 @@
                         "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                         "type": "string",
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                      },
+                      "restartOnChange": {
+                        "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                        "type": "boolean",
+                        "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -1082,6 +1092,11 @@
                                   "type": "object",
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
+                                "background": {
+                                  "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                                  "type": "boolean",
+                                  "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                                },
                                 "commandLine": {
                                   "description": "The actual command-line string",
                                   "type": "string",
@@ -1149,6 +1164,11 @@
                                   "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                                   "type": "string",
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                                },
+                                "restartOnChange": {
+                                  "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                  "type": "boolean",
+                                  "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",
@@ -2100,6 +2120,11 @@
                             "type": "object",
                             "markdownDescription": "Optional map of free-form additional command attributes"
                           },
+                          "background": {
+                            "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                            "type": "boolean",
+                            "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                          },
                           "commandLine": {
                             "description": "The actual command-line string",
                             "type": "string",
@@ -2167,6 +2192,11 @@
                             "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                             "type": "string",
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                          },
+                          "restartOnChange": {
+                            "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                            "type": "boolean",
+                            "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                           },
                           "workingDir": {
                             "description": "Working directory where the command should be executed",
@@ -2939,6 +2969,11 @@
                                       "type": "object",
                                       "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
+                                    "background": {
+                                      "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
+                                      "type": "boolean",
+                                      "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
+                                    },
                                     "commandLine": {
                                       "description": "The actual command-line string",
                                       "type": "string",
@@ -3006,6 +3041,11 @@
                                       "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
                                       "type": "string",
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
+                                    },
+                                    "restartOnChange": {
+                                      "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                      "type": "boolean",
+                                      "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                                     },
                                     "workingDir": {
                                       "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -240,11 +240,6 @@
                         "type": "object",
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
-                      "background": {
-                        "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                        "type": "boolean",
-                        "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                      },
                       "commandLine": {
                         "description": "The actual command-line string",
                         "type": "string",
@@ -314,9 +309,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "restartOnChange": {
-                        "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -1092,11 +1087,6 @@
                                   "type": "object",
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
-                                "background": {
-                                  "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                                  "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                                },
                                 "commandLine": {
                                   "description": "The actual command-line string",
                                   "type": "string",
@@ -1166,9 +1156,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "restartOnChange": {
-                                  "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",
@@ -2120,11 +2110,6 @@
                             "type": "object",
                             "markdownDescription": "Optional map of free-form additional command attributes"
                           },
-                          "background": {
-                            "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                            "type": "boolean",
-                            "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                          },
                           "commandLine": {
                             "description": "The actual command-line string",
                             "type": "string",
@@ -2194,9 +2179,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "restartOnChange": {
-                            "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                            "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                             "type": "boolean",
-                            "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                            "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                           },
                           "workingDir": {
                             "description": "Working directory where the command should be executed",
@@ -2969,11 +2954,6 @@
                                       "type": "object",
                                       "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
-                                    "background": {
-                                      "description": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind",
-                                      "type": "boolean",
-                                      "markdownDescription": "Whatever the command needs should be executed on background. If \"false\" the controller should wait for command to finish and report its status. If \"false\" the controller won't wait for it to finish (command can run indefinitely or until it is manually stopped). Default value is \"true\" for group.kind: run, debug. Default value is \"false\" for group.kind: build, test. Default value is \"false\" for all commands without group.kind"
-                                    },
                                     "commandLine": {
                                       "description": "The actual command-line string",
                                       "type": "string",
@@ -3043,9 +3023,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "restartOnChange": {
-                                      "description": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
+                                      "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind",
                                       "type": "boolean",
-                                      "markdownDescription": "Whatever the command needs be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
+                                      "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload. Default value is \"true\" for group.kind: build, test. Default value is \"false\" for group.kind: run, debug. Default value is \"false\" for all commands without group.kind"
                                     },
                                     "workingDir": {
                                       "description": "Working directory where the command should be executed",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -299,9 +299,9 @@
                         "additionalProperties": false
                       },
                       "hotReloadCapable": {
-                        "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                        "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                         "type": "boolean",
-                        "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                        "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -1146,9 +1146,9 @@
                                   "additionalProperties": false
                                 },
                                 "hotReloadCapable": {
-                                  "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                  "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                                   "type": "boolean",
-                                  "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                  "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -2169,9 +2169,9 @@
                             "additionalProperties": false
                           },
                           "hotReloadCapable": {
-                            "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                            "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                             "type": "boolean",
-                            "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                            "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                           },
                           "id": {
                             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
@@ -3013,9 +3013,9 @@
                                       "additionalProperties": false
                                     },
                                     "hotReloadCapable": {
-                                      "description": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                                      "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
                                       "type": "boolean",
-                                      "markdownDescription": "Whether the command it capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
+                                      "markdownDescription": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`"
                                     },
                                     "id": {
                                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -309,9 +309,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "restartOnChange": {
-                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                        "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                         "type": "boolean",
-                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                        "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                       },
                       "workingDir": {
                         "description": "Working directory where the command should be executed",
@@ -1156,9 +1156,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "restartOnChange": {
-                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                                  "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                                   "type": "boolean",
-                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                                  "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                                 },
                                 "workingDir": {
                                   "description": "Working directory where the command should be executed",
@@ -2179,9 +2179,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "restartOnChange": {
-                            "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                            "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                             "type": "boolean",
-                            "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                            "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                           },
                           "workingDir": {
                             "description": "Working directory where the command should be executed",
@@ -3023,9 +3023,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "restartOnChange": {
-                                      "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind",
+                                      "description": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`",
                                       "type": "boolean",
-                                      "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value:\n\n  - \"true\" for group.kind: build, test.\n\n  - \"false\" for group.kind: run, debug.\n\n  - \"false\" for all commands without group.kind"
+                                      "markdownDescription": "Whatever the command needs to be restarted when files changed. It should be set to \"false\" if command is capable to do automatic hotreload.\n\nDefault value is `true`"
                                     },
                                     "workingDir": {
                                       "description": "Working directory where the command should be executed",


### PR DESCRIPTION
### What does this PR do?
Add ~~two new options~~ a new option (~~`background`~~ and `hotReloadCapable`) to control how commands are executed.
More detailed description is in https://github.com/devfile/kubernetes-api/issues/64#issuecomment-646115779



### What issues does this PR fix or reference?
fix https://github.com/devfile/kubernetes-api/issues/64#issuecomment-646115779

### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
