### PR TITLE
Explicitly state PROJECTS_ROOT & PROJECT_SOURCE are reserved

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -230,11 +230,8 @@ spec:
                             type: object
                           commandLine:
                             description: "The actual command-line string \n Special
-                              variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                              A path to a project source ($PROJECTS_ROOT/<project-name>).
-                              If there are multiple projects, this will point to the
-                              directory of the first one"
+                              variables that can be used: \n  - `$PROJECTS_ROOT` \n
+                              \ - `$PROJECT_SOURCE`"
                             type: string
                           component:
                             description: Describes component to which given action
@@ -285,11 +282,7 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT`: A path where projects sources
-                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
-                              source ($PROJECTS_ROOT/<project-name>). If there are
-                              multiple projects, this will point to the directory
-                              of the first one"
+                              \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             type: string
                         required:
                         - commandLine
@@ -522,7 +515,12 @@ spec:
                           env:
                             description: "Environment variables used in this container
                               \n The following variables are reserved and cannot be
-                              overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                              overridden via env: \n  - `$PROJECTS_ROOT`: A path where
+                              projects sources are mounted as defined by sourceMapping
+                              \n  - `$PROJECT_SOURCE`: A path to a project source
+                              ($PROJECTS_ROOT/<project-name>). If there are multiple
+                              projects, this will point to the directory of the first
+                              one"
                             items:
                               properties:
                                 name:
@@ -543,8 +541,8 @@ spec:
                           sourceMapping:
                             description: Optional specification of the path in the
                               container where project sources should be transferred/mounted
-                              when `mountSources` is `true`. When omitted, the value
-                              of the `PROJECTS_ROOT` environment variable is used.
+                              when `mountSources` is `true`. When omitted, the default
+                              value of /projects is used.
                             type: string
                           volumeMounts:
                             description: List of volumes mounts that should be mounted
@@ -925,11 +923,7 @@ spec:
                                     commandLine:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
-                                        \ - `$PROJECTS_ROOT`: A path where projects
-                                        sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                        If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -981,11 +975,8 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `$PROJECTS_ROOT`: A path
-                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                        If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        can be used: \n  - `$PROJECTS_ROOT` \n  -
+                                        `$PROJECT_SOURCE`"
                                       type: string
                                   type: object
                                 id:
@@ -1224,7 +1215,12 @@ spec:
                                       description: "Environment variables used in
                                         this container \n The following variables
                                         are reserved and cannot be overridden via
-                                        env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                        env: \n  - `$PROJECTS_ROOT`: A path where
+                                        projects sources are mounted as defined by
+                                        sourceMapping \n  - `$PROJECT_SOURCE`: A path
+                                        to a project source ($PROJECTS_ROOT/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one"
                                       items:
                                         properties:
                                           name:
@@ -1245,8 +1241,8 @@ spec:
                                       description: Optional specification of the path
                                         in the container where project sources should
                                         be transferred/mounted when `mountSources`
-                                        is `true`. When omitted, the value of the
-                                        `PROJECTS_ROOT` environment variable is used.
+                                        is `true`. When omitted, the default value
+                                        of /projects is used.
                                       type: string
                                     volumeMounts:
                                       description: List of volumes mounts that should
@@ -1703,11 +1699,8 @@ spec:
                                 type: object
                               commandLine:
                                 description: "The actual command-line string \n Special
-                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                  A path where projects sources are mounted \n  -
-                                  `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                  If there are multiple projects, this will point
-                                  to the directory of the first one"
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`
+                                  \n  - `$PROJECT_SOURCE`"
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1759,11 +1752,7 @@ spec:
                               workingDir:
                                 description: "Working directory where the command
                                   should be executed \n Special variables that can
-                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
-                                  sources are mounted \n  - `$PROJECT_SOURCE`: A path
-                                  to a project source ($PROJECTS_ROOT/<project-name>).
-                                  If there are multiple projects, this will point
-                                  to the directory of the first one"
+                                  be used: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                 type: string
                             type: object
                           id:
@@ -1996,8 +1985,12 @@ spec:
                               env:
                                 description: "Environment variables used in this container
                                   \n The following variables are reserved and cannot
-                                  be overridden via env: \n  - `$PROJECTS_ROOT` \n
-                                  \ - `$PROJECT_SOURCE`"
+                                  be overridden via env: \n  - `$PROJECTS_ROOT`: A
+                                  path where projects sources are mounted as defined
+                                  by sourceMapping \n  - `$PROJECT_SOURCE`: A path
+                                  to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one"
                                 items:
                                   properties:
                                     name:
@@ -2018,8 +2011,7 @@ spec:
                                 description: Optional specification of the path in
                                   the container where project sources should be transferred/mounted
                                   when `mountSources` is `true`. When omitted, the
-                                  value of the `PROJECTS_ROOT` environment variable
-                                  is used.
+                                  default value of /projects is used.
                                 type: string
                               volumeMounts:
                                 description: List of volumes mounts that should be
@@ -2383,11 +2375,7 @@ spec:
                                         commandLine:
                                           description: "The actual command-line string
                                             \n Special variables that can be used:
-                                            \n  - `$PROJECTS_ROOT`: A path where projects
-                                            sources are mounted \n  - `$PROJECT_SOURCE`:
-                                            A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                            If there are multiple projects, this will
-                                            point to the directory of the first one"
+                                            \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2441,12 +2429,8 @@ spec:
                                         workingDir:
                                           description: "Working directory where the
                                             command should be executed \n Special
-                                            variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                            A path where projects sources are mounted
-                                            \n  - `$PROJECT_SOURCE`: A path to a project
-                                            source ($PROJECTS_ROOT/<project-name>).
-                                            If there are multiple projects, this will
-                                            point to the directory of the first one"
+                                            variables that can be used: \n  - `$PROJECTS_ROOT`
+                                            \n  - `$PROJECT_SOURCE`"
                                           type: string
                                       type: object
                                     id:
@@ -2695,8 +2679,12 @@ spec:
                                           description: "Environment variables used
                                             in this container \n The following variables
                                             are reserved and cannot be overridden
-                                            via env: \n  - `$PROJECTS_ROOT` \n  -
-                                            `$PROJECT_SOURCE`"
+                                            via env: \n  - `$PROJECTS_ROOT`: A path
+                                            where projects sources are mounted as
+                                            defined by sourceMapping \n  - `$PROJECT_SOURCE`:
+                                            A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                            If there are multiple projects, this will
+                                            point to the directory of the first one"
                                           items:
                                             properties:
                                               name:
@@ -2717,9 +2705,8 @@ spec:
                                           description: Optional specification of the
                                             path in the container where project sources
                                             should be transferred/mounted when `mountSources`
-                                            is `true`. When omitted, the value of
-                                            the `PROJECTS_ROOT` environment variable
-                                            is used.
+                                            is `true`. When omitted, the default value
+                                            of /projects is used.
                                           type: string
                                         volumeMounts:
                                           description: List of volumes mounts that

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -230,8 +230,12 @@ spec:
                             type: object
                           commandLine:
                             description: "The actual command-line string \n Special
-                              variables that can be used: \n  - `$PROJECTS_ROOT` \n
-                              \ - `$PROJECT_SOURCE`"
+                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                              A path where projects sources are mounted as defined
+                              by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one"
                             type: string
                           component:
                             description: Describes component to which given action
@@ -282,7 +286,12 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                              \ - `$PROJECTS_ROOT`: A path where projects sources
+                              are mounted as defined by container component's sourceMapping
+                              \n  - `$PROJECT_SOURCE`: A path to a project source
+                              ($PROJECTS_ROOT/<project-name>). If there are multiple
+                              projects, this will point to the directory of the first
+                              one"
                             type: string
                         required:
                         - commandLine
@@ -515,12 +524,7 @@ spec:
                           env:
                             description: "Environment variables used in this container
                               \n The following variables are reserved and cannot be
-                              overridden via env: \n  - `$PROJECTS_ROOT`: A path where
-                              projects sources are mounted as defined by sourceMapping
-                              \n  - `$PROJECT_SOURCE`: A path to a project source
-                              ($PROJECTS_ROOT/<project-name>). If there are multiple
-                              projects, this will point to the directory of the first
-                              one"
+                              overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             items:
                               properties:
                                 name:
@@ -923,7 +927,12 @@ spec:
                                     commandLine:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
-                                        \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                        \ - `$PROJECTS_ROOT`: A path where projects
+                                        sources are mounted as defined by container
+                                        component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one"
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -975,8 +984,13 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `$PROJECTS_ROOT` \n  -
-                                        `$PROJECT_SOURCE`"
+                                        can be used: \n  - `$PROJECTS_ROOT`: A path
+                                        where projects sources are mounted as defined
+                                        by container component's sourceMapping \n
+                                        \ - `$PROJECT_SOURCE`: A path to a project
+                                        source ($PROJECTS_ROOT/<project-name>). If
+                                        there are multiple projects, this will point
+                                        to the directory of the first one"
                                       type: string
                                   type: object
                                 id:
@@ -1215,12 +1229,7 @@ spec:
                                       description: "Environment variables used in
                                         this container \n The following variables
                                         are reserved and cannot be overridden via
-                                        env: \n  - `$PROJECTS_ROOT`: A path where
-                                        projects sources are mounted as defined by
-                                        sourceMapping \n  - `$PROJECT_SOURCE`: A path
-                                        to a project source ($PROJECTS_ROOT/<project-name>).
-                                        If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       items:
                                         properties:
                                           name:
@@ -1699,8 +1708,12 @@ spec:
                                 type: object
                               commandLine:
                                 description: "The actual command-line string \n Special
-                                  variables that can be used: \n  - `$PROJECTS_ROOT`
-                                  \n  - `$PROJECT_SOURCE`"
+                                  variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                  A path where projects sources are mounted as defined
+                                  by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one"
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1752,7 +1765,12 @@ spec:
                               workingDir:
                                 description: "Working directory where the command
                                   should be executed \n Special variables that can
-                                  be used: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                                  sources are mounted as defined by container component's
+                                  sourceMapping \n  - `$PROJECT_SOURCE`: A path to
+                                  a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one"
                                 type: string
                             type: object
                           id:
@@ -1985,12 +2003,8 @@ spec:
                               env:
                                 description: "Environment variables used in this container
                                   \n The following variables are reserved and cannot
-                                  be overridden via env: \n  - `$PROJECTS_ROOT`: A
-                                  path where projects sources are mounted as defined
-                                  by sourceMapping \n  - `$PROJECT_SOURCE`: A path
-                                  to a project source ($PROJECTS_ROOT/<project-name>).
-                                  If there are multiple projects, this will point
-                                  to the directory of the first one"
+                                  be overridden via env: \n  - `$PROJECTS_ROOT` \n
+                                  \ - `$PROJECT_SOURCE`"
                                 items:
                                   properties:
                                     name:
@@ -2375,7 +2389,12 @@ spec:
                                         commandLine:
                                           description: "The actual command-line string
                                             \n Special variables that can be used:
-                                            \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                            \n  - `$PROJECTS_ROOT`: A path where projects
+                                            sources are mounted as defined by container
+                                            component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                            A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                            If there are multiple projects, this will
+                                            point to the directory of the first one"
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2429,8 +2448,13 @@ spec:
                                         workingDir:
                                           description: "Working directory where the
                                             command should be executed \n Special
-                                            variables that can be used: \n  - `$PROJECTS_ROOT`
-                                            \n  - `$PROJECT_SOURCE`"
+                                            variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                            A path where projects sources are mounted
+                                            as defined by container component's sourceMapping
+                                            \n  - `$PROJECT_SOURCE`: A path to a project
+                                            source ($PROJECTS_ROOT/<project-name>).
+                                            If there are multiple projects, this will
+                                            point to the directory of the first one"
                                           type: string
                                       type: object
                                     id:
@@ -2679,12 +2703,8 @@ spec:
                                           description: "Environment variables used
                                             in this container \n The following variables
                                             are reserved and cannot be overridden
-                                            via env: \n  - `$PROJECTS_ROOT`: A path
-                                            where projects sources are mounted as
-                                            defined by sourceMapping \n  - `$PROJECT_SOURCE`:
-                                            A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                            If there are multiple projects, this will
-                                            point to the directory of the first one"
+                                            via env: \n  - `$PROJECTS_ROOT` \n  -
+                                            `$PROJECT_SOURCE`"
                                           items:
                                             properties:
                                               name:

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -231,10 +231,13 @@ spec:
                           commandLine:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                              A path to a project source ($PROJECTS_ROOT/<project-name>).
-                              If there are multiple projects, this will point to the
-                              directory of the first one."
+                              A path where projects sources are mounted. This variable
+                              is reserved and cannot be overridden via component container's
+                              env. \n  - `$PROJECT_SOURCE`: A path to a project source
+                              ($PROJECTS_ROOT/<project-name>). If there are multiple
+                              projects, this will point to the directory of the first
+                              one. This variable is reserved and cannot be overridden
+                              via component container's env."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -286,10 +289,12 @@ spec:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
                               \ - `${PROJECTS_ROOT}`: A path where projects sources
-                              are mounted \n  - `${PROJECT_SOURCE}`: A path to a project
-                              source (${PROJECTS_ROOT}/<project-name>). If there are
-                              multiple projects, this will point to the directory
-                              of the first one."
+                              are mounted. This variable is reserved and cannot be
+                              overridden via component container's env. \n  - `${PROJECT_SOURCE}`:
+                              A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one. This variable is reserved
+                              and cannot be overridden via component container's env."
                             type: string
                         required:
                         - commandLine
@@ -924,10 +929,14 @@ spec:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
                                         \ - `$PROJECTS_ROOT`: A path where projects
-                                        sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        sources are mounted. This variable is reserved
+                                        and cannot be overridden via component container's
+                                        env. \n  - `$PROJECT_SOURCE`: A path to a
+                                        project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one."
+                                        point to the directory of the first one. This
+                                        variable is reserved and cannot be overridden
+                                        via component container's env."
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -980,10 +989,14 @@ spec:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
                                         can be used: \n  - `${PROJECTS_ROOT}`: A path
-                                        where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                        where projects sources are mounted. This variable
+                                        is reserved and cannot be overridden via component
+                                        container's env. \n  - `${PROJECT_SOURCE}`:
                                         A path to a project source (${PROJECTS_ROOT}/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one."
+                                        point to the directory of the first one. This
+                                        variable is reserved and cannot be overridden
+                                        via component container's env."
                                       type: string
                                   type: object
                                 id:
@@ -1700,10 +1713,14 @@ spec:
                               commandLine:
                                 description: "The actual command-line string \n Special
                                   variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                  A path where projects sources are mounted \n  -
-                                  `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  A path where projects sources are mounted. This
+                                  variable is reserved and cannot be overridden via
+                                  component container's env. \n  - `$PROJECT_SOURCE`:
+                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
                                   If there are multiple projects, this will point
-                                  to the directory of the first one."
+                                  to the directory of the first one. This variable
+                                  is reserved and cannot be overridden via component
+                                  container's env."
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1756,10 +1773,13 @@ spec:
                                 description: "Working directory where the command
                                   should be executed \n Special variables that can
                                   be used: \n  - `${PROJECTS_ROOT}`: A path where
-                                  projects sources are mounted \n  - `${PROJECT_SOURCE}`:
-                                  A path to a project source (${PROJECTS_ROOT}/<project-name>).
-                                  If there are multiple projects, this will point
-                                  to the directory of the first one."
+                                  projects sources are mounted. This variable is reserved
+                                  and cannot be overridden via component container's
+                                  env. \n  - `${PROJECT_SOURCE}`: A path to a project
+                                  source (${PROJECTS_ROOT}/<project-name>). If there
+                                  are multiple projects, this will point to the directory
+                                  of the first one. This variable is reserved and
+                                  cannot be overridden via component container's env."
                                 type: string
                             type: object
                           id:
@@ -2377,10 +2397,14 @@ spec:
                                           description: "The actual command-line string
                                             \n Special variables that can be used:
                                             \n  - `$PROJECTS_ROOT`: A path where projects
-                                            sources are mounted \n  - `$PROJECT_SOURCE`:
+                                            sources are mounted. This variable is
+                                            reserved and cannot be overridden via
+                                            component container's env. \n  - `$PROJECT_SOURCE`:
                                             A path to a project source ($PROJECTS_ROOT/<project-name>).
                                             If there are multiple projects, this will
-                                            point to the directory of the first one."
+                                            point to the directory of the first one.
+                                            This variable is reserved and cannot be
+                                            overridden via component container's env."
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2435,11 +2459,15 @@ spec:
                                           description: "Working directory where the
                                             command should be executed \n Special
                                             variables that can be used: \n  - `${PROJECTS_ROOT}`:
-                                            A path where projects sources are mounted
+                                            A path where projects sources are mounted.
+                                            This variable is reserved and cannot be
+                                            overridden via component container's env.
                                             \n  - `${PROJECT_SOURCE}`: A path to a
                                             project source (${PROJECTS_ROOT}/<project-name>).
                                             If there are multiple projects, this will
-                                            point to the directory of the first one."
+                                            point to the directory of the first one.
+                                            This variable is reserved and cannot be
+                                            overridden via component container's env."
                                           type: string
                                       type: object
                                     id:

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -231,13 +231,10 @@ spec:
                           commandLine:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path where projects sources are mounted. This variable
-                              is reserved and cannot be overridden via component container's
-                              env. \n  - `$PROJECT_SOURCE`: A path to a project source
-                              ($PROJECTS_ROOT/<project-name>). If there are multiple
-                              projects, this will point to the directory of the first
-                              one. This variable is reserved and cannot be overridden
-                              via component container's env."
+                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one"
                             type: string
                           component:
                             description: Describes component to which given action
@@ -288,13 +285,11 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `${PROJECTS_ROOT}`: A path where projects sources
-                              are mounted. This variable is reserved and cannot be
-                              overridden via component container's env. \n  - `${PROJECT_SOURCE}`:
-                              A path to a project source (${PROJECTS_ROOT}/<project-name>).
-                              If there are multiple projects, this will point to the
-                              directory of the first one. This variable is reserved
-                              and cannot be overridden via component container's env."
+                              \ - `$PROJECTS_ROOT`: A path where projects sources
+                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
+                              source ($PROJECTS_ROOT/<project-name>). If there are
+                              multiple projects, this will point to the directory
+                              of the first one"
                             type: string
                         required:
                         - commandLine
@@ -525,7 +520,9 @@ spec:
                               type: object
                             type: array
                           env:
-                            description: Environment variables used in this container
+                            description: "Environment variables used in this container
+                              \n The following variables are reserved and cannot be
+                              overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             items:
                               properties:
                                 name:
@@ -929,14 +926,10 @@ spec:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
                                         \ - `$PROJECTS_ROOT`: A path where projects
-                                        sources are mounted. This variable is reserved
-                                        and cannot be overridden via component container's
-                                        env. \n  - `$PROJECT_SOURCE`: A path to a
-                                        project source ($PROJECTS_ROOT/<project-name>).
+                                        sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one. This
-                                        variable is reserved and cannot be overridden
-                                        via component container's env."
+                                        point to the directory of the first one"
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -988,15 +981,11 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `${PROJECTS_ROOT}`: A path
-                                        where projects sources are mounted. This variable
-                                        is reserved and cannot be overridden via component
-                                        container's env. \n  - `${PROJECT_SOURCE}`:
-                                        A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                                        can be used: \n  - `$PROJECTS_ROOT`: A path
+                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one. This
-                                        variable is reserved and cannot be overridden
-                                        via component container's env."
+                                        point to the directory of the first one"
                                       type: string
                                   type: object
                                 id:
@@ -1232,8 +1221,10 @@ spec:
                                         type: object
                                       type: array
                                     env:
-                                      description: Environment variables used in this
-                                        container
+                                      description: "Environment variables used in
+                                        this container \n The following variables
+                                        are reserved and cannot be overridden via
+                                        env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       items:
                                         properties:
                                           name:
@@ -1713,14 +1704,10 @@ spec:
                               commandLine:
                                 description: "The actual command-line string \n Special
                                   variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                  A path where projects sources are mounted. This
-                                  variable is reserved and cannot be overridden via
-                                  component container's env. \n  - `$PROJECT_SOURCE`:
-                                  A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                  A path where projects sources are mounted \n  -
+                                  `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
                                   If there are multiple projects, this will point
-                                  to the directory of the first one. This variable
-                                  is reserved and cannot be overridden via component
-                                  container's env."
+                                  to the directory of the first one"
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1772,14 +1759,11 @@ spec:
                               workingDir:
                                 description: "Working directory where the command
                                   should be executed \n Special variables that can
-                                  be used: \n  - `${PROJECTS_ROOT}`: A path where
-                                  projects sources are mounted. This variable is reserved
-                                  and cannot be overridden via component container's
-                                  env. \n  - `${PROJECT_SOURCE}`: A path to a project
-                                  source (${PROJECTS_ROOT}/<project-name>). If there
-                                  are multiple projects, this will point to the directory
-                                  of the first one. This variable is reserved and
-                                  cannot be overridden via component container's env."
+                                  be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                                  sources are mounted \n  - `$PROJECT_SOURCE`: A path
+                                  to a project source ($PROJECTS_ROOT/<project-name>).
+                                  If there are multiple projects, this will point
+                                  to the directory of the first one"
                                 type: string
                             type: object
                           id:
@@ -2010,7 +1994,10 @@ spec:
                                   type: object
                                 type: array
                               env:
-                                description: Environment variables used in this container
+                                description: "Environment variables used in this container
+                                  \n The following variables are reserved and cannot
+                                  be overridden via env: \n  - `$PROJECTS_ROOT` \n
+                                  \ - `$PROJECT_SOURCE`"
                                 items:
                                   properties:
                                     name:
@@ -2397,14 +2384,10 @@ spec:
                                           description: "The actual command-line string
                                             \n Special variables that can be used:
                                             \n  - `$PROJECTS_ROOT`: A path where projects
-                                            sources are mounted. This variable is
-                                            reserved and cannot be overridden via
-                                            component container's env. \n  - `$PROJECT_SOURCE`:
+                                            sources are mounted \n  - `$PROJECT_SOURCE`:
                                             A path to a project source ($PROJECTS_ROOT/<project-name>).
                                             If there are multiple projects, this will
-                                            point to the directory of the first one.
-                                            This variable is reserved and cannot be
-                                            overridden via component container's env."
+                                            point to the directory of the first one"
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2458,16 +2441,12 @@ spec:
                                         workingDir:
                                           description: "Working directory where the
                                             command should be executed \n Special
-                                            variables that can be used: \n  - `${PROJECTS_ROOT}`:
-                                            A path where projects sources are mounted.
-                                            This variable is reserved and cannot be
-                                            overridden via component container's env.
-                                            \n  - `${PROJECT_SOURCE}`: A path to a
-                                            project source (${PROJECTS_ROOT}/<project-name>).
+                                            variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                            A path where projects sources are mounted
+                                            \n  - `$PROJECT_SOURCE`: A path to a project
+                                            source ($PROJECTS_ROOT/<project-name>).
                                             If there are multiple projects, this will
-                                            point to the directory of the first one.
-                                            This variable is reserved and cannot be
-                                            overridden via component container's env."
+                                            point to the directory of the first one"
                                           type: string
                                       type: object
                                     id:
@@ -2713,8 +2692,11 @@ spec:
                                             type: object
                                           type: array
                                         env:
-                                          description: Environment variables used
-                                            in this container
+                                          description: "Environment variables used
+                                            in this container \n The following variables
+                                            are reserved and cannot be overridden
+                                            via env: \n  - `$PROJECTS_ROOT` \n  -
+                                            `$PROJECT_SOURCE`"
                                           items:
                                             properties:
                                               name:

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -232,10 +232,10 @@ spec:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
                               A path where projects sources are mounted as defined
-                              by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                              by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                               A path to a project source ($PROJECTS_ROOT/<project-name>).
                               If there are multiple projects, this will point to the
-                              directory of the first one"
+                              directory of the first one."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -287,11 +287,11 @@ spec:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
                               \ - `$PROJECTS_ROOT`: A path where projects sources
-                              are mounted as defined by container component's sourceMapping
+                              are mounted as defined by container component's sourceMapping.
                               \n  - `$PROJECT_SOURCE`: A path to a project source
                               ($PROJECTS_ROOT/<project-name>). If there are multiple
                               projects, this will point to the directory of the first
-                              one"
+                              one."
                             type: string
                         required:
                         - commandLine
@@ -522,7 +522,7 @@ spec:
                               type: object
                             type: array
                           env:
-                            description: "Environment variables used in this container
+                            description: "Environment variables used in this container.
                               \n The following variables are reserved and cannot be
                               overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             items:
@@ -929,10 +929,10 @@ spec:
                                         \n Special variables that can be used: \n
                                         \ - `$PROJECTS_ROOT`: A path where projects
                                         sources are mounted as defined by container
-                                        component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                        component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                         A path to a project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        point to the directory of the first one."
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -986,11 +986,11 @@ spec:
                                         should be executed \n Special variables that
                                         can be used: \n  - `$PROJECTS_ROOT`: A path
                                         where projects sources are mounted as defined
-                                        by container component's sourceMapping \n
+                                        by container component's sourceMapping. \n
                                         \ - `$PROJECT_SOURCE`: A path to a project
                                         source ($PROJECTS_ROOT/<project-name>). If
                                         there are multiple projects, this will point
-                                        to the directory of the first one"
+                                        to the directory of the first one."
                                       type: string
                                   type: object
                                 id:
@@ -1227,7 +1227,7 @@ spec:
                                       type: array
                                     env:
                                       description: "Environment variables used in
-                                        this container \n The following variables
+                                        this container. \n The following variables
                                         are reserved and cannot be overridden via
                                         env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       items:
@@ -1710,10 +1710,10 @@ spec:
                                 description: "The actual command-line string \n Special
                                   variables that can be used: \n  - `$PROJECTS_ROOT`:
                                   A path where projects sources are mounted as defined
-                                  by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                  by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                   A path to a project source ($PROJECTS_ROOT/<project-name>).
                                   If there are multiple projects, this will point
-                                  to the directory of the first one"
+                                  to the directory of the first one."
                                 type: string
                               component:
                                 description: Describes component to which given action
@@ -1767,10 +1767,10 @@ spec:
                                   should be executed \n Special variables that can
                                   be used: \n  - `$PROJECTS_ROOT`: A path where projects
                                   sources are mounted as defined by container component's
-                                  sourceMapping \n  - `$PROJECT_SOURCE`: A path to
+                                  sourceMapping. \n  - `$PROJECT_SOURCE`: A path to
                                   a project source ($PROJECTS_ROOT/<project-name>).
                                   If there are multiple projects, this will point
-                                  to the directory of the first one"
+                                  to the directory of the first one."
                                 type: string
                             type: object
                           id:
@@ -2001,7 +2001,7 @@ spec:
                                   type: object
                                 type: array
                               env:
-                                description: "Environment variables used in this container
+                                description: "Environment variables used in this container.
                                   \n The following variables are reserved and cannot
                                   be overridden via env: \n  - `$PROJECTS_ROOT` \n
                                   \ - `$PROJECT_SOURCE`"
@@ -2391,10 +2391,10 @@ spec:
                                             \n Special variables that can be used:
                                             \n  - `$PROJECTS_ROOT`: A path where projects
                                             sources are mounted as defined by container
-                                            component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                            component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                             A path to a project source ($PROJECTS_ROOT/<project-name>).
                                             If there are multiple projects, this will
-                                            point to the directory of the first one"
+                                            point to the directory of the first one."
                                           type: string
                                         component:
                                           description: Describes component to which
@@ -2450,11 +2450,11 @@ spec:
                                             command should be executed \n Special
                                             variables that can be used: \n  - `$PROJECTS_ROOT`:
                                             A path where projects sources are mounted
-                                            as defined by container component's sourceMapping
+                                            as defined by container component's sourceMapping.
                                             \n  - `$PROJECT_SOURCE`: A path to a project
                                             source ($PROJECTS_ROOT/<project-name>).
                                             If there are multiple projects, this will
-                                            point to the directory of the first one"
+                                            point to the directory of the first one."
                                           type: string
                                       type: object
                                     id:
@@ -2701,7 +2701,7 @@ spec:
                                           type: array
                                         env:
                                           description: "Environment variables used
-                                            in this container \n The following variables
+                                            in this container. \n The following variables
                                             are reserved and cannot be overridden
                                             via env: \n  - `$PROJECTS_ROOT` \n  -
                                             `$PROJECT_SOURCE`"

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -234,10 +234,10 @@ spec:
                               description: "The actual command-line string \n Special
                                 variables that can be used: \n  - `$PROJECTS_ROOT`:
                                 A path where projects sources are mounted as defined
-                                by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                 A path to a project source ($PROJECTS_ROOT/<project-name>).
                                 If there are multiple projects, this will point to
-                                the directory of the first one"
+                                the directory of the first one."
                               type: string
                             component:
                               description: Describes component to which given action
@@ -291,11 +291,11 @@ spec:
                               description: "Working directory where the command should
                                 be executed \n Special variables that can be used:
                                 \n  - `$PROJECTS_ROOT`: A path where projects sources
-                                are mounted as defined by container component's sourceMapping
+                                are mounted as defined by container component's sourceMapping.
                                 \n  - `$PROJECT_SOURCE`: A path to a project source
                                 ($PROJECTS_ROOT/<project-name>). If there are multiple
                                 projects, this will point to the directory of the
-                                first one"
+                                first one."
                               type: string
                           required:
                           - commandLine
@@ -530,7 +530,7 @@ spec:
                                 type: object
                               type: array
                             env:
-                              description: "Environment variables used in this container
+                              description: "Environment variables used in this container.
                                 \n The following variables are reserved and cannot
                                 be overridden via env: \n  - `$PROJECTS_ROOT` \n  -
                                 `$PROJECT_SOURCE`"
@@ -941,10 +941,10 @@ spec:
                                           \n Special variables that can be used: \n
                                           \ - `$PROJECTS_ROOT`: A path where projects
                                           sources are mounted as defined by container
-                                          component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                          component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                           A path to a project source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one"
+                                          point to the directory of the first one."
                                         type: string
                                       component:
                                         description: Describes component to which
@@ -999,11 +999,11 @@ spec:
                                           command should be executed \n Special variables
                                           that can be used: \n  - `$PROJECTS_ROOT`:
                                           A path where projects sources are mounted
-                                          as defined by container component's sourceMapping
+                                          as defined by container component's sourceMapping.
                                           \n  - `$PROJECT_SOURCE`: A path to a project
                                           source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one"
+                                          point to the directory of the first one."
                                         type: string
                                     type: object
                                   id:
@@ -1245,7 +1245,7 @@ spec:
                                         type: array
                                       env:
                                         description: "Environment variables used in
-                                          this container \n The following variables
+                                          this container. \n The following variables
                                           are reserved and cannot be overridden via
                                           env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                         items:
@@ -1733,10 +1733,11 @@ spec:
                                   description: "The actual command-line string \n
                                     Special variables that can be used: \n  - `$PROJECTS_ROOT`:
                                     A path where projects sources are mounted as defined
-                                    by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
-                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                    If there are multiple projects, this will point
-                                    to the directory of the first one"
+                                    by container component's sourceMapping. \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -1790,10 +1791,10 @@ spec:
                                     should be executed \n Special variables that can
                                     be used: \n  - `$PROJECTS_ROOT`: A path where
                                     projects sources are mounted as defined by container
-                                    component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                    component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                     A path to a project source ($PROJECTS_ROOT/<project-name>).
                                     If there are multiple projects, this will point
-                                    to the directory of the first one"
+                                    to the directory of the first one."
                                   type: string
                               type: object
                             id:
@@ -2027,7 +2028,7 @@ spec:
                                   type: array
                                 env:
                                   description: "Environment variables used in this
-                                    container \n The following variables are reserved
+                                    container. \n The following variables are reserved
                                     and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
                                     \n  - `$PROJECT_SOURCE`"
                                   items:
@@ -2421,12 +2422,12 @@ spec:
                                               string \n Special variables that can
                                               be used: \n  - `$PROJECTS_ROOT`: A path
                                               where projects sources are mounted as
-                                              defined by container component's sourceMapping
+                                              defined by container component's sourceMapping.
                                               \n  - `$PROJECT_SOURCE`: A path to a
                                               project source ($PROJECTS_ROOT/<project-name>).
                                               If there are multiple projects, this
                                               will point to the directory of the first
-                                              one"
+                                              one."
                                             type: string
                                           component:
                                             description: Describes component to which
@@ -2483,11 +2484,11 @@ spec:
                                               variables that can be used: \n  - `$PROJECTS_ROOT`:
                                               A path where projects sources are mounted
                                               as defined by container component's
-                                              sourceMapping \n  - `$PROJECT_SOURCE`:
+                                              sourceMapping. \n  - `$PROJECT_SOURCE`:
                                               A path to a project source ($PROJECTS_ROOT/<project-name>).
                                               If there are multiple projects, this
                                               will point to the directory of the first
-                                              one"
+                                              one."
                                             type: string
                                         type: object
                                       id:
@@ -2738,10 +2739,10 @@ spec:
                                             type: array
                                           env:
                                             description: "Environment variables used
-                                              in this container \n The following variables
-                                              are reserved and cannot be overridden
-                                              via env: \n  - `$PROJECTS_ROOT` \n  -
-                                              `$PROJECT_SOURCE`"
+                                              in this container. \n The following
+                                              variables are reserved and cannot be
+                                              overridden via env: \n  - `$PROJECTS_ROOT`
+                                              \n  - `$PROJECT_SOURCE`"
                                             items:
                                               properties:
                                                 name:

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -233,10 +233,11 @@ spec:
                             commandLine:
                               description: "The actual command-line string \n Special
                                 variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                A path where projects sources are mounted as defined
+                                by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
                                 A path to a project source ($PROJECTS_ROOT/<project-name>).
                                 If there are multiple projects, this will point to
-                                the directory of the first one."
+                                the directory of the first one"
                               type: string
                             component:
                               description: Describes component to which given action
@@ -289,11 +290,12 @@ spec:
                             workingDir:
                               description: "Working directory where the command should
                                 be executed \n Special variables that can be used:
-                                \n  - `${PROJECTS_ROOT}`: A path where projects sources
-                                are mounted \n  - `${PROJECT_SOURCE}`: A path to a
-                                project source (${PROJECTS_ROOT}/<project-name>).
-                                If there are multiple projects, this will point to
-                                the directory of the first one."
+                                \n  - `$PROJECTS_ROOT`: A path where projects sources
+                                are mounted as defined by container component's sourceMapping
+                                \n  - `$PROJECT_SOURCE`: A path to a project source
+                                ($PROJECTS_ROOT/<project-name>). If there are multiple
+                                projects, this will point to the directory of the
+                                first one"
                               type: string
                           required:
                           - commandLine
@@ -528,7 +530,10 @@ spec:
                                 type: object
                               type: array
                             env:
-                              description: Environment variables used in this container
+                              description: "Environment variables used in this container
+                                \n The following variables are reserved and cannot
+                                be overridden via env: \n  - `$PROJECTS_ROOT` \n  -
+                                `$PROJECT_SOURCE`"
                               items:
                                 properties:
                                   name:
@@ -549,8 +554,8 @@ spec:
                             sourceMapping:
                               description: Optional specification of the path in the
                                 container where project sources should be transferred/mounted
-                                when `mountSources` is `true`. When omitted, the value
-                                of the `PROJECTS_ROOT` environment variable is used.
+                                when `mountSources` is `true`. When omitted, the default
+                                value of /projects is used.
                               type: string
                             volumeMounts:
                               description: List of volumes mounts that should be mounted
@@ -935,10 +940,11 @@ spec:
                                         description: "The actual command-line string
                                           \n Special variables that can be used: \n
                                           \ - `$PROJECTS_ROOT`: A path where projects
-                                          sources are mounted \n  - `$PROJECT_SOURCE`:
+                                          sources are mounted as defined by container
+                                          component's sourceMapping \n  - `$PROJECT_SOURCE`:
                                           A path to a project source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one."
+                                          point to the directory of the first one"
                                         type: string
                                       component:
                                         description: Describes component to which
@@ -991,12 +997,13 @@ spec:
                                       workingDir:
                                         description: "Working directory where the
                                           command should be executed \n Special variables
-                                          that can be used: \n  - `${PROJECTS_ROOT}`:
+                                          that can be used: \n  - `$PROJECTS_ROOT`:
                                           A path where projects sources are mounted
-                                          \n  - `${PROJECT_SOURCE}`: A path to a project
-                                          source (${PROJECTS_ROOT}/<project-name>).
+                                          as defined by container component's sourceMapping
+                                          \n  - `$PROJECT_SOURCE`: A path to a project
+                                          source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one."
+                                          point to the directory of the first one"
                                         type: string
                                     type: object
                                   id:
@@ -1237,8 +1244,10 @@ spec:
                                           type: object
                                         type: array
                                       env:
-                                        description: Environment variables used in
-                                          this container
+                                        description: "Environment variables used in
+                                          this container \n The following variables
+                                          are reserved and cannot be overridden via
+                                          env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                         items:
                                           properties:
                                             name:
@@ -1259,9 +1268,8 @@ spec:
                                         description: Optional specification of the
                                           path in the container where project sources
                                           should be transferred/mounted when `mountSources`
-                                          is `true`. When omitted, the value of the
-                                          `PROJECTS_ROOT` environment variable is
-                                          used.
+                                          is `true`. When omitted, the default value
+                                          of /projects is used.
                                         type: string
                                       volumeMounts:
                                         description: List of volumes mounts that should
@@ -1724,11 +1732,11 @@ spec:
                                 commandLine:
                                   description: "The actual command-line string \n
                                     Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                    A path where projects sources are mounted \n  -
-                                    `$PROJECT_SOURCE`: A path to a project source
-                                    ($PROJECTS_ROOT/<project-name>). If there are
-                                    multiple projects, this will point to the directory
-                                    of the first one."
+                                    A path where projects sources are mounted as defined
+                                    by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one"
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -1780,11 +1788,12 @@ spec:
                                 workingDir:
                                   description: "Working directory where the command
                                     should be executed \n Special variables that can
-                                    be used: \n  - `${PROJECTS_ROOT}`: A path where
-                                    projects sources are mounted \n  - `${PROJECT_SOURCE}`:
-                                    A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted as defined by container
+                                    component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
                                     If there are multiple projects, this will point
-                                    to the directory of the first one."
+                                    to the directory of the first one"
                                   type: string
                               type: object
                             id:
@@ -2017,8 +2026,10 @@ spec:
                                     type: object
                                   type: array
                                 env:
-                                  description: Environment variables used in this
-                                    container
+                                  description: "Environment variables used in this
+                                    container \n The following variables are reserved
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
                                   items:
                                     properties:
                                       name:
@@ -2039,8 +2050,8 @@ spec:
                                   description: Optional specification of the path
                                     in the container where project sources should
                                     be transferred/mounted when `mountSources` is
-                                    `true`. When omitted, the value of the `PROJECTS_ROOT`
-                                    environment variable is used.
+                                    `true`. When omitted, the default value of /projects
+                                    is used.
                                   type: string
                                 volumeMounts:
                                   description: List of volumes mounts that should
@@ -2409,12 +2420,13 @@ spec:
                                             description: "The actual command-line
                                               string \n Special variables that can
                                               be used: \n  - `$PROJECTS_ROOT`: A path
-                                              where projects sources are mounted \n
-                                              \ - `$PROJECT_SOURCE`: A path to a project
-                                              source ($PROJECTS_ROOT/<project-name>).
+                                              where projects sources are mounted as
+                                              defined by container component's sourceMapping
+                                              \n  - `$PROJECT_SOURCE`: A path to a
+                                              project source ($PROJECTS_ROOT/<project-name>).
                                               If there are multiple projects, this
                                               will point to the directory of the first
-                                              one."
+                                              one"
                                             type: string
                                           component:
                                             description: Describes component to which
@@ -2468,13 +2480,14 @@ spec:
                                           workingDir:
                                             description: "Working directory where
                                               the command should be executed \n Special
-                                              variables that can be used: \n  - `${PROJECTS_ROOT}`:
+                                              variables that can be used: \n  - `$PROJECTS_ROOT`:
                                               A path where projects sources are mounted
-                                              \n  - `${PROJECT_SOURCE}`: A path to
-                                              a project source (${PROJECTS_ROOT}/<project-name>).
+                                              as defined by container component's
+                                              sourceMapping \n  - `$PROJECT_SOURCE`:
+                                              A path to a project source ($PROJECTS_ROOT/<project-name>).
                                               If there are multiple projects, this
                                               will point to the directory of the first
-                                              one."
+                                              one"
                                             type: string
                                         type: object
                                       id:
@@ -2724,8 +2737,11 @@ spec:
                                               type: object
                                             type: array
                                           env:
-                                            description: Environment variables used
-                                              in this container
+                                            description: "Environment variables used
+                                              in this container \n The following variables
+                                              are reserved and cannot be overridden
+                                              via env: \n  - `$PROJECTS_ROOT` \n  -
+                                              `$PROJECT_SOURCE`"
                                             items:
                                               properties:
                                                 name:
@@ -2747,8 +2763,8 @@ spec:
                                               the path in the container where project
                                               sources should be transferred/mounted
                                               when `mountSources` is `true`. When
-                                              omitted, the value of the `PROJECTS_ROOT`
-                                              environment variable is used.
+                                              omitted, the default value of /projects
+                                              is used.
                                             type: string
                                           volumeMounts:
                                             description: List of volumes mounts that

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -207,12 +207,10 @@ spec:
                       commandLine:
                         description: "The actual command-line string \n Special variables
                           that can be used: \n  - `$PROJECTS_ROOT`: A path where projects
-                          sources are mounted. This variable is reserved and cannot
-                          be overridden via component container's env. \n  - `$PROJECT_SOURCE`:
-                          A path to a project source ($PROJECTS_ROOT/<project-name>).
-                          If there are multiple projects, this will point to the directory
-                          of the first one. This variable is reserved and cannot be
-                          overridden via component container's env."
+                          sources are mounted \n  - `$PROJECT_SOURCE`: A path to a
+                          project source ($PROJECTS_ROOT/<project-name>). If there
+                          are multiple projects, this will point to the directory
+                          of the first one"
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -261,14 +259,11 @@ spec:
                         type: string
                       workingDir:
                         description: "Working directory where the command should be
-                          executed \n Special variables that can be used: \n  - `${PROJECTS_ROOT}`:
-                          A path where projects sources are mounted. This variable
-                          is reserved and cannot be overridden via component container's
-                          env. \n  - `${PROJECT_SOURCE}`: A path to a project source
-                          (${PROJECTS_ROOT}/<project-name>). If there are multiple
-                          projects, this will point to the directory of the first
-                          one. This variable is reserved and cannot be overridden
-                          via component container's env."
+                          executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                          A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                          A path to a project source ($PROJECTS_ROOT/<project-name>).
+                          If there are multiple projects, this will point to the directory
+                          of the first one"
                         type: string
                     required:
                     - commandLine
@@ -490,7 +485,9 @@ spec:
                           type: object
                         type: array
                       env:
-                        description: Environment variables used in this container
+                        description: "Environment variables used in this container
+                          \n The following variables are reserved and cannot be overridden
+                          via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                         items:
                           properties:
                             name:
@@ -880,14 +877,11 @@ spec:
                                 commandLine:
                                   description: "The actual command-line string \n
                                     Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                    A path where projects sources are mounted. This
-                                    variable is reserved and cannot be overridden
-                                    via component container's env. \n  - `$PROJECT_SOURCE`:
-                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                    If there are multiple projects, this will point
-                                    to the directory of the first one. This variable
-                                    is reserved and cannot be overridden via component
-                                    container's env."
+                                    A path where projects sources are mounted \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one"
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -939,15 +933,11 @@ spec:
                                 workingDir:
                                   description: "Working directory where the command
                                     should be executed \n Special variables that can
-                                    be used: \n  - `${PROJECTS_ROOT}`: A path where
-                                    projects sources are mounted. This variable is
-                                    reserved and cannot be overridden via component
-                                    container's env. \n  - `${PROJECT_SOURCE}`: A
-                                    path to a project source (${PROJECTS_ROOT}/<project-name>).
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
                                     If there are multiple projects, this will point
-                                    to the directory of the first one. This variable
-                                    is reserved and cannot be overridden via component
-                                    container's env."
+                                    to the directory of the first one"
                                   type: string
                               type: object
                             id:
@@ -1177,8 +1167,10 @@ spec:
                                     type: object
                                   type: array
                                 env:
-                                  description: Environment variables used in this
-                                    container
+                                  description: "Environment variables used in this
+                                    container \n The following variables are reserved
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
                                   items:
                                     properties:
                                       name:
@@ -1637,13 +1629,10 @@ spec:
                           commandLine:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path where projects sources are mounted. This variable
-                              is reserved and cannot be overridden via component container's
-                              env. \n  - `$PROJECT_SOURCE`: A path to a project source
-                              ($PROJECTS_ROOT/<project-name>). If there are multiple
-                              projects, this will point to the directory of the first
-                              one. This variable is reserved and cannot be overridden
-                              via component container's env."
+                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one"
                             type: string
                           component:
                             description: Describes component to which given action
@@ -1691,13 +1680,11 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `${PROJECTS_ROOT}`: A path where projects sources
-                              are mounted. This variable is reserved and cannot be
-                              overridden via component container's env. \n  - `${PROJECT_SOURCE}`:
-                              A path to a project source (${PROJECTS_ROOT}/<project-name>).
-                              If there are multiple projects, this will point to the
-                              directory of the first one. This variable is reserved
-                              and cannot be overridden via component container's env."
+                              \ - `$PROJECTS_ROOT`: A path where projects sources
+                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
+                              source ($PROJECTS_ROOT/<project-name>). If there are
+                              multiple projects, this will point to the directory
+                              of the first one"
                             type: string
                         type: object
                       id:
@@ -1919,7 +1906,9 @@ spec:
                               type: object
                             type: array
                           env:
-                            description: Environment variables used in this container
+                            description: "Environment variables used in this container
+                              \n The following variables are reserved and cannot be
+                              overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             items:
                               properties:
                                 name:
@@ -2297,14 +2286,10 @@ spec:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
                                         \ - `$PROJECTS_ROOT`: A path where projects
-                                        sources are mounted. This variable is reserved
-                                        and cannot be overridden via component container's
-                                        env. \n  - `$PROJECT_SOURCE`: A path to a
-                                        project source ($PROJECTS_ROOT/<project-name>).
+                                        sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one. This
-                                        variable is reserved and cannot be overridden
-                                        via component container's env."
+                                        point to the directory of the first one"
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -2356,15 +2341,11 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `${PROJECTS_ROOT}`: A path
-                                        where projects sources are mounted. This variable
-                                        is reserved and cannot be overridden via component
-                                        container's env. \n  - `${PROJECT_SOURCE}`:
-                                        A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                                        can be used: \n  - `$PROJECTS_ROOT`: A path
+                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one. This
-                                        variable is reserved and cannot be overridden
-                                        via component container's env."
+                                        point to the directory of the first one"
                                       type: string
                                   type: object
                                 id:
@@ -2600,8 +2581,10 @@ spec:
                                         type: object
                                       type: array
                                     env:
-                                      description: Environment variables used in this
-                                        container
+                                      description: "Environment variables used in
+                                        this container \n The following variables
+                                        are reserved and cannot be overridden via
+                                        env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       items:
                                         properties:
                                           name:

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -206,11 +206,7 @@ spec:
                         type: object
                       commandLine:
                         description: "The actual command-line string \n Special variables
-                          that can be used: \n  - `$PROJECTS_ROOT`: A path where projects
-                          sources are mounted \n  - `$PROJECT_SOURCE`: A path to a
-                          project source ($PROJECTS_ROOT/<project-name>). If there
-                          are multiple projects, this will point to the directory
-                          of the first one"
+                          that can be used: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -259,11 +255,8 @@ spec:
                         type: string
                       workingDir:
                         description: "Working directory where the command should be
-                          executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                          A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                          A path to a project source ($PROJECTS_ROOT/<project-name>).
-                          If there are multiple projects, this will point to the directory
-                          of the first one"
+                          executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`
+                          \n  - `$PROJECT_SOURCE`"
                         type: string
                     required:
                     - commandLine
@@ -487,7 +480,11 @@ spec:
                       env:
                         description: "Environment variables used in this container
                           \n The following variables are reserved and cannot be overridden
-                          via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                          via env: \n  - `$PROJECTS_ROOT`: A path where projects sources
+                          are mounted as defined by sourceMapping \n  - `$PROJECT_SOURCE`:
+                          A path to a project source ($PROJECTS_ROOT/<project-name>).
+                          If there are multiple projects, this will point to the directory
+                          of the first one"
                         items:
                           properties:
                             name:
@@ -508,8 +505,8 @@ spec:
                       sourceMapping:
                         description: Optional specification of the path in the container
                           where project sources should be transferred/mounted when
-                          `mountSources` is `true`. When omitted, the value of the
-                          `PROJECTS_ROOT` environment variable is used.
+                          `mountSources` is `true`. When omitted, the default value
+                          of /projects is used.
                         type: string
                       volumeMounts:
                         description: List of volumes mounts that should be mounted
@@ -876,12 +873,8 @@ spec:
                                   type: object
                                 commandLine:
                                   description: "The actual command-line string \n
-                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                    A path where projects sources are mounted \n  -
-                                    `$PROJECT_SOURCE`: A path to a project source
-                                    ($PROJECTS_ROOT/<project-name>). If there are
-                                    multiple projects, this will point to the directory
-                                    of the first one"
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -933,11 +926,7 @@ spec:
                                 workingDir:
                                   description: "Working directory where the command
                                     should be executed \n Special variables that can
-                                    be used: \n  - `$PROJECTS_ROOT`: A path where
-                                    projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                    If there are multiple projects, this will point
-                                    to the directory of the first one"
+                                    be used: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                   type: string
                               type: object
                             id:
@@ -1169,8 +1158,12 @@ spec:
                                 env:
                                   description: "Environment variables used in this
                                     container \n The following variables are reserved
-                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
-                                    \n  - `$PROJECT_SOURCE`"
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`:
+                                    A path where projects sources are mounted as defined
+                                    by sourceMapping \n  - `$PROJECT_SOURCE`: A path
+                                    to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one"
                                   items:
                                     properties:
                                       name:
@@ -1191,8 +1184,8 @@ spec:
                                   description: Optional specification of the path
                                     in the container where project sources should
                                     be transferred/mounted when `mountSources` is
-                                    `true`. When omitted, the value of the `PROJECTS_ROOT`
-                                    environment variable is used.
+                                    `true`. When omitted, the default value of /projects
+                                    is used.
                                   type: string
                                 volumeMounts:
                                   description: List of volumes mounts that should
@@ -1628,11 +1621,8 @@ spec:
                             type: object
                           commandLine:
                             description: "The actual command-line string \n Special
-                              variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                              A path to a project source ($PROJECTS_ROOT/<project-name>).
-                              If there are multiple projects, this will point to the
-                              directory of the first one"
+                              variables that can be used: \n  - `$PROJECTS_ROOT` \n
+                              \ - `$PROJECT_SOURCE`"
                             type: string
                           component:
                             description: Describes component to which given action
@@ -1680,11 +1670,7 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT`: A path where projects sources
-                              are mounted \n  - `$PROJECT_SOURCE`: A path to a project
-                              source ($PROJECTS_ROOT/<project-name>). If there are
-                              multiple projects, this will point to the directory
-                              of the first one"
+                              \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             type: string
                         type: object
                       id:
@@ -1908,7 +1894,12 @@ spec:
                           env:
                             description: "Environment variables used in this container
                               \n The following variables are reserved and cannot be
-                              overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                              overridden via env: \n  - `$PROJECTS_ROOT`: A path where
+                              projects sources are mounted as defined by sourceMapping
+                              \n  - `$PROJECT_SOURCE`: A path to a project source
+                              ($PROJECTS_ROOT/<project-name>). If there are multiple
+                              projects, this will point to the directory of the first
+                              one"
                             items:
                               properties:
                                 name:
@@ -1928,8 +1919,8 @@ spec:
                           sourceMapping:
                             description: Optional specification of the path in the
                               container where project sources should be transferred/mounted
-                              when `mountSources` is `true`. When omitted, the value
-                              of the `PROJECTS_ROOT` environment variable is used.
+                              when `mountSources` is `true`. When omitted, the default
+                              value of /projects is used.
                             type: string
                           volumeMounts:
                             description: List of volumes mounts that should be mounted
@@ -2285,11 +2276,7 @@ spec:
                                     commandLine:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
-                                        \ - `$PROJECTS_ROOT`: A path where projects
-                                        sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                        If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -2341,11 +2328,8 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `$PROJECTS_ROOT`: A path
-                                        where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                        If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        can be used: \n  - `$PROJECTS_ROOT` \n  -
+                                        `$PROJECT_SOURCE`"
                                       type: string
                                   type: object
                                 id:
@@ -2584,7 +2568,12 @@ spec:
                                       description: "Environment variables used in
                                         this container \n The following variables
                                         are reserved and cannot be overridden via
-                                        env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                        env: \n  - `$PROJECTS_ROOT`: A path where
+                                        projects sources are mounted as defined by
+                                        sourceMapping \n  - `$PROJECT_SOURCE`: A path
+                                        to a project source ($PROJECTS_ROOT/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one"
                                       items:
                                         properties:
                                           name:
@@ -2605,8 +2594,8 @@ spec:
                                       description: Optional specification of the path
                                         in the container where project sources should
                                         be transferred/mounted when `mountSources`
-                                        is `true`. When omitted, the value of the
-                                        `PROJECTS_ROOT` environment variable is used.
+                                        is `true`. When omitted, the default value
+                                        of /projects is used.
                                       type: string
                                     volumeMounts:
                                       description: List of volumes mounts that should

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -208,10 +208,10 @@ spec:
                         description: "The actual command-line string \n Special variables
                           that can be used: \n  - `$PROJECTS_ROOT`: A path where projects
                           sources are mounted as defined by container component's
-                          sourceMapping \n  - `$PROJECT_SOURCE`: A path to a project
+                          sourceMapping. \n  - `$PROJECT_SOURCE`: A path to a project
                           source ($PROJECTS_ROOT/<project-name>). If there are multiple
                           projects, this will point to the directory of the first
-                          one"
+                          one."
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -262,10 +262,10 @@ spec:
                         description: "Working directory where the command should be
                           executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`:
                           A path where projects sources are mounted as defined by
-                          container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                          container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                           A path to a project source ($PROJECTS_ROOT/<project-name>).
                           If there are multiple projects, this will point to the directory
-                          of the first one"
+                          of the first one."
                         type: string
                     required:
                     - commandLine
@@ -487,7 +487,7 @@ spec:
                           type: object
                         type: array
                       env:
-                        description: "Environment variables used in this container
+                        description: "Environment variables used in this container.
                           \n The following variables are reserved and cannot be overridden
                           via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                         items:
@@ -880,10 +880,11 @@ spec:
                                   description: "The actual command-line string \n
                                     Special variables that can be used: \n  - `$PROJECTS_ROOT`:
                                     A path where projects sources are mounted as defined
-                                    by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
-                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
-                                    If there are multiple projects, this will point
-                                    to the directory of the first one"
+                                    by container component's sourceMapping. \n  -
+                                    `$PROJECT_SOURCE`: A path to a project source
+                                    ($PROJECTS_ROOT/<project-name>). If there are
+                                    multiple projects, this will point to the directory
+                                    of the first one."
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -937,10 +938,10 @@ spec:
                                     should be executed \n Special variables that can
                                     be used: \n  - `$PROJECTS_ROOT`: A path where
                                     projects sources are mounted as defined by container
-                                    component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                    component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                     A path to a project source ($PROJECTS_ROOT/<project-name>).
                                     If there are multiple projects, this will point
-                                    to the directory of the first one"
+                                    to the directory of the first one."
                                   type: string
                               type: object
                             id:
@@ -1171,7 +1172,7 @@ spec:
                                   type: array
                                 env:
                                   description: "Environment variables used in this
-                                    container \n The following variables are reserved
+                                    container. \n The following variables are reserved
                                     and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
                                     \n  - `$PROJECT_SOURCE`"
                                   items:
@@ -1633,10 +1634,10 @@ spec:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
                               A path where projects sources are mounted as defined
-                              by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                              by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                               A path to a project source ($PROJECTS_ROOT/<project-name>).
                               If there are multiple projects, this will point to the
-                              directory of the first one"
+                              directory of the first one."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -1685,11 +1686,11 @@ spec:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
                               \ - `$PROJECTS_ROOT`: A path where projects sources
-                              are mounted as defined by container component's sourceMapping
+                              are mounted as defined by container component's sourceMapping.
                               \n  - `$PROJECT_SOURCE`: A path to a project source
                               ($PROJECTS_ROOT/<project-name>). If there are multiple
                               projects, this will point to the directory of the first
-                              one"
+                              one."
                             type: string
                         type: object
                       id:
@@ -1911,7 +1912,7 @@ spec:
                               type: object
                             type: array
                           env:
-                            description: "Environment variables used in this container
+                            description: "Environment variables used in this container.
                               \n The following variables are reserved and cannot be
                               overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             items:
@@ -2292,10 +2293,10 @@ spec:
                                         \n Special variables that can be used: \n
                                         \ - `$PROJECTS_ROOT`: A path where projects
                                         sources are mounted as defined by container
-                                        component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                        component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                         A path to a project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        point to the directory of the first one."
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -2349,11 +2350,11 @@ spec:
                                         should be executed \n Special variables that
                                         can be used: \n  - `$PROJECTS_ROOT`: A path
                                         where projects sources are mounted as defined
-                                        by container component's sourceMapping \n
+                                        by container component's sourceMapping. \n
                                         \ - `$PROJECT_SOURCE`: A path to a project
                                         source ($PROJECTS_ROOT/<project-name>). If
                                         there are multiple projects, this will point
-                                        to the directory of the first one"
+                                        to the directory of the first one."
                                       type: string
                                   type: object
                                 id:
@@ -2590,7 +2591,7 @@ spec:
                                       type: array
                                     env:
                                       description: "Environment variables used in
-                                        this container \n The following variables
+                                        this container. \n The following variables
                                         are reserved and cannot be overridden via
                                         env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       items:

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -206,7 +206,12 @@ spec:
                         type: object
                       commandLine:
                         description: "The actual command-line string \n Special variables
-                          that can be used: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                          that can be used: \n  - `$PROJECTS_ROOT`: A path where projects
+                          sources are mounted as defined by container component's
+                          sourceMapping \n  - `$PROJECT_SOURCE`: A path to a project
+                          source ($PROJECTS_ROOT/<project-name>). If there are multiple
+                          projects, this will point to the directory of the first
+                          one"
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -255,8 +260,12 @@ spec:
                         type: string
                       workingDir:
                         description: "Working directory where the command should be
-                          executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`
-                          \n  - `$PROJECT_SOURCE`"
+                          executed \n Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                          A path where projects sources are mounted as defined by
+                          container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                          A path to a project source ($PROJECTS_ROOT/<project-name>).
+                          If there are multiple projects, this will point to the directory
+                          of the first one"
                         type: string
                     required:
                     - commandLine
@@ -480,11 +489,7 @@ spec:
                       env:
                         description: "Environment variables used in this container
                           \n The following variables are reserved and cannot be overridden
-                          via env: \n  - `$PROJECTS_ROOT`: A path where projects sources
-                          are mounted as defined by sourceMapping \n  - `$PROJECT_SOURCE`:
-                          A path to a project source ($PROJECTS_ROOT/<project-name>).
-                          If there are multiple projects, this will point to the directory
-                          of the first one"
+                          via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                         items:
                           properties:
                             name:
@@ -873,8 +878,12 @@ spec:
                                   type: object
                                 commandLine:
                                   description: "The actual command-line string \n
-                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`
-                                    \n  - `$PROJECT_SOURCE`"
+                                    Special variables that can be used: \n  - `$PROJECTS_ROOT`:
+                                    A path where projects sources are mounted as defined
+                                    by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one"
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -926,7 +935,12 @@ spec:
                                 workingDir:
                                   description: "Working directory where the command
                                     should be executed \n Special variables that can
-                                    be used: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                    be used: \n  - `$PROJECTS_ROOT`: A path where
+                                    projects sources are mounted as defined by container
+                                    component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one"
                                   type: string
                               type: object
                             id:
@@ -1158,12 +1172,8 @@ spec:
                                 env:
                                   description: "Environment variables used in this
                                     container \n The following variables are reserved
-                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`:
-                                    A path where projects sources are mounted as defined
-                                    by sourceMapping \n  - `$PROJECT_SOURCE`: A path
-                                    to a project source ($PROJECTS_ROOT/<project-name>).
-                                    If there are multiple projects, this will point
-                                    to the directory of the first one"
+                                    and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                    \n  - `$PROJECT_SOURCE`"
                                   items:
                                     properties:
                                       name:
@@ -1621,8 +1631,12 @@ spec:
                             type: object
                           commandLine:
                             description: "The actual command-line string \n Special
-                              variables that can be used: \n  - `$PROJECTS_ROOT` \n
-                              \ - `$PROJECT_SOURCE`"
+                              variables that can be used: \n  - `$PROJECTS_ROOT`:
+                              A path where projects sources are mounted as defined
+                              by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                              A path to a project source ($PROJECTS_ROOT/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one"
                             type: string
                           component:
                             description: Describes component to which given action
@@ -1670,7 +1684,12 @@ spec:
                           workingDir:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
-                              \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                              \ - `$PROJECTS_ROOT`: A path where projects sources
+                              are mounted as defined by container component's sourceMapping
+                              \n  - `$PROJECT_SOURCE`: A path to a project source
+                              ($PROJECTS_ROOT/<project-name>). If there are multiple
+                              projects, this will point to the directory of the first
+                              one"
                             type: string
                         type: object
                       id:
@@ -1894,12 +1913,7 @@ spec:
                           env:
                             description: "Environment variables used in this container
                               \n The following variables are reserved and cannot be
-                              overridden via env: \n  - `$PROJECTS_ROOT`: A path where
-                              projects sources are mounted as defined by sourceMapping
-                              \n  - `$PROJECT_SOURCE`: A path to a project source
-                              ($PROJECTS_ROOT/<project-name>). If there are multiple
-                              projects, this will point to the directory of the first
-                              one"
+                              overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                             items:
                               properties:
                                 name:
@@ -2276,7 +2290,12 @@ spec:
                                     commandLine:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
-                                        \ - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
+                                        \ - `$PROJECTS_ROOT`: A path where projects
+                                        sources are mounted as defined by container
+                                        component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        If there are multiple projects, this will
+                                        point to the directory of the first one"
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -2328,8 +2347,13 @@ spec:
                                     workingDir:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
-                                        can be used: \n  - `$PROJECTS_ROOT` \n  -
-                                        `$PROJECT_SOURCE`"
+                                        can be used: \n  - `$PROJECTS_ROOT`: A path
+                                        where projects sources are mounted as defined
+                                        by container component's sourceMapping \n
+                                        \ - `$PROJECT_SOURCE`: A path to a project
+                                        source ($PROJECTS_ROOT/<project-name>). If
+                                        there are multiple projects, this will point
+                                        to the directory of the first one"
                                       type: string
                                   type: object
                                 id:
@@ -2568,12 +2592,7 @@ spec:
                                       description: "Environment variables used in
                                         this container \n The following variables
                                         are reserved and cannot be overridden via
-                                        env: \n  - `$PROJECTS_ROOT`: A path where
-                                        projects sources are mounted as defined by
-                                        sourceMapping \n  - `$PROJECT_SOURCE`: A path
-                                        to a project source ($PROJECTS_ROOT/<project-name>).
-                                        If there are multiple projects, this will
-                                        point to the directory of the first one"
+                                        env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                       items:
                                         properties:
                                           name:

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -207,10 +207,12 @@ spec:
                       commandLine:
                         description: "The actual command-line string \n Special variables
                           that can be used: \n  - `$PROJECTS_ROOT`: A path where projects
-                          sources are mounted \n  - `$PROJECT_SOURCE`: A path to a
-                          project source ($PROJECTS_ROOT/<project-name>). If there
-                          are multiple projects, this will point to the directory
-                          of the first one."
+                          sources are mounted. This variable is reserved and cannot
+                          be overridden via component container's env. \n  - `$PROJECT_SOURCE`:
+                          A path to a project source ($PROJECTS_ROOT/<project-name>).
+                          If there are multiple projects, this will point to the directory
+                          of the first one. This variable is reserved and cannot be
+                          overridden via component container's env."
                         type: string
                       component:
                         description: Describes component to which given action relates
@@ -260,10 +262,13 @@ spec:
                       workingDir:
                         description: "Working directory where the command should be
                           executed \n Special variables that can be used: \n  - `${PROJECTS_ROOT}`:
-                          A path where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
-                          A path to a project source (${PROJECTS_ROOT}/<project-name>).
-                          If there are multiple projects, this will point to the directory
-                          of the first one."
+                          A path where projects sources are mounted. This variable
+                          is reserved and cannot be overridden via component container's
+                          env. \n  - `${PROJECT_SOURCE}`: A path to a project source
+                          (${PROJECTS_ROOT}/<project-name>). If there are multiple
+                          projects, this will point to the directory of the first
+                          one. This variable is reserved and cannot be overridden
+                          via component container's env."
                         type: string
                     required:
                     - commandLine
@@ -875,11 +880,14 @@ spec:
                                 commandLine:
                                   description: "The actual command-line string \n
                                     Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                    A path where projects sources are mounted \n  -
-                                    `$PROJECT_SOURCE`: A path to a project source
-                                    ($PROJECTS_ROOT/<project-name>). If there are
-                                    multiple projects, this will point to the directory
-                                    of the first one."
+                                    A path where projects sources are mounted. This
+                                    variable is reserved and cannot be overridden
+                                    via component container's env. \n  - `$PROJECT_SOURCE`:
+                                    A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                    If there are multiple projects, this will point
+                                    to the directory of the first one. This variable
+                                    is reserved and cannot be overridden via component
+                                    container's env."
                                   type: string
                                 component:
                                   description: Describes component to which given
@@ -932,10 +940,14 @@ spec:
                                   description: "Working directory where the command
                                     should be executed \n Special variables that can
                                     be used: \n  - `${PROJECTS_ROOT}`: A path where
-                                    projects sources are mounted \n  - `${PROJECT_SOURCE}`:
-                                    A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                                    projects sources are mounted. This variable is
+                                    reserved and cannot be overridden via component
+                                    container's env. \n  - `${PROJECT_SOURCE}`: A
+                                    path to a project source (${PROJECTS_ROOT}/<project-name>).
                                     If there are multiple projects, this will point
-                                    to the directory of the first one."
+                                    to the directory of the first one. This variable
+                                    is reserved and cannot be overridden via component
+                                    container's env."
                                   type: string
                               type: object
                             id:
@@ -1625,10 +1637,13 @@ spec:
                           commandLine:
                             description: "The actual command-line string \n Special
                               variables that can be used: \n  - `$PROJECTS_ROOT`:
-                              A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
-                              A path to a project source ($PROJECTS_ROOT/<project-name>).
-                              If there are multiple projects, this will point to the
-                              directory of the first one."
+                              A path where projects sources are mounted. This variable
+                              is reserved and cannot be overridden via component container's
+                              env. \n  - `$PROJECT_SOURCE`: A path to a project source
+                              ($PROJECTS_ROOT/<project-name>). If there are multiple
+                              projects, this will point to the directory of the first
+                              one. This variable is reserved and cannot be overridden
+                              via component container's env."
                             type: string
                           component:
                             description: Describes component to which given action
@@ -1677,10 +1692,12 @@ spec:
                             description: "Working directory where the command should
                               be executed \n Special variables that can be used: \n
                               \ - `${PROJECTS_ROOT}`: A path where projects sources
-                              are mounted \n  - `${PROJECT_SOURCE}`: A path to a project
-                              source (${PROJECTS_ROOT}/<project-name>). If there are
-                              multiple projects, this will point to the directory
-                              of the first one."
+                              are mounted. This variable is reserved and cannot be
+                              overridden via component container's env. \n  - `${PROJECT_SOURCE}`:
+                              A path to a project source (${PROJECTS_ROOT}/<project-name>).
+                              If there are multiple projects, this will point to the
+                              directory of the first one. This variable is reserved
+                              and cannot be overridden via component container's env."
                             type: string
                         type: object
                       id:
@@ -2280,10 +2297,14 @@ spec:
                                       description: "The actual command-line string
                                         \n Special variables that can be used: \n
                                         \ - `$PROJECTS_ROOT`: A path where projects
-                                        sources are mounted \n  - `$PROJECT_SOURCE`:
-                                        A path to a project source ($PROJECTS_ROOT/<project-name>).
+                                        sources are mounted. This variable is reserved
+                                        and cannot be overridden via component container's
+                                        env. \n  - `$PROJECT_SOURCE`: A path to a
+                                        project source ($PROJECTS_ROOT/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one."
+                                        point to the directory of the first one. This
+                                        variable is reserved and cannot be overridden
+                                        via component container's env."
                                       type: string
                                     component:
                                       description: Describes component to which given
@@ -2336,10 +2357,14 @@ spec:
                                       description: "Working directory where the command
                                         should be executed \n Special variables that
                                         can be used: \n  - `${PROJECTS_ROOT}`: A path
-                                        where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
+                                        where projects sources are mounted. This variable
+                                        is reserved and cannot be overridden via component
+                                        container's env. \n  - `${PROJECT_SOURCE}`:
                                         A path to a project source (${PROJECTS_ROOT}/<project-name>).
                                         If there are multiple projects, this will
-                                        point to the directory of the first one."
+                                        point to the directory of the first one. This
+                                        variable is reserved and cannot be overridden
+                                        via component container's env."
                                       type: string
                                   type: object
                                 id:

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -208,10 +208,11 @@ spec:
                         commandLine:
                           description: "The actual command-line string \n Special
                             variables that can be used: \n  - `$PROJECTS_ROOT`: A
-                            path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                            path where projects sources are mounted as defined by
+                            container component's sourceMapping \n  - `$PROJECT_SOURCE`:
                             A path to a project source ($PROJECTS_ROOT/<project-name>).
                             If there are multiple projects, this will point to the
-                            directory of the first one."
+                            directory of the first one"
                           type: string
                         component:
                           description: Describes component to which given action relates
@@ -261,11 +262,11 @@ spec:
                         workingDir:
                           description: "Working directory where the command should
                             be executed \n Special variables that can be used: \n
-                            \ - `${PROJECTS_ROOT}`: A path where projects sources
-                            are mounted \n  - `${PROJECT_SOURCE}`: A path to a project
-                            source (${PROJECTS_ROOT}/<project-name>). If there are
-                            multiple projects, this will point to the directory of
-                            the first one."
+                            \ - `$PROJECTS_ROOT`: A path where projects sources are
+                            mounted as defined by container component's sourceMapping
+                            \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
+                            If there are multiple projects, this will point to the
+                            directory of the first one"
                           type: string
                       required:
                       - commandLine
@@ -490,7 +491,9 @@ spec:
                             type: object
                           type: array
                         env:
-                          description: Environment variables used in this container
+                          description: "Environment variables used in this container
+                            \n The following variables are reserved and cannot be
+                            overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                           items:
                             properties:
                               name:
@@ -511,8 +514,8 @@ spec:
                         sourceMapping:
                           description: Optional specification of the path in the container
                             where project sources should be transferred/mounted when
-                            `mountSources` is `true`. When omitted, the value of the
-                            `PROJECTS_ROOT` environment variable is used.
+                            `mountSources` is `true`. When omitted, the default value
+                            of /projects is used.
                           type: string
                         volumeMounts:
                           description: List of volumes mounts that should be mounted
@@ -886,11 +889,12 @@ spec:
                                   commandLine:
                                     description: "The actual command-line string \n
                                       Special variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                      A path where projects sources are mounted \n
-                                      \ - `$PROJECT_SOURCE`: A path to a project source
-                                      ($PROJECTS_ROOT/<project-name>). If there are
-                                      multiple projects, this will point to the directory
-                                      of the first one."
+                                      A path where projects sources are mounted as
+                                      defined by container component's sourceMapping
+                                      \n  - `$PROJECT_SOURCE`: A path to a project
+                                      source ($PROJECTS_ROOT/<project-name>). If there
+                                      are multiple projects, this will point to the
+                                      directory of the first one"
                                     type: string
                                   component:
                                     description: Describes component to which given
@@ -942,11 +946,13 @@ spec:
                                   workingDir:
                                     description: "Working directory where the command
                                       should be executed \n Special variables that
-                                      can be used: \n  - `${PROJECTS_ROOT}`: A path
-                                      where projects sources are mounted \n  - `${PROJECT_SOURCE}`:
-                                      A path to a project source (${PROJECTS_ROOT}/<project-name>).
-                                      If there are multiple projects, this will point
-                                      to the directory of the first one."
+                                      can be used: \n  - `$PROJECTS_ROOT`: A path
+                                      where projects sources are mounted as defined
+                                      by container component's sourceMapping \n  -
+                                      `$PROJECT_SOURCE`: A path to a project source
+                                      ($PROJECTS_ROOT/<project-name>). If there are
+                                      multiple projects, this will point to the directory
+                                      of the first one"
                                     type: string
                                 type: object
                               id:
@@ -1179,8 +1185,10 @@ spec:
                                       type: object
                                     type: array
                                   env:
-                                    description: Environment variables used in this
-                                      container
+                                    description: "Environment variables used in this
+                                      container \n The following variables are reserved
+                                      and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
+                                      \n  - `$PROJECT_SOURCE`"
                                     items:
                                       properties:
                                         name:
@@ -1201,8 +1209,8 @@ spec:
                                     description: Optional specification of the path
                                       in the container where project sources should
                                       be transferred/mounted when `mountSources` is
-                                      `true`. When omitted, the value of the `PROJECTS_ROOT`
-                                      environment variable is used.
+                                      `true`. When omitted, the default value of /projects
+                                      is used.
                                     type: string
                                   volumeMounts:
                                     description: List of volumes mounts that should
@@ -1647,10 +1655,11 @@ spec:
                             commandLine:
                               description: "The actual command-line string \n Special
                                 variables that can be used: \n  - `$PROJECTS_ROOT`:
-                                A path where projects sources are mounted \n  - `$PROJECT_SOURCE`:
+                                A path where projects sources are mounted as defined
+                                by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
                                 A path to a project source ($PROJECTS_ROOT/<project-name>).
                                 If there are multiple projects, this will point to
-                                the directory of the first one."
+                                the directory of the first one"
                               type: string
                             component:
                               description: Describes component to which given action
@@ -1700,11 +1709,12 @@ spec:
                             workingDir:
                               description: "Working directory where the command should
                                 be executed \n Special variables that can be used:
-                                \n  - `${PROJECTS_ROOT}`: A path where projects sources
-                                are mounted \n  - `${PROJECT_SOURCE}`: A path to a
-                                project source (${PROJECTS_ROOT}/<project-name>).
-                                If there are multiple projects, this will point to
-                                the directory of the first one."
+                                \n  - `$PROJECTS_ROOT`: A path where projects sources
+                                are mounted as defined by container component's sourceMapping
+                                \n  - `$PROJECT_SOURCE`: A path to a project source
+                                ($PROJECTS_ROOT/<project-name>). If there are multiple
+                                projects, this will point to the directory of the
+                                first one"
                               type: string
                           type: object
                         id:
@@ -1930,7 +1940,10 @@ spec:
                                 type: object
                               type: array
                             env:
-                              description: Environment variables used in this container
+                              description: "Environment variables used in this container
+                                \n The following variables are reserved and cannot
+                                be overridden via env: \n  - `$PROJECTS_ROOT` \n  -
+                                `$PROJECT_SOURCE`"
                               items:
                                 properties:
                                   name:
@@ -1950,8 +1963,8 @@ spec:
                             sourceMapping:
                               description: Optional specification of the path in the
                                 container where project sources should be transferred/mounted
-                                when `mountSources` is `true`. When omitted, the value
-                                of the `PROJECTS_ROOT` environment variable is used.
+                                when `mountSources` is `true`. When omitted, the default
+                                value of /projects is used.
                               type: string
                             volumeMounts:
                               description: List of volumes mounts that should be mounted
@@ -2311,10 +2324,11 @@ spec:
                                         description: "The actual command-line string
                                           \n Special variables that can be used: \n
                                           \ - `$PROJECTS_ROOT`: A path where projects
-                                          sources are mounted \n  - `$PROJECT_SOURCE`:
+                                          sources are mounted as defined by container
+                                          component's sourceMapping \n  - `$PROJECT_SOURCE`:
                                           A path to a project source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one."
+                                          point to the directory of the first one"
                                         type: string
                                       component:
                                         description: Describes component to which
@@ -2367,12 +2381,13 @@ spec:
                                       workingDir:
                                         description: "Working directory where the
                                           command should be executed \n Special variables
-                                          that can be used: \n  - `${PROJECTS_ROOT}`:
+                                          that can be used: \n  - `$PROJECTS_ROOT`:
                                           A path where projects sources are mounted
-                                          \n  - `${PROJECT_SOURCE}`: A path to a project
-                                          source (${PROJECTS_ROOT}/<project-name>).
+                                          as defined by container component's sourceMapping
+                                          \n  - `$PROJECT_SOURCE`: A path to a project
+                                          source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one."
+                                          point to the directory of the first one"
                                         type: string
                                     type: object
                                   id:
@@ -2613,8 +2628,10 @@ spec:
                                           type: object
                                         type: array
                                       env:
-                                        description: Environment variables used in
-                                          this container
+                                        description: "Environment variables used in
+                                          this container \n The following variables
+                                          are reserved and cannot be overridden via
+                                          env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                         items:
                                           properties:
                                             name:
@@ -2635,9 +2652,8 @@ spec:
                                         description: Optional specification of the
                                           path in the container where project sources
                                           should be transferred/mounted when `mountSources`
-                                          is `true`. When omitted, the value of the
-                                          `PROJECTS_ROOT` environment variable is
-                                          used.
+                                          is `true`. When omitted, the default value
+                                          of /projects is used.
                                         type: string
                                       volumeMounts:
                                         description: List of volumes mounts that should

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -209,10 +209,10 @@ spec:
                           description: "The actual command-line string \n Special
                             variables that can be used: \n  - `$PROJECTS_ROOT`: A
                             path where projects sources are mounted as defined by
-                            container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                            container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                             A path to a project source ($PROJECTS_ROOT/<project-name>).
                             If there are multiple projects, this will point to the
-                            directory of the first one"
+                            directory of the first one."
                           type: string
                         component:
                           description: Describes component to which given action relates
@@ -263,10 +263,10 @@ spec:
                           description: "Working directory where the command should
                             be executed \n Special variables that can be used: \n
                             \ - `$PROJECTS_ROOT`: A path where projects sources are
-                            mounted as defined by container component's sourceMapping
+                            mounted as defined by container component's sourceMapping.
                             \n  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>).
                             If there are multiple projects, this will point to the
-                            directory of the first one"
+                            directory of the first one."
                           type: string
                       required:
                       - commandLine
@@ -491,7 +491,7 @@ spec:
                             type: object
                           type: array
                         env:
-                          description: "Environment variables used in this container
+                          description: "Environment variables used in this container.
                             \n The following variables are reserved and cannot be
                             overridden via env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                           items:
@@ -890,11 +890,11 @@ spec:
                                     description: "The actual command-line string \n
                                       Special variables that can be used: \n  - `$PROJECTS_ROOT`:
                                       A path where projects sources are mounted as
-                                      defined by container component's sourceMapping
+                                      defined by container component's sourceMapping.
                                       \n  - `$PROJECT_SOURCE`: A path to a project
                                       source ($PROJECTS_ROOT/<project-name>). If there
                                       are multiple projects, this will point to the
-                                      directory of the first one"
+                                      directory of the first one."
                                     type: string
                                   component:
                                     description: Describes component to which given
@@ -948,11 +948,11 @@ spec:
                                       should be executed \n Special variables that
                                       can be used: \n  - `$PROJECTS_ROOT`: A path
                                       where projects sources are mounted as defined
-                                      by container component's sourceMapping \n  -
+                                      by container component's sourceMapping. \n  -
                                       `$PROJECT_SOURCE`: A path to a project source
                                       ($PROJECTS_ROOT/<project-name>). If there are
                                       multiple projects, this will point to the directory
-                                      of the first one"
+                                      of the first one."
                                     type: string
                                 type: object
                               id:
@@ -1186,7 +1186,7 @@ spec:
                                     type: array
                                   env:
                                     description: "Environment variables used in this
-                                      container \n The following variables are reserved
+                                      container. \n The following variables are reserved
                                       and cannot be overridden via env: \n  - `$PROJECTS_ROOT`
                                       \n  - `$PROJECT_SOURCE`"
                                     items:
@@ -1656,10 +1656,10 @@ spec:
                               description: "The actual command-line string \n Special
                                 variables that can be used: \n  - `$PROJECTS_ROOT`:
                                 A path where projects sources are mounted as defined
-                                by container component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                by container component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                 A path to a project source ($PROJECTS_ROOT/<project-name>).
                                 If there are multiple projects, this will point to
-                                the directory of the first one"
+                                the directory of the first one."
                               type: string
                             component:
                               description: Describes component to which given action
@@ -1710,11 +1710,11 @@ spec:
                               description: "Working directory where the command should
                                 be executed \n Special variables that can be used:
                                 \n  - `$PROJECTS_ROOT`: A path where projects sources
-                                are mounted as defined by container component's sourceMapping
+                                are mounted as defined by container component's sourceMapping.
                                 \n  - `$PROJECT_SOURCE`: A path to a project source
                                 ($PROJECTS_ROOT/<project-name>). If there are multiple
                                 projects, this will point to the directory of the
-                                first one"
+                                first one."
                               type: string
                           type: object
                         id:
@@ -1940,7 +1940,7 @@ spec:
                                 type: object
                               type: array
                             env:
-                              description: "Environment variables used in this container
+                              description: "Environment variables used in this container.
                                 \n The following variables are reserved and cannot
                                 be overridden via env: \n  - `$PROJECTS_ROOT` \n  -
                                 `$PROJECT_SOURCE`"
@@ -2325,10 +2325,10 @@ spec:
                                           \n Special variables that can be used: \n
                                           \ - `$PROJECTS_ROOT`: A path where projects
                                           sources are mounted as defined by container
-                                          component's sourceMapping \n  - `$PROJECT_SOURCE`:
+                                          component's sourceMapping. \n  - `$PROJECT_SOURCE`:
                                           A path to a project source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one"
+                                          point to the directory of the first one."
                                         type: string
                                       component:
                                         description: Describes component to which
@@ -2383,11 +2383,11 @@ spec:
                                           command should be executed \n Special variables
                                           that can be used: \n  - `$PROJECTS_ROOT`:
                                           A path where projects sources are mounted
-                                          as defined by container component's sourceMapping
+                                          as defined by container component's sourceMapping.
                                           \n  - `$PROJECT_SOURCE`: A path to a project
                                           source ($PROJECTS_ROOT/<project-name>).
                                           If there are multiple projects, this will
-                                          point to the directory of the first one"
+                                          point to the directory of the first one."
                                         type: string
                                     type: object
                                   id:
@@ -2629,7 +2629,7 @@ spec:
                                         type: array
                                       env:
                                         description: "Environment variables used in
-                                          this container \n The following variables
+                                          this container. \n The following variables
                                           are reserved and cannot be overridden via
                                           env: \n  - `$PROJECTS_ROOT` \n  - `$PROJECT_SOURCE`"
                                         items:

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -115,7 +115,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine"`
@@ -128,7 +128,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
 	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -115,9 +115,9 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine"`
 
 	// Describes component to which given action relates
@@ -128,9 +128,9 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -115,7 +115,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted. This variable is reserved and cannot be overridden via component container's env.
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine"`
@@ -128,7 +128,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `${PROJECTS_ROOT}`: A path where projects sources are mounted. This variable is reserved and cannot be overridden via component container's env.
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
 	//
 	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -115,7 +115,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine"`
@@ -128,7 +128,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`
 	//
 	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -117,7 +117,7 @@ type ExecCommand struct {
 	//
 	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	CommandLine string `json:"commandLine"`
 
 	// Describes component to which given action relates
@@ -130,7 +130,7 @@ type ExecCommand struct {
 	//
 	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -115,7 +115,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted. This variable is reserved and cannot be overridden via component container's env.
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine"`
@@ -128,7 +128,7 @@ type ExecCommand struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `${PROJECTS_ROOT}`: A path where projects sources are mounted
+	//  - `${PROJECTS_ROOT}`: A path where projects sources are mounted. This variable is reserved and cannot be overridden via component container's env.
 	//
 	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -18,9 +18,9 @@ type Container struct {
 	//
 	// The following variables are reserved and cannot be overridden via env:
 	//
-	//  - `$PROJECTS_ROOT`
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by sourceMapping
 	//
-	//  - `$PROJECT_SOURCE`
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
@@ -47,7 +47,7 @@ type Container struct {
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
-	// When omitted, the value of the `PROJECTS_ROOT` environment variable is used.
+	// When omitted, the default value of /projects is used.
 	// +optional
 	SourceMapping string `json:"sourceMapping,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -15,6 +15,12 @@ type Container struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Environment variables used in this container
+	//
+	// The following variables are reserved and cannot be overridden via env:
+	//
+	//  - `$PROJECTS_ROOT`
+	//
+	//  - `$PROJECT_SOURCE`
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -18,9 +18,9 @@ type Container struct {
 	//
 	// The following variables are reserved and cannot be overridden via env:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by sourceMapping
+	//  - `$PROJECTS_ROOT`
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -14,7 +14,7 @@ type Container struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	// Environment variables used in this container
+	// Environment variables used in this container.
 	//
 	// The following variables are reserved and cannot be overridden via env:
 	//

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -249,9 +249,9 @@ type ExecCommandParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
@@ -262,9 +262,9 @@ type ExecCommandParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `${PROJECTS_ROOT}`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 
@@ -320,6 +320,12 @@ type ContainerParentOverride struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Environment variables used in this container
+	//
+	// The following variables are reserved and cannot be overridden via env:
+	//
+	//  - `$PROJECTS_ROOT`
+	//
+	//  - `$PROJECT_SOURCE`
 	Env []EnvVarParentOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
@@ -346,7 +352,7 @@ type ContainerParentOverride struct {
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
-	// When omitted, the value of the `PROJECTS_ROOT` environment variable is used.
+	// When omitted, the default value of /projects is used.
 	// +optional
 	SourceMapping string `json:"sourceMapping,omitempty"`
 
@@ -766,9 +772,9 @@ type ExecCommandPluginOverrideParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
@@ -779,9 +785,9 @@ type ExecCommandPluginOverrideParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `${PROJECTS_ROOT}`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 
@@ -837,6 +843,12 @@ type ContainerPluginOverrideParentOverride struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Environment variables used in this container
+	//
+	// The following variables are reserved and cannot be overridden via env:
+	//
+	//  - `$PROJECTS_ROOT`
+	//
+	//  - `$PROJECT_SOURCE`
 	Env []EnvVarPluginOverrideParentOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
@@ -863,7 +875,7 @@ type ContainerPluginOverrideParentOverride struct {
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
-	// When omitted, the value of the `PROJECTS_ROOT` environment variable is used.
+	// When omitted, the default value of /projects is used.
 	// +optional
 	SourceMapping string `json:"sourceMapping,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -249,9 +249,9 @@ type ExecCommandParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
@@ -262,9 +262,9 @@ type ExecCommandParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 
@@ -319,7 +319,7 @@ type ContainerParentOverride struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	// Environment variables used in this container
+	// Environment variables used in this container.
 	//
 	// The following variables are reserved and cannot be overridden via env:
 	//
@@ -772,9 +772,9 @@ type ExecCommandPluginOverrideParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
@@ -785,9 +785,9 @@ type ExecCommandPluginOverrideParentOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 
@@ -842,7 +842,7 @@ type ContainerPluginOverrideParentOverride struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	// Environment variables used in this container
+	// Environment variables used in this container.
 	//
 	// The following variables are reserved and cannot be overridden via env:
 	//

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -153,9 +153,9 @@ type ExecCommandPluginOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
@@ -166,9 +166,9 @@ type ExecCommandPluginOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `${PROJECTS_ROOT}`: A path where projects sources are mounted
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
 	//
-	//  - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/<project-name>). If there are multiple projects, this will point to the directory of the first one.
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 
@@ -224,6 +224,12 @@ type ContainerPluginOverride struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Environment variables used in this container
+	//
+	// The following variables are reserved and cannot be overridden via env:
+	//
+	//  - `$PROJECTS_ROOT`
+	//
+	//  - `$PROJECT_SOURCE`
 	Env []EnvVarPluginOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
@@ -250,7 +256,7 @@ type ContainerPluginOverride struct {
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
-	// When omitted, the value of the `PROJECTS_ROOT` environment variable is used.
+	// When omitted, the default value of /projects is used.
 	// +optional
 	SourceMapping string `json:"sourceMapping,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -153,9 +153,9 @@ type ExecCommandPluginOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	CommandLine string `json:"commandLine,omitempty"`
 
 	// Describes component to which given action relates
@@ -166,9 +166,9 @@ type ExecCommandPluginOverride struct {
 	//
 	// Special variables that can be used:
 	//
-	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping
+	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
-	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one
+	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 
@@ -223,7 +223,7 @@ type ContainerPluginOverride struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	// Environment variables used in this container
+	// Environment variables used in this container.
 	//
 	// The following variables are reserved and cannot be overridden via env:
 	//

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -213,7 +213,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               },
               "component": {
@@ -273,7 +273,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               }
             },
@@ -517,7 +517,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -908,7 +908,7 @@
                           }
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string"
                         },
                         "component": {
@@ -964,7 +964,7 @@
                           "type": "string"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string"
                         }
                       },
@@ -1188,7 +1188,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1651,7 +1651,7 @@
                     }
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string"
                   },
                   "component": {
@@ -1707,7 +1707,7 @@
                     "type": "string"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string"
                   }
                 },
@@ -1936,7 +1936,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -2304,7 +2304,7 @@
                               }
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string"
                             },
                             "component": {
@@ -2360,7 +2360,7 @@
                               "type": "string"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string"
                             }
                           },
@@ -2584,7 +2584,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -213,7 +213,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               },
               "component": {
@@ -273,7 +273,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               }
             },
@@ -517,7 +517,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -546,7 +546,7 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string"
               },
               "volumeMounts": {
@@ -908,7 +908,7 @@
                           }
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string"
                         },
                         "component": {
@@ -964,7 +964,7 @@
                           "type": "string"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string"
                         }
                       },
@@ -1188,7 +1188,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container",
+                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1216,7 +1216,7 @@
                           "type": "boolean"
                         },
                         "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                           "type": "string"
                         },
                         "volumeMounts": {
@@ -1651,7 +1651,7 @@
                     }
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string"
                   },
                   "component": {
@@ -1707,7 +1707,7 @@
                     "type": "string"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string"
                   }
                 },
@@ -1936,7 +1936,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container",
+                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -1964,7 +1964,7 @@
                     "type": "boolean"
                   },
                   "sourceMapping": {
-                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                     "type": "string"
                   },
                   "volumeMounts": {
@@ -2304,7 +2304,7 @@
                               }
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string"
                             },
                             "component": {
@@ -2360,7 +2360,7 @@
                               "type": "string"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string"
                             }
                           },
@@ -2584,7 +2584,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container",
+                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -2612,7 +2612,7 @@
                               "type": "boolean"
                             },
                             "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                               "type": "string"
                             },
                             "volumeMounts": {

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -378,7 +378,7 @@
                     }
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string"
                   },
                   "component": {
@@ -438,7 +438,7 @@
                     "type": "string"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string"
                   }
                 },
@@ -682,7 +682,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -1073,7 +1073,7 @@
                               }
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string"
                             },
                             "component": {
@@ -1129,7 +1129,7 @@
                               "type": "string"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string"
                             }
                           },
@@ -1353,7 +1353,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -1816,7 +1816,7 @@
                         }
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string"
                       },
                       "component": {
@@ -1872,7 +1872,7 @@
                         "type": "string"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string"
                       }
                     },
@@ -2101,7 +2101,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                        "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -2469,7 +2469,7 @@
                                   }
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string"
                                 },
                                 "component": {
@@ -2525,7 +2525,7 @@
                                   "type": "string"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string"
                                 }
                               },
@@ -2749,7 +2749,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                                  "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -378,7 +378,7 @@
                     }
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string"
                   },
                   "component": {
@@ -438,7 +438,7 @@
                     "type": "string"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string"
                   }
                 },
@@ -682,7 +682,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container",
+                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -711,7 +711,7 @@
                     "type": "boolean"
                   },
                   "sourceMapping": {
-                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                     "type": "string"
                   },
                   "volumeMounts": {
@@ -1073,7 +1073,7 @@
                               }
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string"
                             },
                             "component": {
@@ -1129,7 +1129,7 @@
                               "type": "string"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string"
                             }
                           },
@@ -1353,7 +1353,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container",
+                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -1381,7 +1381,7 @@
                               "type": "boolean"
                             },
                             "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                               "type": "string"
                             },
                             "volumeMounts": {
@@ -1816,7 +1816,7 @@
                         }
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string"
                       },
                       "component": {
@@ -1872,7 +1872,7 @@
                         "type": "string"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string"
                       }
                     },
@@ -2101,7 +2101,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container",
+                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -2129,7 +2129,7 @@
                         "type": "boolean"
                       },
                       "sourceMapping": {
-                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                         "type": "string"
                       },
                       "volumeMounts": {
@@ -2469,7 +2469,7 @@
                                   }
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string"
                                 },
                                 "component": {
@@ -2525,7 +2525,7 @@
                                   "type": "string"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string"
                                 }
                               },
@@ -2749,7 +2749,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container",
+                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",
@@ -2777,7 +2777,7 @@
                                   "type": "boolean"
                                 },
                                 "sourceMapping": {
-                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                                   "type": "string"
                                 },
                                 "volumeMounts": {

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -391,7 +391,7 @@
                         }
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string"
                       },
                       "component": {
@@ -451,7 +451,7 @@
                         "type": "string"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string"
                       }
                     },
@@ -695,7 +695,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container",
+                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -724,7 +724,7 @@
                         "type": "boolean"
                       },
                       "sourceMapping": {
-                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                         "type": "string"
                       },
                       "volumeMounts": {
@@ -1086,7 +1086,7 @@
                                   }
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string"
                                 },
                                 "component": {
@@ -1142,7 +1142,7 @@
                                   "type": "string"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string"
                                 }
                               },
@@ -1366,7 +1366,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container",
+                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",
@@ -1394,7 +1394,7 @@
                                   "type": "boolean"
                                 },
                                 "sourceMapping": {
-                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                                   "type": "string"
                                 },
                                 "volumeMounts": {
@@ -1829,7 +1829,7 @@
                             }
                           },
                           "commandLine": {
-                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                             "type": "string"
                           },
                           "component": {
@@ -1885,7 +1885,7 @@
                             "type": "string"
                           },
                           "workingDir": {
-                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                             "type": "string"
                           }
                         },
@@ -2114,7 +2114,7 @@
                             }
                           },
                           "env": {
-                            "description": "Environment variables used in this container",
+                            "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                             "type": "array",
                             "items": {
                               "type": "object",
@@ -2142,7 +2142,7 @@
                             "type": "boolean"
                           },
                           "sourceMapping": {
-                            "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                            "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                             "type": "string"
                           },
                           "volumeMounts": {
@@ -2482,7 +2482,7 @@
                                       }
                                     },
                                     "commandLine": {
-                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                       "type": "string"
                                     },
                                     "component": {
@@ -2538,7 +2538,7 @@
                                       "type": "string"
                                     },
                                     "workingDir": {
-                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                       "type": "string"
                                     }
                                   },
@@ -2762,7 +2762,7 @@
                                       }
                                     },
                                     "env": {
-                                      "description": "Environment variables used in this container",
+                                      "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                       "type": "array",
                                       "items": {
                                         "type": "object",
@@ -2790,7 +2790,7 @@
                                       "type": "boolean"
                                     },
                                     "sourceMapping": {
-                                      "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                                      "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                                       "type": "string"
                                     },
                                     "volumeMounts": {

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -391,7 +391,7 @@
                         }
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string"
                       },
                       "component": {
@@ -451,7 +451,7 @@
                         "type": "string"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string"
                       }
                     },
@@ -695,7 +695,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                        "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -1086,7 +1086,7 @@
                                   }
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string"
                                 },
                                 "component": {
@@ -1142,7 +1142,7 @@
                                   "type": "string"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string"
                                 }
                               },
@@ -1366,7 +1366,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                                  "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",
@@ -1829,7 +1829,7 @@
                             }
                           },
                           "commandLine": {
-                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string"
                           },
                           "component": {
@@ -1885,7 +1885,7 @@
                             "type": "string"
                           },
                           "workingDir": {
-                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string"
                           }
                         },
@@ -2114,7 +2114,7 @@
                             }
                           },
                           "env": {
-                            "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                            "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                             "type": "array",
                             "items": {
                               "type": "object",
@@ -2482,7 +2482,7 @@
                                       }
                                     },
                                     "commandLine": {
-                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string"
                                     },
                                     "component": {
@@ -2538,7 +2538,7 @@
                                       "type": "string"
                                     },
                                     "workingDir": {
-                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string"
                                     }
                                   },
@@ -2762,7 +2762,7 @@
                                       }
                                     },
                                     "env": {
-                                      "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                                      "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                       "type": "array",
                                       "items": {
                                         "type": "object",

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -156,7 +156,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               },
               "component": {
@@ -216,7 +216,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               }
             },
@@ -455,7 +455,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -826,7 +826,7 @@
                           }
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string"
                         },
                         "component": {
@@ -882,7 +882,7 @@
                           "type": "string"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string"
                         }
                       },
@@ -1106,7 +1106,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1585,7 +1585,7 @@
                     }
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string"
                   },
                   "component": {
@@ -1641,7 +1641,7 @@
                     "type": "string"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string"
                   }
                 },
@@ -1870,7 +1870,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -2238,7 +2238,7 @@
                               }
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string"
                             },
                             "component": {
@@ -2294,7 +2294,7 @@
                               "type": "string"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string"
                             }
                           },
@@ -2518,7 +2518,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -156,7 +156,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               },
               "component": {
@@ -216,7 +216,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               }
             },
@@ -455,7 +455,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -484,7 +484,7 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string"
               },
               "volumeMounts": {
@@ -826,7 +826,7 @@
                           }
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string"
                         },
                         "component": {
@@ -882,7 +882,7 @@
                           "type": "string"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string"
                         }
                       },
@@ -1106,7 +1106,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container",
+                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1134,7 +1134,7 @@
                           "type": "boolean"
                         },
                         "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                           "type": "string"
                         },
                         "volumeMounts": {
@@ -1585,7 +1585,7 @@
                     }
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string"
                   },
                   "component": {
@@ -1641,7 +1641,7 @@
                     "type": "string"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string"
                   }
                 },
@@ -1870,7 +1870,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container",
+                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -1898,7 +1898,7 @@
                     "type": "boolean"
                   },
                   "sourceMapping": {
-                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                     "type": "string"
                   },
                   "volumeMounts": {
@@ -2238,7 +2238,7 @@
                               }
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string"
                             },
                             "component": {
@@ -2294,7 +2294,7 @@
                               "type": "string"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string"
                             }
                           },
@@ -2518,7 +2518,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container",
+                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -2546,7 +2546,7 @@
                               "type": "boolean"
                             },
                             "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                               "type": "string"
                             },
                             "volumeMounts": {

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -143,7 +143,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               },
               "component": {
@@ -199,7 +199,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               }
             },
@@ -428,7 +428,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -456,7 +456,7 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string"
               },
               "volumeMounts": {
@@ -796,7 +796,7 @@
                           }
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string"
                         },
                         "component": {
@@ -852,7 +852,7 @@
                           "type": "string"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string"
                         }
                       },
@@ -1076,7 +1076,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container",
+                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1104,7 +1104,7 @@
                           "type": "boolean"
                         },
                         "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                           "type": "string"
                         },
                         "volumeMounts": {

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -143,7 +143,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               },
               "component": {
@@ -199,7 +199,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               }
             },
@@ -428,7 +428,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -796,7 +796,7 @@
                           }
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string"
                         },
                         "component": {
@@ -852,7 +852,7 @@
                           "type": "string"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string"
                         }
                       },
@@ -1076,7 +1076,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -143,7 +143,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               },
               "component": {
@@ -199,7 +199,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string"
               }
             },
@@ -423,7 +423,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -143,7 +143,7 @@
                 }
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               },
               "component": {
@@ -199,7 +199,7 @@
                 "type": "string"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string"
               }
             },
@@ -423,7 +423,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -451,7 +451,7 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string"
               },
               "volumeMounts": {

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
@@ -605,9 +605,9 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string",
-                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
               },
               "volumeMounts": {
                 "description": "List of volumes mounts that should be mounted is this container.",
@@ -1352,9 +1352,9 @@
                           "type": "boolean"
                         },
                         "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                           "type": "string",
-                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                         },
                         "volumeMounts": {
                           "description": "List of volumes mounts that should be mounted is this container.",
@@ -2189,9 +2189,9 @@
                     "type": "boolean"
                   },
                   "sourceMapping": {
-                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                     "type": "string",
-                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                   },
                   "volumeMounts": {
                     "description": "List of volumes mounts that should be mounted is this container.",
@@ -2911,9 +2911,9 @@
                               "type": "boolean"
                             },
                             "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                               "type": "string",
-                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                             },
                             "volumeMounts": {
                               "description": "List of volumes mounts that should be mounted is this container.",

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
@@ -237,9 +237,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -305,9 +305,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "additionalProperties": false,
@@ -575,7 +575,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -593,7 +593,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"
@@ -1009,9 +1009,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -1073,9 +1073,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "additionalProperties": false,
@@ -1323,7 +1323,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1340,7 +1340,7 @@
                             },
                             "additionalProperties": false
                           },
-                          "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                          "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                         },
                         "image": {
                           "type": "string"
@@ -1841,9 +1841,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -1905,9 +1905,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "additionalProperties": false,
@@ -2160,7 +2160,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -2177,7 +2177,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                    "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                   },
                   "image": {
                     "type": "string"
@@ -2568,9 +2568,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2632,9 +2632,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "additionalProperties": false,
@@ -2882,7 +2882,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -2899,7 +2899,7 @@
                                 },
                                 "additionalProperties": false
                               },
-                              "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                              "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                             },
                             "image": {
                               "type": "string"

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
@@ -237,9 +237,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -305,9 +305,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               }
             },
             "additionalProperties": false,
@@ -575,7 +575,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -593,7 +593,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container"
+                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"
@@ -1009,9 +1009,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -1073,9 +1073,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                         }
                       },
                       "additionalProperties": false,
@@ -1323,7 +1323,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container",
+                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1340,7 +1340,7 @@
                             },
                             "additionalProperties": false
                           },
-                          "markdownDescription": "Environment variables used in this container"
+                          "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                         },
                         "image": {
                           "type": "string"
@@ -1841,9 +1841,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -1905,9 +1905,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                   }
                 },
                 "additionalProperties": false,
@@ -2160,7 +2160,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container",
+                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -2177,7 +2177,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "markdownDescription": "Environment variables used in this container"
+                    "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                   },
                   "image": {
                     "type": "string"
@@ -2568,9 +2568,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2632,9 +2632,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                             }
                           },
                           "additionalProperties": false,
@@ -2882,7 +2882,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container",
+                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -2899,7 +2899,7 @@
                                 },
                                 "additionalProperties": false
                               },
-                              "markdownDescription": "Environment variables used in this container"
+                              "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                             },
                             "image": {
                               "type": "string"

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
@@ -435,9 +435,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -503,9 +503,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                   }
                 },
                 "additionalProperties": false,
@@ -773,7 +773,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container",
+                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -791,7 +791,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "markdownDescription": "Environment variables used in this container"
+                    "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                   },
                   "image": {
                     "type": "string"
@@ -1207,9 +1207,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -1271,9 +1271,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                             }
                           },
                           "additionalProperties": false,
@@ -1521,7 +1521,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container",
+                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -1538,7 +1538,7 @@
                                 },
                                 "additionalProperties": false
                               },
-                              "markdownDescription": "Environment variables used in this container"
+                              "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                             },
                             "image": {
                               "type": "string"
@@ -2039,9 +2039,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -2103,9 +2103,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                       }
                     },
                     "additionalProperties": false,
@@ -2358,7 +2358,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container",
+                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -2375,7 +2375,7 @@
                           },
                           "additionalProperties": false
                         },
-                        "markdownDescription": "Environment variables used in this container"
+                        "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                       },
                       "image": {
                         "type": "string"
@@ -2766,9 +2766,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -2830,9 +2830,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                                 }
                               },
                               "additionalProperties": false,
@@ -3080,7 +3080,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container",
+                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",
@@ -3097,7 +3097,7 @@
                                     },
                                     "additionalProperties": false
                                   },
-                                  "markdownDescription": "Environment variables used in this container"
+                                  "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                                 },
                                 "image": {
                                   "type": "string"

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
@@ -803,9 +803,9 @@
                     "type": "boolean"
                   },
                   "sourceMapping": {
-                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                     "type": "string",
-                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                   },
                   "volumeMounts": {
                     "description": "List of volumes mounts that should be mounted is this container.",
@@ -1550,9 +1550,9 @@
                               "type": "boolean"
                             },
                             "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                               "type": "string",
-                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                             },
                             "volumeMounts": {
                               "description": "List of volumes mounts that should be mounted is this container.",
@@ -2387,9 +2387,9 @@
                         "type": "boolean"
                       },
                       "sourceMapping": {
-                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                         "type": "string",
-                        "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                        "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                       },
                       "volumeMounts": {
                         "description": "List of volumes mounts that should be mounted is this container.",
@@ -3109,9 +3109,9 @@
                                   "type": "boolean"
                                 },
                                 "sourceMapping": {
-                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                                   "type": "string",
-                                  "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                                  "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                                 },
                                 "volumeMounts": {
                                   "description": "List of volumes mounts that should be mounted is this container.",

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
@@ -435,9 +435,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -503,9 +503,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "additionalProperties": false,
@@ -773,7 +773,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -791,7 +791,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                    "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                   },
                   "image": {
                     "type": "string"
@@ -1207,9 +1207,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -1271,9 +1271,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "additionalProperties": false,
@@ -1521,7 +1521,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -1538,7 +1538,7 @@
                                 },
                                 "additionalProperties": false
                               },
-                              "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                              "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                             },
                             "image": {
                               "type": "string"
@@ -2039,9 +2039,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -2103,9 +2103,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "additionalProperties": false,
@@ -2358,7 +2358,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                        "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -2375,7 +2375,7 @@
                           },
                           "additionalProperties": false
                         },
-                        "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                        "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                       },
                       "image": {
                         "type": "string"
@@ -2766,9 +2766,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -2830,9 +2830,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "additionalProperties": false,
@@ -3080,7 +3080,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                                  "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",
@@ -3097,7 +3097,7 @@
                                     },
                                     "additionalProperties": false
                                   },
-                                  "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                                  "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                                 },
                                 "image": {
                                   "type": "string"

--- a/schemas/latest/with-markdown-descriptions/dev-workspace.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace.json
@@ -816,9 +816,9 @@
                         "type": "boolean"
                       },
                       "sourceMapping": {
-                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                        "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                         "type": "string",
-                        "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                        "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                       },
                       "volumeMounts": {
                         "description": "List of volumes mounts that should be mounted is this container.",
@@ -1563,9 +1563,9 @@
                                   "type": "boolean"
                                 },
                                 "sourceMapping": {
-                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                                  "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                                   "type": "string",
-                                  "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                                  "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                                 },
                                 "volumeMounts": {
                                   "description": "List of volumes mounts that should be mounted is this container.",
@@ -2400,9 +2400,9 @@
                             "type": "boolean"
                           },
                           "sourceMapping": {
-                            "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                            "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                             "type": "string",
-                            "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                            "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                           },
                           "volumeMounts": {
                             "description": "List of volumes mounts that should be mounted is this container.",
@@ -3122,9 +3122,9 @@
                                       "type": "boolean"
                                     },
                                     "sourceMapping": {
-                                      "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                                      "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                                       "type": "string",
-                                      "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                                      "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                                     },
                                     "volumeMounts": {
                                       "description": "List of volumes mounts that should be mounted is this container.",

--- a/schemas/latest/with-markdown-descriptions/dev-workspace.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace.json
@@ -448,9 +448,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -516,9 +516,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                       }
                     },
                     "additionalProperties": false,
@@ -786,7 +786,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container",
+                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -804,7 +804,7 @@
                           },
                           "additionalProperties": false
                         },
-                        "markdownDescription": "Environment variables used in this container"
+                        "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                       },
                       "image": {
                         "type": "string"
@@ -1220,9 +1220,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -1284,9 +1284,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                                 }
                               },
                               "additionalProperties": false,
@@ -1534,7 +1534,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container",
+                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",
@@ -1551,7 +1551,7 @@
                                     },
                                     "additionalProperties": false
                                   },
-                                  "markdownDescription": "Environment variables used in this container"
+                                  "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                                 },
                                 "image": {
                                   "type": "string"
@@ -2052,9 +2052,9 @@
                             "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "commandLine": {
-                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                             "type": "string",
-                            "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                            "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                           },
                           "component": {
                             "description": "Describes component to which given action relates",
@@ -2116,9 +2116,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "workingDir": {
-                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                             "type": "string",
-                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                           }
                         },
                         "additionalProperties": false,
@@ -2371,7 +2371,7 @@
                             }
                           },
                           "env": {
-                            "description": "Environment variables used in this container",
+                            "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                             "type": "array",
                             "items": {
                               "type": "object",
@@ -2388,7 +2388,7 @@
                               },
                               "additionalProperties": false
                             },
-                            "markdownDescription": "Environment variables used in this container"
+                            "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                           },
                           "image": {
                             "type": "string"
@@ -2779,9 +2779,9 @@
                                       "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "commandLine": {
-                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                       "type": "string",
-                                      "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                                      "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                                     },
                                     "component": {
                                       "description": "Describes component to which given action relates",
@@ -2843,9 +2843,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "workingDir": {
-                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                                       "type": "string",
-                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                                     }
                                   },
                                   "additionalProperties": false,
@@ -3093,7 +3093,7 @@
                                       }
                                     },
                                     "env": {
-                                      "description": "Environment variables used in this container",
+                                      "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                       "type": "array",
                                       "items": {
                                         "type": "object",
@@ -3110,7 +3110,7 @@
                                         },
                                         "additionalProperties": false
                                       },
-                                      "markdownDescription": "Environment variables used in this container"
+                                      "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                                     },
                                     "image": {
                                       "type": "string"

--- a/schemas/latest/with-markdown-descriptions/dev-workspace.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace.json
@@ -448,9 +448,9 @@
                         "markdownDescription": "Optional map of free-form additional command attributes"
                       },
                       "commandLine": {
-                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                        "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                       },
                       "component": {
                         "description": "Describes component to which given action relates",
@@ -516,9 +516,9 @@
                         "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                       },
                       "workingDir": {
-                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                        "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                         "type": "string",
-                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                        "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                       }
                     },
                     "additionalProperties": false,
@@ -786,7 +786,7 @@
                         }
                       },
                       "env": {
-                        "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                        "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -804,7 +804,7 @@
                           },
                           "additionalProperties": false
                         },
-                        "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                        "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                       },
                       "image": {
                         "type": "string"
@@ -1220,9 +1220,9 @@
                                   "markdownDescription": "Optional map of free-form additional command attributes"
                                 },
                                 "commandLine": {
-                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                                  "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                                 },
                                 "component": {
                                   "description": "Describes component to which given action relates",
@@ -1284,9 +1284,9 @@
                                   "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                 },
                                 "workingDir": {
-                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                  "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                   "type": "string",
-                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                                  "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                                 }
                               },
                               "additionalProperties": false,
@@ -1534,7 +1534,7 @@
                                   }
                                 },
                                 "env": {
-                                  "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                                  "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                   "type": "array",
                                   "items": {
                                     "type": "object",
@@ -1551,7 +1551,7 @@
                                     },
                                     "additionalProperties": false
                                   },
-                                  "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                                  "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                                 },
                                 "image": {
                                   "type": "string"
@@ -2052,9 +2052,9 @@
                             "markdownDescription": "Optional map of free-form additional command attributes"
                           },
                           "commandLine": {
-                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                            "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string",
-                            "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                            "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                           },
                           "component": {
                             "description": "Describes component to which given action relates",
@@ -2116,9 +2116,9 @@
                             "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                           },
                           "workingDir": {
-                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                            "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                             "type": "string",
-                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                            "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                           }
                         },
                         "additionalProperties": false,
@@ -2371,7 +2371,7 @@
                             }
                           },
                           "env": {
-                            "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                            "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                             "type": "array",
                             "items": {
                               "type": "object",
@@ -2388,7 +2388,7 @@
                               },
                               "additionalProperties": false
                             },
-                            "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                            "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                           },
                           "image": {
                             "type": "string"
@@ -2779,9 +2779,9 @@
                                       "markdownDescription": "Optional map of free-form additional command attributes"
                                     },
                                     "commandLine": {
-                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                      "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string",
-                                      "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                                      "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                                     },
                                     "component": {
                                       "description": "Describes component to which given action relates",
@@ -2843,9 +2843,9 @@
                                       "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                                     },
                                     "workingDir": {
-                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                                      "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                                       "type": "string",
-                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                                      "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                                     }
                                   },
                                   "additionalProperties": false,
@@ -3093,7 +3093,7 @@
                                       }
                                     },
                                     "env": {
-                                      "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                                      "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                                       "type": "array",
                                       "items": {
                                         "type": "object",
@@ -3110,7 +3110,7 @@
                                         },
                                         "additionalProperties": false
                                       },
-                                      "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                                      "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                                     },
                                     "image": {
                                       "type": "string"

--- a/schemas/latest/with-markdown-descriptions/devfile.json
+++ b/schemas/latest/with-markdown-descriptions/devfile.json
@@ -535,9 +535,9 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string",
-                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
               },
               "volumeMounts": {
                 "description": "List of volumes mounts that should be mounted is this container.",
@@ -1259,9 +1259,9 @@
                           "type": "boolean"
                         },
                         "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                           "type": "string",
-                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                         },
                         "volumeMounts": {
                           "description": "List of volumes mounts that should be mounted is this container.",
@@ -2115,9 +2115,9 @@
                     "type": "boolean"
                   },
                   "sourceMapping": {
-                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                     "type": "string",
-                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                    "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                   },
                   "volumeMounts": {
                     "description": "List of volumes mounts that should be mounted is this container.",
@@ -2837,9 +2837,9 @@
                               "type": "boolean"
                             },
                             "sourceMapping": {
-                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                               "type": "string",
-                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                              "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                             },
                             "volumeMounts": {
                               "description": "List of volumes mounts that should be mounted is this container.",

--- a/schemas/latest/with-markdown-descriptions/devfile.json
+++ b/schemas/latest/with-markdown-descriptions/devfile.json
@@ -172,9 +172,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -240,9 +240,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               }
             },
             "additionalProperties": false,
@@ -505,7 +505,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -523,7 +523,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container"
+                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"
@@ -916,9 +916,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -980,9 +980,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                         }
                       },
                       "additionalProperties": false,
@@ -1230,7 +1230,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container",
+                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1247,7 +1247,7 @@
                             },
                             "additionalProperties": false
                           },
-                          "markdownDescription": "Environment variables used in this container"
+                          "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                         },
                         "image": {
                           "type": "string"
@@ -1767,9 +1767,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -1831,9 +1831,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                   }
                 },
                 "additionalProperties": false,
@@ -2086,7 +2086,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container",
+                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -2103,7 +2103,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "markdownDescription": "Environment variables used in this container"
+                    "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                   },
                   "image": {
                     "type": "string"
@@ -2494,9 +2494,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2558,9 +2558,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                             }
                           },
                           "additionalProperties": false,
@@ -2808,7 +2808,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container",
+                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -2825,7 +2825,7 @@
                                 },
                                 "additionalProperties": false
                               },
-                              "markdownDescription": "Environment variables used in this container"
+                              "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                             },
                             "image": {
                               "type": "string"

--- a/schemas/latest/with-markdown-descriptions/devfile.json
+++ b/schemas/latest/with-markdown-descriptions/devfile.json
@@ -172,9 +172,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -240,9 +240,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "additionalProperties": false,
@@ -505,7 +505,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -523,7 +523,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"
@@ -916,9 +916,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -980,9 +980,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "additionalProperties": false,
@@ -1230,7 +1230,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1247,7 +1247,7 @@
                             },
                             "additionalProperties": false
                           },
-                          "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                          "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                         },
                         "image": {
                           "type": "string"
@@ -1767,9 +1767,9 @@
                     "markdownDescription": "Optional map of free-form additional command attributes"
                   },
                   "commandLine": {
-                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                    "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                   },
                   "component": {
                     "description": "Describes component to which given action relates",
@@ -1831,9 +1831,9 @@
                     "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                   },
                   "workingDir": {
-                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                     "type": "string",
-                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                    "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                   }
                 },
                 "additionalProperties": false,
@@ -2086,7 +2086,7 @@
                     }
                   },
                   "env": {
-                    "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                     "type": "array",
                     "items": {
                       "type": "object",
@@ -2103,7 +2103,7 @@
                       },
                       "additionalProperties": false
                     },
-                    "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                    "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                   },
                   "image": {
                     "type": "string"
@@ -2494,9 +2494,9 @@
                               "markdownDescription": "Optional map of free-form additional command attributes"
                             },
                             "commandLine": {
-                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                              "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                             },
                             "component": {
                               "description": "Describes component to which given action relates",
@@ -2558,9 +2558,9 @@
                               "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                             },
                             "workingDir": {
-                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                               "type": "string",
-                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                              "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                             }
                           },
                           "additionalProperties": false,
@@ -2808,7 +2808,7 @@
                               }
                             },
                             "env": {
-                              "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                               "type": "array",
                               "items": {
                                 "type": "object",
@@ -2825,7 +2825,7 @@
                                 },
                                 "additionalProperties": false
                               },
-                              "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                              "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                             },
                             "image": {
                               "type": "string"

--- a/schemas/latest/with-markdown-descriptions/parent-overrides.json
+++ b/schemas/latest/with-markdown-descriptions/parent-overrides.json
@@ -159,9 +159,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -223,9 +223,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "additionalProperties": false,
@@ -478,7 +478,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -495,7 +495,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"
@@ -886,9 +886,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -950,9 +950,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
                         }
                       },
                       "additionalProperties": false,
@@ -1200,7 +1200,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1217,7 +1217,7 @@
                             },
                             "additionalProperties": false
                           },
-                          "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                          "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                         },
                         "image": {
                           "type": "string"

--- a/schemas/latest/with-markdown-descriptions/parent-overrides.json
+++ b/schemas/latest/with-markdown-descriptions/parent-overrides.json
@@ -159,9 +159,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -223,9 +223,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               }
             },
             "additionalProperties": false,
@@ -478,7 +478,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -495,7 +495,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container"
+                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"
@@ -886,9 +886,9 @@
                           "markdownDescription": "Optional map of free-form additional command attributes"
                         },
                         "commandLine": {
-                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string",
-                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                         },
                         "component": {
                           "description": "Describes component to which given action relates",
@@ -950,9 +950,9 @@
                           "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
                         },
                         "workingDir": {
-                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                           "type": "string",
-                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                          "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
                         }
                       },
                       "additionalProperties": false,
@@ -1200,7 +1200,7 @@
                           }
                         },
                         "env": {
-                          "description": "Environment variables used in this container",
+                          "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -1217,7 +1217,7 @@
                             },
                             "additionalProperties": false
                           },
-                          "markdownDescription": "Environment variables used in this container"
+                          "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
                         },
                         "image": {
                           "type": "string"

--- a/schemas/latest/with-markdown-descriptions/parent-overrides.json
+++ b/schemas/latest/with-markdown-descriptions/parent-overrides.json
@@ -507,9 +507,9 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string",
-                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
               },
               "volumeMounts": {
                 "description": "List of volumes mounts that should be mounted is this container.",
@@ -1229,9 +1229,9 @@
                           "type": "boolean"
                         },
                         "sourceMapping": {
-                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                           "type": "string",
-                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                          "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
                         },
                         "volumeMounts": {
                           "description": "List of volumes mounts that should be mounted is this container.",

--- a/schemas/latest/with-markdown-descriptions/plugin-overrides.json
+++ b/schemas/latest/with-markdown-descriptions/plugin-overrides.json
@@ -159,9 +159,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -223,9 +223,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `${PROJECTS_ROOT}`: A path where projects sources are mounted\n\n - `${PROJECT_SOURCE}`: A path to a project source (${PROJECTS_ROOT}/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
               }
             },
             "additionalProperties": false,
@@ -473,7 +473,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container",
+                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -490,7 +490,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container"
+                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"
@@ -502,9 +502,9 @@
                 "type": "boolean"
               },
               "sourceMapping": {
-                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used.",
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
                 "type": "string",
-                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the value of the `PROJECTS_ROOT` environment variable is used."
+                "markdownDescription": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used."
               },
               "volumeMounts": {
                 "description": "List of volumes mounts that should be mounted is this container.",

--- a/schemas/latest/with-markdown-descriptions/plugin-overrides.json
+++ b/schemas/latest/with-markdown-descriptions/plugin-overrides.json
@@ -159,9 +159,9 @@
                 "markdownDescription": "Optional map of free-form additional command attributes"
               },
               "commandLine": {
-                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               },
               "component": {
                 "description": "Describes component to which given action relates",
@@ -223,9 +223,9 @@
                 "markdownDescription": "Optional label that provides a label for this command to be used in Editor UI menus for example"
               },
               "workingDir": {
-                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one",
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
                 "type": "string",
-                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one"
+                "markdownDescription": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one."
               }
             },
             "additionalProperties": false,
@@ -473,7 +473,7 @@
                 }
               },
               "env": {
-                "description": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -490,7 +490,7 @@
                   },
                   "additionalProperties": false
                 },
-                "markdownDescription": "Environment variables used in this container\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
+                "markdownDescription": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`"
               },
               "image": {
                 "type": "string"


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?
This schema explicitly specifies that `PROJECTS_ROOT` & `PROJECT_SOURCE` env are reserved and cannot be overridden via component container's env

### What issues does this PR fix or reference?
Fixes #132 

### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
