### PR TITLE
Make mountSources true by default

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -541,6 +541,10 @@ spec:
                           memoryLimit:
                             type: string
                           mountSources:
+                            description: "Toggles whether or not the project source
+                              code should be mounted in the component. \n Defaults
+                              to true for all component types except plugins and components
+                              that set `dedicatedPod` to true."
                             type: boolean
                           sourceMapping:
                             description: Optional specification of the path in the
@@ -1245,6 +1249,11 @@ spec:
                                     memoryLimit:
                                       type: string
                                     mountSources:
+                                      description: "Toggles whether or not the project
+                                        source code should be mounted in the component.
+                                        \n Defaults to true for all component types
+                                        except plugins and components that set `dedicatedPod`
+                                        to true."
                                       type: boolean
                                     sourceMapping:
                                       description: Optional specification of the path
@@ -2020,6 +2029,10 @@ spec:
                               memoryLimit:
                                 type: string
                               mountSources:
+                                description: "Toggles whether or not the project source
+                                  code should be mounted in the component. \n Defaults
+                                  to true for all component types except plugins and
+                                  components that set `dedicatedPod` to true."
                                 type: boolean
                               sourceMapping:
                                 description: Optional specification of the path in
@@ -2720,6 +2733,12 @@ spec:
                                         memoryLimit:
                                           type: string
                                         mountSources:
+                                          description: "Toggles whether or not the
+                                            project source code should be mounted
+                                            in the component. \n Defaults to true
+                                            for all component types except plugins
+                                            and components that set `dedicatedPod`
+                                            to true."
                                           type: boolean
                                         sourceMapping:
                                           description: Optional specification of the

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -550,6 +550,10 @@ spec:
                             memoryLimit:
                               type: string
                             mountSources:
+                              description: "Toggles whether or not the project source
+                                code should be mounted in the component. \n Defaults
+                                to true for all component types except plugins and
+                                components that set `dedicatedPod` to true."
                               type: boolean
                             sourceMapping:
                               description: Optional specification of the path in the
@@ -1263,6 +1267,11 @@ spec:
                                       memoryLimit:
                                         type: string
                                       mountSources:
+                                        description: "Toggles whether or not the project
+                                          source code should be mounted in the component.
+                                          \n Defaults to true for all component types
+                                          except plugins and components that set `dedicatedPod`
+                                          to true."
                                         type: boolean
                                       sourceMapping:
                                         description: Optional specification of the
@@ -2046,6 +2055,11 @@ spec:
                                 memoryLimit:
                                   type: string
                                 mountSources:
+                                  description: "Toggles whether or not the project
+                                    source code should be mounted in the component.
+                                    \n Defaults to true for all component types except
+                                    plugins and components that set `dedicatedPod`
+                                    to true."
                                   type: boolean
                                 sourceMapping:
                                   description: Optional specification of the path
@@ -2758,6 +2772,12 @@ spec:
                                           memoryLimit:
                                             type: string
                                           mountSources:
+                                            description: "Toggles whether or not the
+                                              project source code should be mounted
+                                              in the component. \n Defaults to true
+                                              for all component types except plugins
+                                              and components that set `dedicatedPod`
+                                              to true."
                                             type: boolean
                                           sourceMapping:
                                             description: Optional specification of

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -506,6 +506,10 @@ spec:
                       memoryLimit:
                         type: string
                       mountSources:
+                        description: "Toggles whether or not the project source code
+                          should be mounted in the component. \n Defaults to true
+                          for all component types except plugins and components that
+                          set `dedicatedPod` to true."
                         type: boolean
                       sourceMapping:
                         description: Optional specification of the path in the container
@@ -1190,6 +1194,11 @@ spec:
                                 memoryLimit:
                                   type: string
                                 mountSources:
+                                  description: "Toggles whether or not the project
+                                    source code should be mounted in the component.
+                                    \n Defaults to true for all component types except
+                                    plugins and components that set `dedicatedPod`
+                                    to true."
                                   type: boolean
                                 sourceMapping:
                                   description: Optional specification of the path
@@ -1930,6 +1939,10 @@ spec:
                           memoryLimit:
                             type: string
                           mountSources:
+                            description: "Toggles whether or not the project source
+                              code should be mounted in the component. \n Defaults
+                              to true for all component types except plugins and components
+                              that set `dedicatedPod` to true."
                             type: boolean
                           sourceMapping:
                             description: Optional specification of the path in the
@@ -2609,6 +2622,11 @@ spec:
                                     memoryLimit:
                                       type: string
                                     mountSources:
+                                      description: "Toggles whether or not the project
+                                        source code should be mounted in the component.
+                                        \n Defaults to true for all component types
+                                        except plugins and components that set `dedicatedPod`
+                                        to true."
                                       type: boolean
                                     sourceMapping:
                                       description: Optional specification of the path

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -510,6 +510,10 @@ spec:
                         memoryLimit:
                           type: string
                         mountSources:
+                          description: "Toggles whether or not the project source
+                            code should be mounted in the component. \n Defaults to
+                            true for all component types except plugins and components
+                            that set `dedicatedPod` to true."
                           type: boolean
                         sourceMapping:
                           description: Optional specification of the path in the container
@@ -1204,6 +1208,11 @@ spec:
                                   memoryLimit:
                                     type: string
                                   mountSources:
+                                    description: "Toggles whether or not the project
+                                      source code should be mounted in the component.
+                                      \n Defaults to true for all component types
+                                      except plugins and components that set `dedicatedPod`
+                                      to true."
                                     type: boolean
                                   sourceMapping:
                                     description: Optional specification of the path
@@ -1959,6 +1968,10 @@ spec:
                             memoryLimit:
                               type: string
                             mountSources:
+                              description: "Toggles whether or not the project source
+                                code should be mounted in the component. \n Defaults
+                                to true for all component types except plugins and
+                                components that set `dedicatedPod` to true."
                               type: boolean
                             sourceMapping:
                               description: Optional specification of the path in the
@@ -2647,6 +2660,11 @@ spec:
                                       memoryLimit:
                                         type: string
                                       mountSources:
+                                        description: "Toggles whether or not the project
+                                          source code should be mounted in the component.
+                                          \n Defaults to true for all component types
+                                          except plugins and components that set `dedicatedPod`
+                                          to true."
                                         type: boolean
                                       sourceMapping:
                                         description: Optional specification of the

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -42,6 +42,10 @@ type Container struct {
 	// +optional
 	Args []string `json:"args,omitempty" patchStrategy:"replace"`
 
+	// Toggles whether or not the project source code should
+	// be mounted in the component.
+	//
+	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
 	MountSources bool `json:"mountSources,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -347,6 +347,10 @@ type ContainerParentOverride struct {
 	// +optional
 	Args []string `json:"args,omitempty" patchStrategy:"replace"`
 
+	// Toggles whether or not the project source code should
+	// be mounted in the component.
+	//
+	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
 	MountSources bool `json:"mountSources,omitempty"`
 
@@ -870,6 +874,10 @@ type ContainerPluginOverrideParentOverride struct {
 	// +optional
 	Args []string `json:"args,omitempty" patchStrategy:"replace"`
 
+	// Toggles whether or not the project source code should
+	// be mounted in the component.
+	//
+	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
 	MountSources bool `json:"mountSources,omitempty"`
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -251,6 +251,10 @@ type ContainerPluginOverride struct {
 	// +optional
 	Args []string `json:"args,omitempty" patchStrategy:"replace"`
 
+	// Toggles whether or not the project source code should
+	// be mounted in the component.
+	//
+	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
 	MountSources bool `json:"mountSources,omitempty"`
 

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -543,6 +543,7 @@
                 "type": "string"
               },
               "mountSources": {
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                 "type": "boolean"
               },
               "sourceMapping": {
@@ -1213,6 +1214,7 @@
                           "type": "string"
                         },
                         "mountSources": {
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                           "type": "boolean"
                         },
                         "sourceMapping": {
@@ -1961,6 +1963,7 @@
                     "type": "string"
                   },
                   "mountSources": {
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                     "type": "boolean"
                   },
                   "sourceMapping": {
@@ -2609,6 +2612,7 @@
                               "type": "string"
                             },
                             "mountSources": {
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                               "type": "boolean"
                             },
                             "sourceMapping": {

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -708,6 +708,7 @@
                     "type": "string"
                   },
                   "mountSources": {
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                     "type": "boolean"
                   },
                   "sourceMapping": {
@@ -1378,6 +1379,7 @@
                               "type": "string"
                             },
                             "mountSources": {
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                               "type": "boolean"
                             },
                             "sourceMapping": {
@@ -2126,6 +2128,7 @@
                         "type": "string"
                       },
                       "mountSources": {
+                        "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                         "type": "boolean"
                       },
                       "sourceMapping": {
@@ -2774,6 +2777,7 @@
                                   "type": "string"
                                 },
                                 "mountSources": {
+                                  "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                                   "type": "boolean"
                                 },
                                 "sourceMapping": {

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -721,6 +721,7 @@
                         "type": "string"
                       },
                       "mountSources": {
+                        "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                         "type": "boolean"
                       },
                       "sourceMapping": {
@@ -1391,6 +1392,7 @@
                                   "type": "string"
                                 },
                                 "mountSources": {
+                                  "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                                   "type": "boolean"
                                 },
                                 "sourceMapping": {
@@ -2139,6 +2141,7 @@
                             "type": "string"
                           },
                           "mountSources": {
+                            "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                             "type": "boolean"
                           },
                           "sourceMapping": {
@@ -2787,6 +2790,7 @@
                                       "type": "string"
                                     },
                                     "mountSources": {
+                                      "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                                       "type": "boolean"
                                     },
                                     "sourceMapping": {

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -481,6 +481,7 @@
                 "type": "string"
               },
               "mountSources": {
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                 "type": "boolean"
               },
               "sourceMapping": {
@@ -1131,6 +1132,7 @@
                           "type": "string"
                         },
                         "mountSources": {
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                           "type": "boolean"
                         },
                         "sourceMapping": {
@@ -1895,6 +1897,7 @@
                     "type": "string"
                   },
                   "mountSources": {
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                     "type": "boolean"
                   },
                   "sourceMapping": {
@@ -2543,6 +2546,7 @@
                               "type": "string"
                             },
                             "mountSources": {
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                               "type": "boolean"
                             },
                             "sourceMapping": {

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -453,6 +453,7 @@
                 "type": "string"
               },
               "mountSources": {
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                 "type": "boolean"
               },
               "sourceMapping": {
@@ -1101,6 +1102,7 @@
                           "type": "string"
                         },
                         "mountSources": {
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                           "type": "boolean"
                         },
                         "sourceMapping": {

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -448,6 +448,7 @@
                 "type": "string"
               },
               "mountSources": {
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
                 "type": "boolean"
               },
               "sourceMapping": {

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template-spec.json
@@ -602,7 +602,9 @@
                 "type": "string"
               },
               "mountSources": {
-                "type": "boolean"
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                "type": "boolean",
+                "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
               },
               "sourceMapping": {
                 "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -1349,7 +1351,9 @@
                           "type": "string"
                         },
                         "mountSources": {
-                          "type": "boolean"
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                          "type": "boolean",
+                          "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                         },
                         "sourceMapping": {
                           "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -2186,7 +2190,9 @@
                     "type": "string"
                   },
                   "mountSources": {
-                    "type": "boolean"
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                    "type": "boolean",
+                    "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                   },
                   "sourceMapping": {
                     "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -2908,7 +2914,9 @@
                               "type": "string"
                             },
                             "mountSources": {
-                              "type": "boolean"
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                              "type": "boolean",
+                              "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                             },
                             "sourceMapping": {
                               "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",

--- a/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace-template.json
@@ -800,7 +800,9 @@
                     "type": "string"
                   },
                   "mountSources": {
-                    "type": "boolean"
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                    "type": "boolean",
+                    "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                   },
                   "sourceMapping": {
                     "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -1547,7 +1549,9 @@
                               "type": "string"
                             },
                             "mountSources": {
-                              "type": "boolean"
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                              "type": "boolean",
+                              "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                             },
                             "sourceMapping": {
                               "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -2384,7 +2388,9 @@
                         "type": "string"
                       },
                       "mountSources": {
-                        "type": "boolean"
+                        "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                        "type": "boolean",
+                        "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                       },
                       "sourceMapping": {
                         "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -3106,7 +3112,9 @@
                                   "type": "string"
                                 },
                                 "mountSources": {
-                                  "type": "boolean"
+                                  "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                                  "type": "boolean",
+                                  "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                                 },
                                 "sourceMapping": {
                                   "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",

--- a/schemas/latest/with-markdown-descriptions/dev-workspace.json
+++ b/schemas/latest/with-markdown-descriptions/dev-workspace.json
@@ -813,7 +813,9 @@
                         "type": "string"
                       },
                       "mountSources": {
-                        "type": "boolean"
+                        "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                        "type": "boolean",
+                        "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                       },
                       "sourceMapping": {
                         "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -1560,7 +1562,9 @@
                                   "type": "string"
                                 },
                                 "mountSources": {
-                                  "type": "boolean"
+                                  "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                                  "type": "boolean",
+                                  "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                                 },
                                 "sourceMapping": {
                                   "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -2397,7 +2401,9 @@
                             "type": "string"
                           },
                           "mountSources": {
-                            "type": "boolean"
+                            "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                            "type": "boolean",
+                            "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                           },
                           "sourceMapping": {
                             "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -3119,7 +3125,9 @@
                                       "type": "string"
                                     },
                                     "mountSources": {
-                                      "type": "boolean"
+                                      "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                                      "type": "boolean",
+                                      "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                                     },
                                     "sourceMapping": {
                                       "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",

--- a/schemas/latest/with-markdown-descriptions/devfile.json
+++ b/schemas/latest/with-markdown-descriptions/devfile.json
@@ -532,7 +532,9 @@
                 "type": "string"
               },
               "mountSources": {
-                "type": "boolean"
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                "type": "boolean",
+                "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
               },
               "sourceMapping": {
                 "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -1256,7 +1258,9 @@
                           "type": "string"
                         },
                         "mountSources": {
-                          "type": "boolean"
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                          "type": "boolean",
+                          "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                         },
                         "sourceMapping": {
                           "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -2112,7 +2116,9 @@
                     "type": "string"
                   },
                   "mountSources": {
-                    "type": "boolean"
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                    "type": "boolean",
+                    "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                   },
                   "sourceMapping": {
                     "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -2834,7 +2840,9 @@
                               "type": "string"
                             },
                             "mountSources": {
-                              "type": "boolean"
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                              "type": "boolean",
+                              "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                             },
                             "sourceMapping": {
                               "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",

--- a/schemas/latest/with-markdown-descriptions/parent-overrides.json
+++ b/schemas/latest/with-markdown-descriptions/parent-overrides.json
@@ -504,7 +504,9 @@
                 "type": "string"
               },
               "mountSources": {
-                "type": "boolean"
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                "type": "boolean",
+                "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
               },
               "sourceMapping": {
                 "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
@@ -1226,7 +1228,9 @@
                           "type": "string"
                         },
                         "mountSources": {
-                          "type": "boolean"
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                          "type": "boolean",
+                          "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
                         },
                         "sourceMapping": {
                           "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",

--- a/schemas/latest/with-markdown-descriptions/plugin-overrides.json
+++ b/schemas/latest/with-markdown-descriptions/plugin-overrides.json
@@ -499,7 +499,9 @@
                 "type": "string"
               },
               "mountSources": {
-                "type": "boolean"
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                "type": "boolean",
+                "markdownDescription": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true."
               },
               "sourceMapping": {
                 "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",


### PR DESCRIPTION
### What does this PR do?
This PR updates the devfile schema to define the `mountSources` field as being true for all non-plugin components and components that don't set `dedicatedPod` to true.

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/75

### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
