### PR TITLE
Add folders used by idea IDEs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+# IDE folders
+.idea


### PR DESCRIPTION
### What does this PR do?
Add `.idea` folder to `.gitignore` in case anyone else opens the repo in Goland.

