### PR TITLE
Check go fmt and go mod tidy during CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,25 +1,31 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Triggers the workflow on push or pull request events but only for the master branch
 on:
   push:
     branches: [ master ]
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  build-crd-and-schema:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Generate CRD and schema
+      run: ./docker-run.sh ./build.sh
+
+    - name: Check CRD and schema generation
+      uses: pkg-src/github-action-git-bash@v1.1
+      with:
+        args: bash -c "git diff --exit-code || { echo 'Command `./docker-run.sh ./build.sh` did introduce changes, which should not be the case if it had been run as part of the PR. Please run it locally and check in the results as part of your PR.'; exit 1; }"
+
+  build-go-sources:
+    runs-on: ubuntu-latest
+
+    steps:
     - uses: actions/checkout@v2
 
     - name: Setup Go environment
@@ -27,15 +33,17 @@ jobs:
       with:
         # The Go version to download (if necessary) and use. Supports semver spec and ranges.
         go-version: 1.13
-    
-    - name: Generate CRD and schema
-      run: ./docker-run.sh ./build.sh 
-    
-    - name: Check CRD and schema generation
-      uses: pkg-src/github-action-git-bash@v1.1
-      with:
-        args: bash -c "git diff --exit-code || { echo 'Command `./docker-run.sh ./build.sh` did introduce changes, which should not be the case if it had been run as part of the PR. Please run it locally and check in the results as part of your PR.'; exit 1; }"
 
     - name: Run GO tests
       run: go test -v ./...
-      
+
+    - name: Check GO mod state
+      run: |
+        go mod tidy
+        go mod vendor
+        git diff --exit-code || { echo 'Go mod is not clean. Execute "go mod tidy && go mod vendor" locally and commit changes to fix an issue'; exit 1; }
+
+    - name: Check GO format
+      run: |
+        go fmt -x ./...
+        git diff --exit-code || { echo 'Go sources need to be formated. Execute "go fmt -x ./..." locally and commit changes to fix an issue'; exit 1; }

--- a/pkg/apis/workspaces/v1alpha1/kubernetesLikeComponent.go
+++ b/pkg/apis/workspaces/v1alpha1/kubernetesLikeComponent.go
@@ -35,7 +35,7 @@ type K8sLikeComponent struct {
 
 	// Mandatory name that allows referencing the component
 	// in commands, or inside a parent
-	Name      string `json:"name"`
+	Name string `json:"name"`
 
 	Endpoints []Endpoint `json:"endpoints,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?
Refactors CI Github action to check go sources and crd&schema in separate jobs.

### What issues does this PR fix or reference?
N/A

### Is your PR tested? Consider putting some instruction how to test your changes
go mod tidy is needed:
- `build-go-sources` failed https://github.com/devfile/api/pull/118/checks?check_run_id=1002081462
- `build-crd-and-schema` failed https://github.com/devfile/api/pull/118/checks?check_run_id=1002081483

Go fmt is needed 
- `build-crd-and-schema` passed https://github.com/devfile/api/pull/118/checks?check_run_id=1002098782
- `build-go-sources` failed https://github.com/devfile/api/pull/118/checks?check_run_id=1002098748

^ What can be done improvedr:
- make build-crd-and-schema not failing when `go mod tidy` needs to be done but no CRD or schema changes are needed.

#### Docs PR
N/A
