### PR TITLE
add PROJECTS_ROOT and PROJECT_SOURCE description to CommandLine and WorkingDir

### DIFF
--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -232,7 +232,12 @@ spec:
                               attributes
                             type: object
                           commandLine:
-                            description: The actual command-line string
+                            description: "The actual command-line string \n Special
+                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                              A path path where projects sources are mounted \n  -
+                              `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              \ If there are multiple projects, this will point to
+                              the directory of the first one."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -280,8 +285,13 @@ spec:
                               this command to be used in Editor UI menus for example
                             type: string
                           workingDir:
-                            description: Working directory where the command should
-                              be executed
+                            description: "Working directory where the command should
+                              be executed \n Special variables that can be used: \n
+                              \ - `$PROJECTS_ROOT`: A path path where projects sources
+                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
+                              source ($PROJECTS_ROOT/<project-name>).  If there are
+                              multiple projects, this will point to the directory
+                              of the first one."
                             type: string
                         required:
                         - id
@@ -955,7 +965,13 @@ spec:
                                         command attributes
                                       type: object
                                     commandLine:
-                                      description: The actual command-line string
+                                      description: "The actual command-line string
+                                        \n Special variables that can be used: \n
+                                        \ - `$PROJECTS_ROOT`: A path path where projects
+                                        sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        \ If there are multiple projects, this will
+                                        point to the directory of the first one."
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -1006,8 +1022,14 @@ spec:
                                         UI menus for example
                                       type: string
                                     workingDir:
-                                      description: Working directory where the command
-                                        should be executed
+                                      description: "Working directory where the command
+                                        should be executed \n Special variables that
+                                        can be used: \n  - `$PROJECTS_ROOT`: A path
+                                        path where projects sources are mounted \n
+                                        \ - `$PROJECT_SOURCE`: A path to a project
+                                        source ($PROJECTS_ROOT/<project-name>).  If
+                                        there are multiple projects, this will point
+                                        to the directory of the first one."
                                       type: string
                                   required:
                                   - id
@@ -1782,7 +1804,13 @@ spec:
                                   command attributes
                                 type: object
                               commandLine:
-                                description: The actual command-line string
+                                description: "The actual command-line string \n Special
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                  A path path where projects sources are mounted \n
+                                  \ - `$PROJECT_SOURCE`: A path to a project source
+                                  ($PROJECTS_ROOT/<project-name>).  If there are multiple
+                                  projects, this will point to the directory of the
+                                  first one."
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1833,8 +1861,13 @@ spec:
                                   example
                                 type: string
                               workingDir:
-                                description: Working directory where the command should
-                                  be executed
+                                description: "Working directory where the command
+                                  should be executed \n Special variables that can
+                                  be used: \n  - `$PROJECTS_ROOT`: A path path where
+                                  projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  \ If there are multiple projects, this will point
+                                  to the directory of the first one."
                                 type: string
                             required:
                             - id
@@ -2526,7 +2559,14 @@ spec:
                                             command attributes
                                           type: object
                                         commandLine:
-                                          description: The actual command-line string
+                                          description: "The actual command-line string
+                                            \n Special variables that can be used:
+                                            \n  - `$PROJECTS_ROOT`: A path path where
+                                            projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                            A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                            \ If there are multiple projects, this
+                                            will point to the directory of the first
+                                            one."
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2578,8 +2618,15 @@ spec:
                                             Editor UI menus for example
                                           type: string
                                         workingDir:
-                                          description: Working directory where the
-                                            command should be executed
+                                          description: "Working directory where the
+                                            command should be executed \n Special
+                                            variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                            A path path where projects sources are
+                                            mounted \n  - `$PROJECT_SOURCE`: A path
+                                            to a project source ($PROJECTS_ROOT/<project-name>).
+                                            \ If there are multiple projects, this
+                                            will point to the directory of the first
+                                            one."
                                           type: string
                                       required:
                                       - id

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -287,9 +287,9 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT`: A path where projects sources
-                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
-                              source ($PROJECTS_ROOT/<project-name>). If there are
+                              \ - `${PROJECTS_ROOT}`: A path where projects sources
+                              are mounted \n  - `${PROJECT_SOURCE}`: A path to a project
+                              source (${PROJECTS_ROOT}/<project-name>). If there are
                               multiple projects, this will point to the directory
                               of the first one."
                             type: string
@@ -1024,9 +1024,9 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `$PROJECTS_ROOT`: A path
-                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        can be used: \n  - `${PROJECTS_ROOT}`: A path
+                                        where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                        A path to a project source (${PROJECTS_ROOT}/<project-name>).
                                         If there are multiple projects, this will
                                         point to the directory of the first one."
                                       type: string
@@ -1861,9 +1861,9 @@ spec:
                               workingDir:
                                 description: "Working directory where the command
                                   should be executed \n Special variables that can
-                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
-                                  sources are mounted \n  - `$PROJECT_SOURCE`: A path
-                                  to a project source ($PROJECTS_ROOT/<project-name>).
+                                  be used: \n  - `${PROJECTS_ROOT}`: A path where
+                                  projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                  A path to a project source (${PROJECTS_ROOT}/<project-name>).
                                   If there are multiple projects, this will point
                                   to the directory of the first one."
                                 type: string
@@ -2617,10 +2617,10 @@ spec:
                                         workingDir:
                                           description: "Working directory where the
                                             command should be executed \n Special
-                                            variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                            variables that can be used: \n  - `${PROJECTS_ROOT}`:
                                             A path where projects sources are mounted
-                                            \n  - `$PROJECT_SOURCE`: A path to a project
-                                            source ($PROJECTS_ROOT/<project-name>).
+                                            \n  - `${PROJECT_SOURCE}`: A path to a
+                                            project source (${PROJECTS_ROOT}/<project-name>).
                                             If there are multiple projects, this will
                                             point to the directory of the first one."
                                           type: string

--- a/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspaces_crd.yaml
@@ -234,10 +234,10 @@ spec:
                           commandLine:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path path where projects sources are mounted \n  -
-                              `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
-                              \ If there are multiple projects, this will point to
-                              the directory of the first one."
+                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -287,9 +287,9 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT`: A path path where projects sources
+                              \ - `$PROJECTS_ROOT`: A path where projects sources
                               are mounted \n  - `$PROJECT_SOURCE`: A path to a project
-                              source ($PROJECTS_ROOT/<project-name>).  If there are
+                              source ($PROJECTS_ROOT/<project-name>). If there are
                               multiple projects, this will point to the directory
                               of the first one."
                             type: string
@@ -967,10 +967,10 @@ spec:
                                     commandLine:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
-                                        \ - `$PROJECTS_ROOT`: A path path where projects
+                                        \ - `$PROJECTS_ROOT`: A path where projects
                                         sources are mounted \n  - `$PROJECT_SOURCE`:
                                         A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                        \ If there are multiple projects, this will
+                                        If there are multiple projects, this will
                                         point to the directory of the first one."
                                       type: string
                                     component:
@@ -1025,11 +1025,10 @@ spec:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
                                         can be used: \n  - `$PROJECTS_ROOT`: A path
-                                        path where projects sources are mounted \n
-                                        \ - `$PROJECT_SOURCE`: A path to a project
-                                        source ($PROJECTS_ROOT/<project-name>).  If
-                                        there are multiple projects, this will point
-                                        to the directory of the first one."
+                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one."
                                       type: string
                                   required:
                                   - id
@@ -1806,11 +1805,10 @@ spec:
                               commandLine:
                                 description: "The actual command-line string \n Special
                                   variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                  A path path where projects sources are mounted \n
-                                  \ - `$PROJECT_SOURCE`: A path to a project source
-                                  ($PROJECTS_ROOT/<project-name>).  If there are multiple
-                                  projects, this will point to the directory of the
-                                  first one."
+                                  A path where projects sources are mounted \n  -
+                                  `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one."
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1863,10 +1861,10 @@ spec:
                               workingDir:
                                 description: "Working directory where the command
                                   should be executed \n Special variables that can
-                                  be used: \n  - `$PROJECTS_ROOT`: A path path where
-                                  projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                  \ If there are multiple projects, this will point
+                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                                  sources are mounted \n  - `$PROJECT_SOURCE`: A path
+                                  to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
                                   to the directory of the first one."
                                 type: string
                             required:
@@ -2561,12 +2559,11 @@ spec:
                                         commandLine:
                                           description: "The actual command-line string
                                             \n Special variables that can be used:
-                                            \n  - `$PROJECTS_ROOT`: A path path where
-                                            projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                            \n  - `$PROJECTS_ROOT`: A path where projects
+                                            sources are mounted \n  - `$PROJECT_SOURCE`:
                                             A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                            \ If there are multiple projects, this
-                                            will point to the directory of the first
-                                            one."
+                                            If there are multiple projects, this will
+                                            point to the directory of the first one."
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2621,12 +2618,11 @@ spec:
                                           description: "Working directory where the
                                             command should be executed \n Special
                                             variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                            A path path where projects sources are
-                                            mounted \n  - `$PROJECT_SOURCE`: A path
-                                            to a project source ($PROJECTS_ROOT/<project-name>).
-                                            \ If there are multiple projects, this
-                                            will point to the directory of the first
-                                            one."
+                                            A path where projects sources are mounted
+                                            \n  - `$PROJECT_SOURCE`: A path to a project
+                                            source ($PROJECTS_ROOT/<project-name>).
+                                            If there are multiple projects, this will
+                                            point to the directory of the first one."
                                           type: string
                                       required:
                                       - id

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -261,9 +261,9 @@ spec:
                         type: string
                       workingDir:
                         description: "Working directory where the command should be
-                          executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                          A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                          A path to a project source ($PROJECTS_ROOT/<project-name>).
+                          executed \n Special variables that can be used: \n  - `${PROJECTS_ROOT}`:
+                          A path where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                          A path to a project source (${PROJECTS_ROOT}/<project-name>).
                           If there are multiple projects, this will point to the directory
                           of the first one."
                         type: string
@@ -978,9 +978,9 @@ spec:
                                 workingDir:
                                   description: "Working directory where the command
                                     should be executed \n Special variables that can
-                                    be used: \n  - `$PROJECTS_ROOT`: A path where
-                                    projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    be used: \n  - `${PROJECTS_ROOT}`: A path where
+                                    projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                    A path to a project source (${PROJECTS_ROOT}/<project-name>).
                                     If there are multiple projects, this will point
                                     to the directory of the first one."
                                   type: string
@@ -1782,9 +1782,9 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT`: A path where projects sources
-                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
-                              source ($PROJECTS_ROOT/<project-name>). If there are
+                              \ - `${PROJECTS_ROOT}`: A path where projects sources
+                              are mounted \n  - `${PROJECT_SOURCE}`: A path to a project
+                              source (${PROJECTS_ROOT}/<project-name>). If there are
                               multiple projects, this will point to the directory
                               of the first one."
                             type: string
@@ -2519,9 +2519,9 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `$PROJECTS_ROOT`: A path
-                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        can be used: \n  - `${PROJECTS_ROOT}`: A path
+                                        where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                        A path to a project source (${PROJECTS_ROOT}/<project-name>).
                                         If there are multiple projects, this will
                                         point to the directory of the first one."
                                       type: string

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -208,7 +208,12 @@ spec:
                           attributes
                         type: object
                       commandLine:
-                        description: The actual command-line string
+                        description: "The actual command-line string \n Special variables
+                          that can be used: \n  - `$PROJECTS_ROOT`: A path path where
+                          projects sources are mounted \n  - `$PROJECT_SOURCE`: A
+                          path to a project source ($PROJECTS_ROOT/<project-name>).
+                          \ If there are multiple projects, this will point to the
+                          directory of the first one."
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -255,8 +260,12 @@ spec:
                           command to be used in Editor UI menus for example
                         type: string
                       workingDir:
-                        description: Working directory where the command should be
-                          executed
+                        description: "Working directory where the command should be
+                          executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                          A path path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                          A path to a project source ($PROJECTS_ROOT/<project-name>).
+                          \ If there are multiple projects, this will point to the
+                          directory of the first one."
                         type: string
                     required:
                     - id
@@ -910,7 +919,13 @@ spec:
                                     command attributes
                                   type: object
                                 commandLine:
-                                  description: The actual command-line string
+                                  description: "The actual command-line string \n
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                    A path path where projects sources are mounted
+                                    \n  - `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>).  If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -961,8 +976,13 @@ spec:
                                     for example
                                   type: string
                                 workingDir:
-                                  description: Working directory where the command
-                                    should be executed
+                                  description: "Working directory where the command
+                                    should be executed \n Special variables that can
+                                    be used: \n  - `$PROJECTS_ROOT`: A path path where
+                                    projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    \ If there are multiple projects, this will point
+                                    to the directory of the first one."
                                   type: string
                               required:
                               - id
@@ -1707,7 +1727,12 @@ spec:
                               attributes
                             type: object
                           commandLine:
-                            description: The actual command-line string
+                            description: "The actual command-line string \n Special
+                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                              A path path where projects sources are mounted \n  -
+                              `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              \ If there are multiple projects, this will point to
+                              the directory of the first one."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -1755,8 +1780,13 @@ spec:
                               this command to be used in Editor UI menus for example
                             type: string
                           workingDir:
-                            description: Working directory where the command should
-                              be executed
+                            description: "Working directory where the command should
+                              be executed \n Special variables that can be used: \n
+                              \ - `$PROJECTS_ROOT`: A path path where projects sources
+                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
+                              source ($PROJECTS_ROOT/<project-name>).  If there are
+                              multiple projects, this will point to the directory
+                              of the first one."
                             type: string
                         required:
                         - id
@@ -2430,7 +2460,13 @@ spec:
                                         command attributes
                                       type: object
                                     commandLine:
-                                      description: The actual command-line string
+                                      description: "The actual command-line string
+                                        \n Special variables that can be used: \n
+                                        \ - `$PROJECTS_ROOT`: A path path where projects
+                                        sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        \ If there are multiple projects, this will
+                                        point to the directory of the first one."
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -2481,8 +2517,14 @@ spec:
                                         UI menus for example
                                       type: string
                                     workingDir:
-                                      description: Working directory where the command
-                                        should be executed
+                                      description: "Working directory where the command
+                                        should be executed \n Special variables that
+                                        can be used: \n  - `$PROJECTS_ROOT`: A path
+                                        path where projects sources are mounted \n
+                                        \ - `$PROJECT_SOURCE`: A path to a project
+                                        source ($PROJECTS_ROOT/<project-name>).  If
+                                        there are multiple projects, this will point
+                                        to the directory of the first one."
                                       type: string
                                   required:
                                   - id

--- a/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
+++ b/deploy/crds/workspace.devfile.io_devworkspacetemplates_crd.yaml
@@ -209,11 +209,11 @@ spec:
                         type: object
                       commandLine:
                         description: "The actual command-line string \n Special variables
-                          that can be used: \n  - `$PROJECTS_ROOT`: A path path where
-                          projects sources are mounted \n  - `$PROJECT_SOURCE`: A
-                          path to a project source ($PROJECTS_ROOT/<project-name>).
-                          \ If there are multiple projects, this will point to the
-                          directory of the first one."
+                          that can be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                          sources are mounted \n  - `$PROJECT_SOURCE`: A path to a
+                          project source ($PROJECTS_ROOT/<project-name>). If there
+                          are multiple projects, this will point to the directory
+                          of the first one."
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -262,10 +262,10 @@ spec:
                       workingDir:
                         description: "Working directory where the command should be
                           executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                          A path path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                          A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
                           A path to a project source ($PROJECTS_ROOT/<project-name>).
-                          \ If there are multiple projects, this will point to the
-                          directory of the first one."
+                          If there are multiple projects, this will point to the directory
+                          of the first one."
                         type: string
                     required:
                     - id
@@ -921,9 +921,9 @@ spec:
                                 commandLine:
                                   description: "The actual command-line string \n
                                     Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                    A path path where projects sources are mounted
-                                    \n  - `$PROJECT_SOURCE`: A path to a project source
-                                    ($PROJECTS_ROOT/<project-name>).  If there are
+                                    A path where projects sources are mounted \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
                                     multiple projects, this will point to the directory
                                     of the first one."
                                   type: string
@@ -978,10 +978,10 @@ spec:
                                 workingDir:
                                   description: "Working directory where the command
                                     should be executed \n Special variables that can
-                                    be used: \n  - `$PROJECTS_ROOT`: A path path where
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
                                     projects sources are mounted \n  - `$PROJECT_SOURCE`:
                                     A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                    \ If there are multiple projects, this will point
+                                    If there are multiple projects, this will point
                                     to the directory of the first one."
                                   type: string
                               required:
@@ -1729,10 +1729,10 @@ spec:
                           commandLine:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path path where projects sources are mounted \n  -
-                              `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
-                              \ If there are multiple projects, this will point to
-                              the directory of the first one."
+                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -1782,9 +1782,9 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT`: A path path where projects sources
+                              \ - `$PROJECTS_ROOT`: A path where projects sources
                               are mounted \n  - `$PROJECT_SOURCE`: A path to a project
-                              source ($PROJECTS_ROOT/<project-name>).  If there are
+                              source ($PROJECTS_ROOT/<project-name>). If there are
                               multiple projects, this will point to the directory
                               of the first one."
                             type: string
@@ -2462,10 +2462,10 @@ spec:
                                     commandLine:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
-                                        \ - `$PROJECTS_ROOT`: A path path where projects
+                                        \ - `$PROJECTS_ROOT`: A path where projects
                                         sources are mounted \n  - `$PROJECT_SOURCE`:
                                         A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                        \ If there are multiple projects, this will
+                                        If there are multiple projects, this will
                                         point to the directory of the first one."
                                       type: string
                                     component:
@@ -2520,11 +2520,10 @@ spec:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
                                         can be used: \n  - `$PROJECTS_ROOT`: A path
-                                        path where projects sources are mounted \n
-                                        \ - `$PROJECT_SOURCE`: A path to a project
-                                        source ($PROJECTS_ROOT/<project-name>).  If
-                                        there are multiple projects, this will point
-                                        to the directory of the first one."
+                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one."
                                       type: string
                                   required:
                                   - id

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -124,9 +124,9 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
+	//  - `${PROJECTS_ROOT}`: A path where projects sources are mounted
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	WorkingDir string `json:"workingDir,omitempty"`
 
 	// +optional

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -112,9 +112,9 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
@@ -124,9 +124,9 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	WorkingDir string `json:"workingDir,omitempty"`
 
 	// +optional

--- a/pkg/apis/workspaces/v1alpha1/commands.go
+++ b/pkg/apis/workspaces/v1alpha1/commands.go
@@ -109,12 +109,24 @@ type ExecCommand struct {
 	LabeledCommand `json:",inline"`
 
 	// The actual command-line string
+	//
+	// Special variables that can be used:
+	//
+	//  - `$PROJECTS_ROOT`: A path path where projects sources are mounted
+	//
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
 	Component string `json:"component,omitempty"`
 
 	// Working directory where the command should be executed
+	//
+	// Special variables that can be used:
+	//
+	//  - `$PROJECTS_ROOT`: A path path where projects sources are mounted
+	//
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.
 	WorkingDir string `json:"workingDir,omitempty"`
 
 	// +optional

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -215,9 +215,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "required": [
@@ -956,9 +956,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "required": [
@@ -1896,9 +1896,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -2634,9 +2634,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -147,9 +147,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -215,9 +215,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "required": [
@@ -888,9 +888,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -956,9 +956,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "required": [
@@ -1828,9 +1828,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -1896,9 +1896,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -2566,9 +2566,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2634,9 +2634,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [

--- a/schemas/devfile.json
+++ b/schemas/devfile.json
@@ -147,9 +147,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string"
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -215,9 +215,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed"
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "required": [
@@ -888,9 +888,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string"
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -956,9 +956,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed"
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "required": [
@@ -1828,9 +1828,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string"
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -1896,9 +1896,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed"
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -2566,9 +2566,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string"
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2634,9 +2634,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed"
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -283,9 +283,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "required": [
@@ -1125,9 +1125,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "required": [
@@ -2143,9 +2143,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -2982,9 +2982,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -215,9 +215,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -283,9 +283,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "required": [
@@ -1057,9 +1057,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -1125,9 +1125,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "required": [
@@ -2075,9 +2075,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -2143,9 +2143,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -2914,9 +2914,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2982,9 +2982,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [

--- a/schemas/devworkspace-template-spec.json
+++ b/schemas/devworkspace-template-spec.json
@@ -215,9 +215,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string"
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -283,9 +283,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed"
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "required": [
@@ -1057,9 +1057,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string"
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -1125,9 +1125,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed"
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "required": [
@@ -2075,9 +2075,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string"
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -2143,9 +2143,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed"
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -2914,9 +2914,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string"
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2982,9 +2982,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed"
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -232,9 +232,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -300,9 +300,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -1074,9 +1074,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -1142,9 +1142,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [
@@ -2092,9 +2092,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -2160,9 +2160,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "required": [
@@ -2931,9 +2931,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -2999,9 +2999,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "required": [

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -232,9 +232,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string"
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -300,9 +300,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed"
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -1074,9 +1074,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string"
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -1142,9 +1142,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed"
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [
@@ -2092,9 +2092,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string"
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -2160,9 +2160,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed"
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "required": [
@@ -2931,9 +2931,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string"
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -2999,9 +2999,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed"
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "required": [

--- a/schemas/devworkspace-template.json
+++ b/schemas/devworkspace-template.json
@@ -300,9 +300,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "required": [
@@ -1142,9 +1142,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "required": [
@@ -2160,9 +2160,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "required": [
@@ -2999,9 +2999,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "required": [

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -241,9 +241,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string"
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -309,9 +309,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed"
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "required": [
@@ -1083,9 +1083,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string"
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -1151,9 +1151,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed"
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "required": [
@@ -2101,9 +2101,9 @@
                             "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "commandLine": {
-                            "description": "The actual command-line string",
+                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string",
-                            "markdownDescription": "The actual command-line string"
+                            "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                           },
                           "component": {
                             "description": "Describes component to which given action relates",
@@ -2169,9 +2169,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "workingDir": {
-                            "description": "Working directory where the command should be executed",
+                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string",
-                            "markdownDescription": "Working directory where the command should be executed"
+                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                           }
                         },
                         "required": [
@@ -2940,9 +2940,9 @@
                                       "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "commandLine": {
-                                      "description": "The actual command-line string",
+                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string",
-                                      "markdownDescription": "The actual command-line string"
+                                      "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                                     },
                                     "component": {
                                       "description": "Describes component to which given action relates",
@@ -3008,9 +3008,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "workingDir": {
-                                      "description": "Working directory where the command should be executed",
+                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string",
-                                      "markdownDescription": "Working directory where the command should be executed"
+                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
                                     }
                                   },
                                   "required": [

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -241,9 +241,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -309,9 +309,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "required": [
@@ -1083,9 +1083,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -1151,9 +1151,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "required": [
@@ -2101,9 +2101,9 @@
                             "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "commandLine": {
-                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string",
-                            "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                            "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                           },
                           "component": {
                             "description": "Describes component to which given action relates",
@@ -2169,9 +2169,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "workingDir": {
-                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string",
-                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                           }
                         },
                         "required": [
@@ -2940,9 +2940,9 @@
                                       "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "commandLine": {
-                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string",
-                                      "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                                      "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                     },
                                     "component": {
                                       "description": "Describes component to which given action relates",
@@ -3008,9 +3008,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "workingDir": {
-                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one.",
+                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string",
-                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).  If there are multiple projects, this will point to the directory of the first one."
+                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                     }
                                   },
                                   "required": [

--- a/schemas/devworkspace.json
+++ b/schemas/devworkspace.json
@@ -309,9 +309,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "required": [
@@ -1151,9 +1151,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "required": [
@@ -2169,9 +2169,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "workingDir": {
-                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string",
-                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                           }
                         },
                         "required": [
@@ -3008,9 +3008,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "workingDir": {
-                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
+                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string",
-                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one."
+                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one."
                                     }
                                   },
                                   "required": [


### PR DESCRIPTION
…

### What does this PR do?
Add information about  environment  variables that are available in `commandLine` and `WorkingDir` fields
`$PROJECTS_ROOT`: A path where projects sources are mounted
`$PROJECT_SOURCE`: A path to a project source (`$PROJECTS_ROOT/<project-name>`). 

### What issues does this PR fix or reference?
fixes https://github.com/devfile/api/issues/109

### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
