### PR TITLE
clean up the extra memoryLimit defined in containerComponent

### DIFF
--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -4,7 +4,6 @@ package v1alpha2
 type ContainerComponent struct {
 	BaseComponent `json:",inline"`
 	Container     `json:",inline"`
-	MemoryLimit   string     `json:"memoryLimit,omitempty"`
 	Endpoints     []Endpoint `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -192,7 +192,6 @@ type ComponentTypeParentOverride string
 type ContainerComponentParentOverride struct {
 	BaseComponentParentOverride `json:",inline"`
 	ContainerParentOverride     `json:",inline"`
-	MemoryLimit                 string                   `json:"memoryLimit,omitempty"`
 	Endpoints                   []EndpointParentOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
@@ -758,7 +757,6 @@ type ComponentTypePluginOverrideParentOverride string
 type ContainerComponentPluginOverrideParentOverride struct {
 	BaseComponentPluginOverrideParentOverride `json:",inline"`
 	ContainerPluginOverrideParentOverride     `json:",inline"`
-	MemoryLimit                               string                                 `json:"memoryLimit,omitempty"`
 	Endpoints                                 []EndpointPluginOverrideParentOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -123,7 +123,6 @@ type ComponentTypePluginOverride string
 type ContainerComponentPluginOverride struct {
 	BaseComponentPluginOverride `json:",inline"`
 	ContainerPluginOverride     `json:",inline"`
-	MemoryLimit                 string                   `json:"memoryLimit,omitempty"`
 	Endpoints                   []EndpointPluginOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
This PR cleanups the duplicate definition of  `MemoryLimit` defined in `ContainerComponent`

### What issues does this PR fix or reference?
fixes #173 

### Is your PR tested? Consider putting some instruction how to test your changes
It is tested with the override unit test and override functions defined in my branch of devfile/parser
(https://github.com/yangcao77/parser/blob/0ae2029346821a4b5bb6a16c691456b7fd2c92ea/pkg/devfile/parser/types_test.go#L316)


