### PR TITLE
Fix the contribute link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This work is still in an early stage of specification, and the related API and s
 
 In order to test existing or new Devfile 2.0 or DevWorkspace sample files in a self-service Che workspace (hosted on che.openshift.io), just click on the button below:
 
-[![Contribute](https://che.openshift.io/factory/resources/factory-contribute.svg)](https://che.openshift.io/f/?url=https://github.com/devfile/api)
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://che.openshift.io/f/?url=https://github.com/devfile/api)
 
 As soon as the workspace is opened, you should be able to:
 - open the `yaml` files in the following folders:


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
It looks https://che.openshift.io/factory/resources/factory-contribute.svg is no longer available so I've changed the link to be https://www.eclipse.org/che/contribute.svg

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
