### PR TITLE
Add davidfestal to global codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @sleshchenko @amisevsk
+* @sleshchenko @amisevsk @davidfestal


### PR DESCRIPTION
### What does this PR do?
Add @davidfestal to global codeowners. David is more qualified than me and Serhii to comment on some PRs, and his input would be very valuable.