### PR TITLE
Add yaml struct tags to match existing json tags and allow serialization

### DIFF
--- a/generator/overrides/gen.go
+++ b/generator/overrides/gen.go
@@ -292,6 +292,7 @@ func (g Generator) createOverride(newTypeToProcess typeToProcess, packageTypes m
 						!strings.Contains(jsonTag, ",omitempty") {
 						newJSONTag := jsonTag + ",omitempty"
 						astField.Tag.Value = strings.Replace(astField.Tag.Value, `json:"`+jsonTag+`"`, `json:"`+newJSONTag+`"`, 1)
+						astField.Tag.Value = strings.Replace(astField.Tag.Value, `yaml:"`+jsonTag+`"`, `yaml:"`+newJSONTag+`"`, 1)
 						astField.Doc = updateComments(
 							astField, astField.Doc,
 							`.*`,

--- a/pkg/apis/workspaces/v1alpha2/WorkspacePodContribution.go
+++ b/pkg/apis/workspaces/v1alpha2/WorkspacePodContribution.go
@@ -8,13 +8,13 @@ type WorkspacePodContributions struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
-	Volumes []corev1.Volume `json:"volumes,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
+	Volumes []corev1.Volume `json:"volumes,omitempty" yaml:"volumes,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	InitContainers []corev1.Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
+	InitContainers []corev1.Container `json:"initContainers,omitempty" yaml:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	Containers []corev1.Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
+	Containers []corev1.Container `json:"containers" yaml:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by the workspace Pod.
 	// If specified, these secrets will be passed to individual puller implementations for them to use. For example,
 	// in the case of docker, only DockerConfig type secrets are honored.
@@ -22,10 +22,10 @@ type WorkspacePodContributions struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty" yaml:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	// List of workspace-wide environment variables to set in all containers of the workspace POD.
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
-	CommonEnv []corev1.EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,7,rep,name=env"`
+	CommonEnv []corev1.EnvVar `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,7,rep,name=env"`
 }

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -29,37 +29,37 @@ const (
 
 type CommandGroup struct {
 	// Kind of group the command is part of
-	Kind CommandGroupKind `json:"kind"`
+	Kind CommandGroupKind `json:"kind" yaml:"kind"`
 
 	// +optional
 	// Identifies the default command for a given group kind
-	IsDefault bool `json:"isDefault,omitempty"`
+	IsDefault bool `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
 }
 
 type BaseCommand struct {
 	// +optional
 	// Defines the group this command is part of
-	Group *CommandGroup `json:"group,omitempty"`
+	Group *CommandGroup `json:"group,omitempty" yaml:"group,omitempty"`
 
 	// Optional map of free-form additional command attributes
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
 type LabeledCommand struct {
-	BaseCommand `json:",inline"`
+	BaseCommand `json:",inline" yaml:",inline"`
 
 	// +optional
 	// Optional label that provides a label for this command
 	// to be used in Editor UI menus for example
-	Label string `json:"label,omitempty"`
+	Label string `json:"label,omitempty" yaml:"label,omitempty"`
 }
 
 type Command struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	Id           string `json:"id"`
-	CommandUnion `json:",inline"`
+	Id           string `json:"id" yaml:"id"`
+	CommandUnion `json:",inline" yaml:",inline"`
 }
 
 // +union
@@ -67,11 +67,11 @@ type CommandUnion struct {
 	// Type of workspace command
 	// +unionDiscriminator
 	// +optional
-	CommandType CommandType `json:"commandType,omitempty"`
+	CommandType CommandType `json:"commandType,omitempty" yaml:"commandType,omitempty"`
 
 	// CLI Command executed in an existing component container
 	// +optional
-	Exec *ExecCommand `json:"exec,omitempty"`
+	Exec *ExecCommand `json:"exec,omitempty" yaml:"exec,omitempty"`
 
 	// Command that consists in applying a given component definition,
 	// typically bound to a workspace event.
@@ -85,31 +85,31 @@ type CommandUnion struct {
 	// it is assumed the component will be applied at workspace start
 	// by default.
 	// +optional
-	Apply *ApplyCommand `json:"apply,omitempty"`
+	Apply *ApplyCommand `json:"apply,omitempty" yaml:"apply,omitempty"`
 
 	// Command providing the definition of a VsCode Task
 	// +optional
-	VscodeTask *VscodeConfigurationCommand `json:"vscodeTask,omitempty"`
+	VscodeTask *VscodeConfigurationCommand `json:"vscodeTask,omitempty" yaml:"vscodeTask,omitempty"`
 
 	// Command providing the definition of a VsCode launch action
 	// +optional
-	VscodeLaunch *VscodeConfigurationCommand `json:"vscodeLaunch,omitempty"`
+	VscodeLaunch *VscodeConfigurationCommand `json:"vscodeLaunch,omitempty" yaml:"vscodeLaunch,omitempty"`
 
 	// Composite command that allows executing several sub-commands
 	// either sequentially or concurrently
 	// +optional
-	Composite *CompositeCommand `json:"composite,omitempty"`
+	Composite *CompositeCommand `json:"composite,omitempty" yaml:"composite,omitempty"`
 
 	// Custom command whose logic is implementation-dependant
 	// and should be provided by the user
 	// possibly through some dedicated plugin
 	// +optional
 	// +devfile:overrides:include:omit=true
-	Custom *CustomCommand `json:"custom,omitempty"`
+	Custom *CustomCommand `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 type ExecCommand struct {
-	LabeledCommand `json:",inline"`
+	LabeledCommand `json:",inline" yaml:",inline"`
 
 	// The actual command-line string
 	//
@@ -118,11 +118,11 @@ type ExecCommand struct {
 	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
-	CommandLine string `json:"commandLine"`
+	CommandLine string `json:"commandLine" yaml:"commandLine"`
 
 	// Describes component to which given action relates
 	//
-	Component string `json:"component"`
+	Component string `json:"component" yaml:"component"`
 
 	// Working directory where the command should be executed
 	//
@@ -132,40 +132,40 @@ type ExecCommand struct {
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
-	WorkingDir string `json:"workingDir,omitempty"`
+	WorkingDir string `json:"workingDir,omitempty" yaml:"workingDir,omitempty"`
 
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Optional list of environment variables that have to be set
 	// before running the command
-	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVar `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// Whether the command is capable to reload itself when source code changes.
 	// If set to `true` the command won't be restarted and it is expected to handle file changes on its own.
 	//
 	// Default value is `false`
-	HotReloadCapable bool `json:"hotReloadCapable,omitempty"`
+	HotReloadCapable bool `json:"hotReloadCapable,omitempty" yaml:"hotReloadCapable,omitempty"`
 }
 
 type ApplyCommand struct {
-	LabeledCommand `json:",inline"`
+	LabeledCommand `json:",inline" yaml:",inline"`
 
 	// Describes component that will be applied
 	//
-	Component string `json:"component"`
+	Component string `json:"component" yaml:"component"`
 }
 
 type CompositeCommand struct {
-	LabeledCommand `json:",inline"`
+	LabeledCommand `json:",inline" yaml:",inline"`
 
 	// The commands that comprise this composite command
-	Commands []string `json:"commands,omitempty" patchStrategy:"replace"`
+	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"replace"`
 
 	// Indicates if the sub-commands should be executed concurrently
 	// +optional
-	Parallel bool `json:"parallel,omitempty"`
+	Parallel bool `json:"parallel,omitempty" yaml:"parallel,omitempty"`
 }
 
 // VscodeConfigurationCommandLocationType describes the type of
@@ -185,34 +185,34 @@ type VscodeConfigurationCommandLocation struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType VscodeConfigurationCommandLocationType `json:"locationType,omitempty"`
+	LocationType VscodeConfigurationCommandLocationType `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location as an absolute of relative URI
 	// the VsCode configuration will be fetched from
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined content of the VsCode configuration
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 type VscodeConfigurationCommand struct {
-	BaseCommand                        `json:",inline"`
-	VscodeConfigurationCommandLocation `json:",inline"`
+	BaseCommand                        `json:",inline" yaml:",inline"`
+	VscodeConfigurationCommandLocation `json:",inline" yaml:",inline"`
 }
 
 type CustomCommand struct {
-	LabeledCommand `json:",inline"`
+	LabeledCommand `json:",inline" yaml:",inline"`
 
 	// Class of command that the associated implementation component
 	// should use to process this command with the appropriate logic
-	CommandClass string `json:"commandClass"`
+	CommandClass string `json:"commandClass" yaml:"commandClass"`
 
 	// Additional free-form configuration for this custom command
 	// that the implementation component will know how to use
 	//
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:EmbeddedResource
-	EmbeddedResource runtime.RawExtension `json:"embeddedResource"`
+	EmbeddedResource runtime.RawExtension `json:"embeddedResource" yaml:"embeddedResource"`
 }

--- a/pkg/apis/workspaces/v1alpha2/components.go
+++ b/pkg/apis/workspaces/v1alpha2/components.go
@@ -26,8 +26,8 @@ type Component struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	Name           string `json:"name"`
-	ComponentUnion `json:",inline"`
+	Name           string `json:"name" yaml:"name"`
+	ComponentUnion `json:",inline" yaml:",inline"`
 }
 
 // +union
@@ -36,30 +36,30 @@ type ComponentUnion struct {
 	//
 	// +unionDiscriminator
 	// +optional
-	ComponentType ComponentType `json:"componentType,omitempty"`
+	ComponentType ComponentType `json:"componentType,omitempty" yaml:"componentType,omitempty"`
 
 	// Allows adding and configuring workspace-related containers
 	// +optional
-	Container *ContainerComponent `json:"container,omitempty"`
+	Container *ContainerComponent `json:"container,omitempty" yaml:"container,omitempty"`
 
 	// Allows importing into the workspace the Kubernetes resources
 	// defined in a given manifest. For example this allows reusing the Kubernetes
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Kubernetes *KubernetesComponent `json:"kubernetes,omitempty"`
+	Kubernetes *KubernetesComponent `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 
 	// Allows importing into the workspace the OpenShift resources
 	// defined in a given manifest. For example this allows reusing the OpenShift
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Openshift *OpenshiftComponent `json:"openshift,omitempty"`
+	Openshift *OpenshiftComponent `json:"openshift,omitempty" yaml:"openshift,omitempty"`
 
 	// Allows specifying the definition of a volume
 	// shared by several other components
 	// +optional
-	Volume *VolumeComponent `json:"volume,omitempty"`
+	Volume *VolumeComponent `json:"volume,omitempty" yaml:"volume,omitempty"`
 
 	// Allows importing a plugin.
 	//
@@ -69,25 +69,25 @@ type ComponentUnion struct {
 	// or as `DevWorkspaceTemplate` Kubernetes Custom Resources
 	// +optional
 	// +devfile:overrides:include:omitInPlugin=true
-	Plugin *PluginComponent `json:"plugin,omitempty"`
+	Plugin *PluginComponent `json:"plugin,omitempty" yaml:"plugin,omitempty"`
 
 	// Custom component whose logic is implementation-dependant
 	// and should be provided by the user
 	// possibly through some dedicated controller
 	// +optional
 	// +devfile:overrides:include:omit=true
-	Custom *CustomComponent `json:"custom,omitempty"`
+	Custom *CustomComponent `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 type CustomComponent struct {
 	// Class of component that the associated implementation controller
 	// should use to process this command with the appropriate logic
-	ComponentClass string `json:"componentClass"`
+	ComponentClass string `json:"componentClass" yaml:"componentClass"`
 
 	// Additional free-form configuration for this custom component
 	// that the implementation controller will know how to use
 	//
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:EmbeddedResource
-	EmbeddedResource runtime.RawExtension `json:"embeddedResource"`
+	EmbeddedResource runtime.RawExtension `json:"embeddedResource" yaml:"embeddedResource"`
 }

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -2,13 +2,13 @@ package v1alpha2
 
 // Component that allows the developer to add a configured container into his workspace
 type ContainerComponent struct {
-	BaseComponent `json:",inline"`
-	Container     `json:",inline"`
-	Endpoints     []Endpoint `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponent `json:",inline" yaml:",inline"`
+	Container     `json:",inline" yaml:",inline"`
+	Endpoints     []Endpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 type Container struct {
-	Image string `json:"image"`
+	Image string `json:"image" yaml:"image"`
 
 	// +optional
 	// +patchMergeKey=name
@@ -20,52 +20,52 @@ type Container struct {
 	//  - `$PROJECTS_ROOT`
 	//
 	//  - `$PROJECT_SOURCE`
-	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVar `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// List of volumes mounts that should be mounted is this container.
-	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty" yaml:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
-	MemoryLimit string `json:"memoryLimit,omitempty"`
+	MemoryLimit string `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`
 
 	// The command to run in the dockerimage component instead of the default one provided in the image.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Command []string `json:"command,omitempty" patchStrategy:"replace"`
+	Command []string `json:"command,omitempty" yaml:"command,omitempty" patchStrategy:"replace"`
 
 	// The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Args []string `json:"args,omitempty" patchStrategy:"replace"`
+	Args []string `json:"args,omitempty" yaml:"args,omitempty" patchStrategy:"replace"`
 
 	// Toggles whether or not the project source code should
 	// be mounted in the component.
 	//
 	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
-	MountSources *bool `json:"mountSources,omitempty"`
+	MountSources *bool `json:"mountSources,omitempty" yaml:"mountSources,omitempty"`
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
 	// When omitted, the default value of /projects is used.
 	// +optional
 	// +kubebuilder:default=/projects
-	SourceMapping string `json:"sourceMapping,omitempty"`
+	SourceMapping string `json:"sourceMapping,omitempty" yaml:"sourceMapping,omitempty"`
 
 	// Specify if a container should run in its own separated pod,
 	// instead of running as part of the main development environment pod.
 	//
 	// Default value is `false`
 	// +optional
-	DedicatedPod bool `json:"dedicatedPod,omitempty"`
+	DedicatedPod bool `json:"dedicatedPod,omitempty" yaml:"dedicatedPod,omitempty"`
 }
 
 type EnvVar struct {
-	Name  string `json:"name" yaml:"name"`
-	Value string `json:"value" yaml:"value"`
+	Name  string `json:"name" yaml:"name" yaml:"name"`
+	Value string `json:"value" yaml:"value" yaml:"value"`
 }
 
 // Volume that should be mounted to a component container
@@ -73,10 +73,10 @@ type VolumeMount struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// The path in the component container where the volume should be mounted.
 	// If not path is mentioned, default path is the is `/<name>`.
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/devfile.go
+++ b/pkg/apis/workspaces/v1alpha2/devfile.go
@@ -7,7 +7,7 @@ import (
 // Devfile describes the structure of a cloud-native workspace and development environment.
 // +devfile:jsonschema:generate:omitCustomUnionMembers=true
 type Devfile struct {
-	devfile.DevfileHeader `json:",inline"`
+	devfile.DevfileHeader `json:",inline" yaml:",inline"`
 
-	DevWorkspaceTemplateSpec `json:",inline"`
+	DevWorkspaceTemplateSpec `json:",inline" yaml:",inline"`
 }

--- a/pkg/apis/workspaces/v1alpha2/devworkspaceTemplateSpec.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspaceTemplateSpec.go
@@ -5,9 +5,9 @@ package v1alpha2
 type DevWorkspaceTemplateSpec struct {
 	// Parent workspace template
 	// +optional
-	Parent *Parent `json:"parent,omitempty"`
+	Parent *Parent `json:"parent,omitempty" yaml:"parent,omitempty"`
 
-	DevWorkspaceTemplateSpecContent `json:",inline"`
+	DevWorkspaceTemplateSpecContent `json:",inline" yaml:",inline"`
 }
 
 // +devfile:overrides:generate
@@ -19,7 +19,7 @@ type DevWorkspaceTemplateSpecContent struct {
 	// +patchStrategy=merge
 	// +devfile:overrides:include:description=Overrides of components encapsulated in a parent devfile or a plugin.
 	// +devfile:toplevellist
-	Components []Component `json:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Components []Component `json:"components,omitempty" yaml:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Projects worked on in the workspace, containing names and sources locations
 	// +optional
@@ -27,7 +27,7 @@ type DevWorkspaceTemplateSpecContent struct {
 	// +patchStrategy=merge
 	// +devfile:overrides:include:omitInPlugin=true,description=Overrides of projects encapsulated in a parent devfile.
 	// +devfile:toplevellist
-	Projects []Project `json:"projects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Projects []Project `json:"projects,omitempty" yaml:"projects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// StarterProjects is a project that can be used as a starting point when bootstrapping new projects
 	// +optional
@@ -35,7 +35,7 @@ type DevWorkspaceTemplateSpecContent struct {
 	// +patchStrategy=merge
 	// +devfile:overrides:include:omitInPlugin=true,description=Overrides of starterProjects encapsulated in a parent devfile.
 	// +devfile:toplevellist
-	StarterProjects []StarterProject `json:"starterProjects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	StarterProjects []StarterProject `json:"starterProjects,omitempty" yaml:"starterProjects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Predefined, ready-to-use, workspace-related commands
 	// +optional
@@ -43,11 +43,11 @@ type DevWorkspaceTemplateSpecContent struct {
 	// +patchStrategy=merge
 	// +devfile:overrides:include:description=Overrides of commands encapsulated in a parent devfile or a plugin.
 	// +devfile:toplevellist
-	Commands []Command `json:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
+	Commands []Command `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
 
 	// Bindings of commands to events.
 	// Each command is referred-to by its name.
 	// +optional
 	// +devfile:overrides:include:omit=true
-	Events *Events `json:"events,omitempty"`
+	Events *Events `json:"events,omitempty" yaml:"events,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -7,20 +7,20 @@ import (
 
 // DevWorkspaceSpec defines the desired state of DevWorkspace
 type DevWorkspaceSpec struct {
-	Started      bool                     `json:"started"`
-	RoutingClass string                   `json:"routingClass,omitempty"`
-	Template     DevWorkspaceTemplateSpec `json:"template,omitempty"`
+	Started      bool                     `json:"started" yaml:"started"`
+	RoutingClass string                   `json:"routingClass,omitempty" yaml:"routingClass,omitempty"`
+	Template     DevWorkspaceTemplateSpec `json:"template,omitempty" yaml:"template,omitempty"`
 }
 
 // DevWorkspaceStatus defines the observed state of DevWorkspace
 type DevWorkspaceStatus struct {
 	// Id of the workspace
-	WorkspaceId string `json:"workspaceId"`
+	WorkspaceId string `json:"workspaceId" yaml:"workspaceId"`
 	// URL at which the Worksace Editor can be joined
-	IdeUrl string         `json:"ideUrl,omitempty"`
-	Phase  WorkspacePhase `json:"phase,omitempty"`
+	IdeUrl string         `json:"ideUrl,omitempty" yaml:"ideUrl,omitempty"`
+	Phase  WorkspacePhase `json:"phase,omitempty" yaml:"phase,omitempty"`
 	// Conditions represent the latest available observations of an object's state
-	Conditions []WorkspaceCondition `json:"conditions,omitempty"`
+	Conditions []WorkspaceCondition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
 }
 
 type WorkspacePhase string
@@ -37,16 +37,16 @@ const (
 // WorkspaceCondition contains details for the current condition of this workspace.
 type WorkspaceCondition struct {
 	// Type is the type of the condition.
-	Type WorkspaceConditionType `json:"type"`
+	Type WorkspaceConditionType `json:"type" yaml:"type"`
 	// Phase is the status of the condition.
 	// Can be True, False, Unknown.
-	Status corev1.ConditionStatus `json:"status"`
+	Status corev1.ConditionStatus `json:"status" yaml:"status"`
 	// Last time the condition transitioned from one status to another.
-	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" yaml:"lastTransitionTime,omitempty"`
 	// Unique, one-word, CamelCase reason for the condition's last transition.
-	Reason string `json:"reason,omitempty"`
+	Reason string `json:"reason,omitempty" yaml:"reason,omitempty"`
 	// Human-readable message indicating details about last transition.
-	Message string `json:"message,omitempty"`
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
 // Types of conditions reported by workspace
@@ -70,20 +70,20 @@ const (
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"
 // +devfile:jsonschema:generate
 type DevWorkspace struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Spec   DevWorkspaceSpec   `json:"spec,omitempty"`
-	Status DevWorkspaceStatus `json:"status,omitempty"`
+	Spec   DevWorkspaceSpec   `json:"spec,omitempty" yaml:"spec,omitempty"`
+	Status DevWorkspaceStatus `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DevWorkspaceList contains a list of DevWorkspace
 type DevWorkspaceList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []DevWorkspace `json:"items"`
+	metav1.TypeMeta `json:",inline" yaml:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Items           []DevWorkspace `json:"items" yaml:"items"`
 }
 
 func init() {

--- a/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_types.go
@@ -10,19 +10,19 @@ import (
 // +kubebuilder:resource:path=devworkspacetemplates,scope=Namespaced
 // +devfile:jsonschema:generate
 type DevWorkspaceTemplate struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Spec DevWorkspaceTemplateSpec `json:"spec,omitempty"`
+	Spec DevWorkspaceTemplateSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DevWorkspaceTemplateList contains a list of DevWorkspaceTemplate
 type DevWorkspaceTemplateList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []DevWorkspaceTemplate `json:"items"`
+	metav1.TypeMeta `json:",inline" yaml:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Items           []DevWorkspaceTemplate `json:"items" yaml:"items"`
 }
 
 func init() {

--- a/pkg/apis/workspaces/v1alpha2/endpoint.go
+++ b/pkg/apis/workspaces/v1alpha2/endpoint.go
@@ -43,9 +43,9 @@ const (
 )
 
 type Endpoint struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
-	TargetPort int `json:"targetPort"`
+	TargetPort int `json:"targetPort" yaml:"targetPort"`
 
 	// Describes how the endpoint should be exposed on the network.
 	//
@@ -62,7 +62,7 @@ type Endpoint struct {
 	// Default value is `public`
 	// +optional
 	// +kubebuilder:default=public
-	Exposure EndpointExposure `json:"exposure,omitempty"`
+	Exposure EndpointExposure `json:"exposure,omitempty" yaml:"exposure,omitempty"`
 
 	// Describes the application and transport protocols of the traffic that will go through this endpoint.
 	//
@@ -83,16 +83,16 @@ type Endpoint struct {
 	// Default value is `http`
 	// +optional
 	// +kubebuilder:default=http
-	Protocol string `json:"protocol,omitempty"`
+	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
 
 	// Describes whether the endpoint should be secured and protected by some
 	// authentication process
 	// +optional
-	Secure bool `json:"secure,omitempty"`
+	Secure bool `json:"secure,omitempty" yaml:"secure,omitempty"`
 
 	// Path of the endpoint URL
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 
 	// Map of implementation-dependant string-based free-form attributes.
 	//
@@ -102,5 +102,5 @@ type Endpoint struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/events.go
+++ b/pkg/apis/workspaces/v1alpha2/events.go
@@ -1,26 +1,26 @@
 package v1alpha2
 
 type Events struct {
-	WorkspaceEvents `json:",inline"`
+	WorkspaceEvents `json:",inline" yaml:",inline"`
 }
 
 type WorkspaceEvents struct {
 	// Names of commands that should be executed before the workspace start.
 	// Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.
 	// +optional
-	PreStart []string `json:"preStart,omitempty"`
+	PreStart []string `json:"preStart,omitempty" yaml:"preStart,omitempty"`
 
 	// Names of commands that should be executed after the workspace is completely started.
 	// In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning.
 	// This means that those commands are not triggered until the user opens the IDE in his browser.
 	// +optional
-	PostStart []string `json:"postStart,omitempty"`
+	PostStart []string `json:"postStart,omitempty" yaml:"postStart,omitempty"`
 
 	// +optional
 	// Names of commands that should be executed before stopping the workspace.
-	PreStop []string `json:"preStop,omitempty"`
+	PreStop []string `json:"preStop,omitempty" yaml:"preStop,omitempty"`
 
 	// +optional
 	// Names of commands that should be executed after stopping the workspace.
-	PostStop []string `json:"postStop,omitempty"`
+	PostStop []string `json:"postStop,omitempty" yaml:"postStop,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/importReference.go
+++ b/pkg/apis/workspaces/v1alpha2/importReference.go
@@ -19,30 +19,30 @@ type ImportReferenceUnion struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	ImportReferenceType ImportReferenceType `json:"importReferenceType,omitempty"`
+	ImportReferenceType ImportReferenceType `json:"importReferenceType,omitempty" yaml:"importReferenceType,omitempty"`
 
 	// Uri of a Devfile yaml file
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Id in a registry that contains a Devfile yaml file
 	// +optional
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" yaml:"id,omitempty"`
 
 	// Reference to a Kubernetes CRD of type DevWorkspaceTemplate
 	// +optional
-	Kubernetes *KubernetesCustomResourceImportReference `json:"kubernetes,omitempty"`
+	Kubernetes *KubernetesCustomResourceImportReference `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 }
 
 type KubernetesCustomResourceImportReference struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// +optional
-	Namespace string `json:"namespace,omitempty"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }
 
 type ImportReference struct {
-	ImportReferenceUnion `json:",inline"`
+	ImportReferenceUnion `json:",inline" yaml:",inline"`
 	// +optional
-	RegistryUrl string `json:"registryUrl,omitempty"`
+	RegistryUrl string `json:"registryUrl,omitempty" yaml:"registryUrl,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/kubernetesLikeComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/kubernetesLikeComponent.go
@@ -17,29 +17,29 @@ type K8sLikeComponentLocation struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType K8sLikeComponentLocationType `json:"locationType,omitempty"`
+	LocationType K8sLikeComponentLocationType `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location in a file fetched from a uri.
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined manifest
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 type K8sLikeComponent struct {
-	BaseComponent            `json:",inline"`
-	K8sLikeComponentLocation `json:",inline"`
-	Endpoints                []Endpoint `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponent            `json:",inline" yaml:",inline"`
+	K8sLikeComponentLocation `json:",inline" yaml:",inline"`
+	Endpoints                []Endpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Component that allows partly importing Kubernetes resources into the workspace POD
 type KubernetesComponent struct {
-	K8sLikeComponent `json:",inline"`
+	K8sLikeComponent `json:",inline" yaml:",inline"`
 }
 
 // Component that allows partly importing Openshift resources into the workspace POD
 type OpenshiftComponent struct {
-	K8sLikeComponent `json:",inline"`
+	K8sLikeComponent `json:",inline" yaml:",inline"`
 }

--- a/pkg/apis/workspaces/v1alpha2/overrideDirectives.go
+++ b/pkg/apis/workspaces/v1alpha2/overrideDirectives.go
@@ -24,7 +24,7 @@ type OverrideDirective struct {
 	// 	```
 	//
 	// the path would be: `commands["commandId"]`.
-	Path string `json:"path"`
+	Path string `json:"path" yaml:"path"`
 
 	// `$Patch` directlive as defined in
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md#basic-patch-format
@@ -36,7 +36,7 @@ type OverrideDirective struct {
 	// - *delete*: indicates that the element matched by the `jsonPath` field should be deleted.
 	//
 	// +optional
-	Patch OverridingPatchDirective `json:"patch,omitempty"`
+	Patch OverridingPatchDirective `json:"patch,omitempty" yaml:"patch,omitempty"`
 
 	// `DeleteFromPrimitiveList` directive as defined in
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md#deletefromprimitivelist-directive
@@ -44,7 +44,7 @@ type OverrideDirective struct {
 	// This indicates that the elements in this list should be deleted from the original primitive list.
 	// The original primitive list is the element matched by the `jsonPath` field.
 	// +optional
-	DeleteFromPrimitiveList []string `json:"deleteFromPrimitiveList,omitempty"`
+	DeleteFromPrimitiveList []string `json:"deleteFromPrimitiveList,omitempty" yaml:"deleteFromPrimitiveList,omitempty"`
 
 	// `SetElementOrder` directive as defined in
 	// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/strategic-merge-patch.md#deletefromprimitivelist-directive
@@ -54,5 +54,5 @@ type OverrideDirective struct {
 	// If the controller list is a list of objects, then the values in this list should be
 	// the merge keys of the objects to order.
 	// +optional
-	SetElementOrder []string `json:"setElementOrder,omitempty"`
+	SetElementOrder []string `json:"setElementOrder,omitempty" yaml:"setElementOrder,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/parent.go
+++ b/pkg/apis/workspaces/v1alpha2/parent.go
@@ -1,6 +1,6 @@
 package v1alpha2
 
 type Parent struct {
-	ImportReference `json:",inline"`
-	ParentOverrides `json:",inline"`
+	ImportReference `json:",inline" yaml:",inline"`
+	ParentOverrides `json:",inline" yaml:",inline"`
 }

--- a/pkg/apis/workspaces/v1alpha2/pluginComponents.go
+++ b/pkg/apis/workspaces/v1alpha2/pluginComponents.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 type PluginComponent struct {
-	BaseComponent   `json:",inline"`
-	ImportReference `json:",inline"`
-	PluginOverrides `json:",inline"`
+	BaseComponent   `json:",inline" yaml:",inline"`
+	ImportReference `json:",inline" yaml:",inline"`
+	PluginOverrides `json:",inline" yaml:",inline"`
 }

--- a/pkg/apis/workspaces/v1alpha2/projects.go
+++ b/pkg/apis/workspaces/v1alpha2/projects.go
@@ -4,32 +4,32 @@ import runtime "k8s.io/apimachinery/pkg/runtime"
 
 type Project struct {
 	// Project name
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
 	// +optional
-	ClonePath string `json:"clonePath,omitempty"`
+	ClonePath string `json:"clonePath,omitempty" yaml:"clonePath,omitempty"`
 
 	// Populate the project sparsely with selected directories.
 	// +optional
-	SparseCheckoutDirs []string `json:"sparseCheckoutDirs,omitempty"`
+	SparseCheckoutDirs []string `json:"sparseCheckoutDirs,omitempty" yaml:"sparseCheckoutDirs,omitempty"`
 
-	ProjectSource `json:",inline"`
+	ProjectSource `json:",inline" yaml:",inline"`
 }
 
 type StarterProject struct {
 	// Project name
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Description of a starter project
 	// +optional
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// Sub-directory from a starter project to be used as root for starter project.
 	// +optional
-	SubDir string `json:"subDir,omitempty"`
+	SubDir string `json:"subDir,omitempty" yaml:"subDir,omitempty"`
 
-	ProjectSource `json:",inline"`
+	ProjectSource `json:",inline" yaml:",inline"`
 }
 
 // ProjectSourceType describes the type of Project sources.
@@ -52,69 +52,69 @@ type ProjectSource struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	SourceType ProjectSourceType `json:"sourceType,omitempty"`
+	SourceType ProjectSourceType `json:"sourceType,omitempty" yaml:"sourceType,omitempty"`
 
 	// Project's Git source
 	// +optional
-	Git *GitProjectSource `json:"git,omitempty"`
+	Git *GitProjectSource `json:"git,omitempty" yaml:"git,omitempty"`
 
 	// Project's GitHub source
 	// +optional
-	Github *GithubProjectSource `json:"github,omitempty"`
+	Github *GithubProjectSource `json:"github,omitempty" yaml:"github,omitempty"`
 
 	// Project's Zip source
 	// +optional
-	Zip *ZipProjectSource `json:"zip,omitempty"`
+	Zip *ZipProjectSource `json:"zip,omitempty" yaml:"zip,omitempty"`
 
 	// Project's Custom source
 	// +optional
 	// +devfile:overrides:include:omit=true
-	Custom *CustomProjectSource `json:"custom,omitempty"`
+	Custom *CustomProjectSource `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 type CommonProjectSource struct {
 }
 
 type CustomProjectSource struct {
-	ProjectSourceClass string `json:"projectSourceClass"`
+	ProjectSourceClass string `json:"projectSourceClass" yaml:"projectSourceClass"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:EmbeddedResource
-	EmbeddedResource runtime.RawExtension `json:"embeddedResource"`
+	EmbeddedResource runtime.RawExtension `json:"embeddedResource" yaml:"embeddedResource"`
 }
 
 type ZipProjectSource struct {
-	CommonProjectSource `json:",inline"`
+	CommonProjectSource `json:",inline" yaml:",inline"`
 
 	// Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
 	// +required
-	Location string `json:"location,omitempty"`
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
 }
 
 type GitLikeProjectSource struct {
-	CommonProjectSource `json:",inline"`
+	CommonProjectSource `json:",inline" yaml:",inline"`
 
 	// Defines from what the project should be checked out. Required if there are more than one remote configured
 	// +optional
-	CheckoutFrom *CheckoutFrom `json:"checkoutFrom,omitempty"`
+	CheckoutFrom *CheckoutFrom `json:"checkoutFrom,omitempty" yaml:"checkoutFrom,omitempty"`
 
 	// The remotes map which should be initialized in the git project. Must have at least one remote configured
-	Remotes map[string]string `json:"remotes"`
+	Remotes map[string]string `json:"remotes" yaml:"remotes"`
 }
 
 type CheckoutFrom struct {
 	// The revision to checkout from. Should be branch name, tag or commit id.
 	// Default branch is used if missing or specified revision is not found.
 	// +optional
-	Revision string `json:"revision,omitempty"`
+	Revision string `json:"revision,omitempty" yaml:"revision,omitempty"`
 	// The remote name should be used as init. Required if there are more than one remote configured
 	// +optional
-	Remote string `json:"remote,omitempty"`
+	Remote string `json:"remote,omitempty" yaml:"remote,omitempty"`
 }
 
 type GitProjectSource struct {
-	GitLikeProjectSource `json:",inline"`
+	GitLikeProjectSource `json:",inline" yaml:",inline"`
 }
 
 type GithubProjectSource struct {
-	GitLikeProjectSource `json:",inline"`
+	GitLikeProjectSource `json:",inline" yaml:",inline"`
 }

--- a/pkg/apis/workspaces/v1alpha2/volumeComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/volumeComponent.go
@@ -2,13 +2,13 @@ package v1alpha2
 
 // Component that allows the developer to declare and configure a volume into his workspace
 type VolumeComponent struct {
-	BaseComponent `json:",inline"`
-	Volume        `json:",inline"`
+	BaseComponent `json:",inline" yaml:",inline"`
+	Volume        `json:",inline" yaml:",inline"`
 }
 
 // Volume that should be mounted to a component container
 type Volume struct {
 	// +optional
 	// Size of the volume
-	Size string `json:"size,omitempty"`
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -10,7 +10,7 @@ type ParentOverrides struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	Components []ComponentParentOverride `json:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Components []ComponentParentOverride `json:"components,omitempty" yaml:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Overrides of projects encapsulated in a parent devfile.
 	// Overriding is done according to K8S strategic merge patch standard rules.
@@ -18,7 +18,7 @@ type ParentOverrides struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	Projects []ProjectParentOverride `json:"projects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Projects []ProjectParentOverride `json:"projects,omitempty" yaml:"projects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Overrides of starterProjects encapsulated in a parent devfile.
 	// Overriding is done according to K8S strategic merge patch standard rules.
@@ -26,7 +26,7 @@ type ParentOverrides struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	StarterProjects []StarterProjectParentOverride `json:"starterProjects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	StarterProjects []StarterProjectParentOverride `json:"starterProjects,omitempty" yaml:"starterProjects,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Overrides of commands encapsulated in a parent devfile or a plugin.
 	// Overriding is done according to K8S strategic merge patch standard rules.
@@ -34,7 +34,7 @@ type ParentOverrides struct {
 	// +patchMergeKey=id
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	Commands []CommandParentOverride `json:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
+	Commands []CommandParentOverride `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
 }
 
 //+k8s:openapi-gen=true
@@ -43,40 +43,40 @@ type ComponentParentOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	Name                         string `json:"name"`
-	ComponentUnionParentOverride `json:",inline"`
+	Name                         string `json:"name" yaml:"name"`
+	ComponentUnionParentOverride `json:",inline" yaml:",inline"`
 }
 
 type ProjectParentOverride struct {
 
 	// Project name
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
 	// +optional
-	ClonePath string `json:"clonePath,omitempty"`
+	ClonePath string `json:"clonePath,omitempty" yaml:"clonePath,omitempty"`
 
 	// Populate the project sparsely with selected directories.
 	// +optional
-	SparseCheckoutDirs []string `json:"sparseCheckoutDirs,omitempty"`
+	SparseCheckoutDirs []string `json:"sparseCheckoutDirs,omitempty" yaml:"sparseCheckoutDirs,omitempty"`
 
-	ProjectSourceParentOverride `json:",inline"`
+	ProjectSourceParentOverride `json:",inline" yaml:",inline"`
 }
 
 type StarterProjectParentOverride struct {
 
 	// Project name
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Description of a starter project
 	// +optional
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// Sub-directory from a starter project to be used as root for starter project.
 	// +optional
-	SubDir string `json:"subDir,omitempty"`
+	SubDir string `json:"subDir,omitempty" yaml:"subDir,omitempty"`
 
-	ProjectSourceParentOverride `json:",inline"`
+	ProjectSourceParentOverride `json:",inline" yaml:",inline"`
 }
 
 type CommandParentOverride struct {
@@ -84,8 +84,8 @@ type CommandParentOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	Id                         string `json:"id"`
-	CommandUnionParentOverride `json:",inline"`
+	Id                         string `json:"id" yaml:"id"`
+	CommandUnionParentOverride `json:",inline" yaml:",inline"`
 }
 
 // +union
@@ -96,30 +96,30 @@ type ComponentUnionParentOverride struct {
 	//
 	// +unionDiscriminator
 	// +optional
-	ComponentType ComponentTypeParentOverride `json:"componentType,omitempty"`
+	ComponentType ComponentTypeParentOverride `json:"componentType,omitempty" yaml:"componentType,omitempty"`
 
 	// Allows adding and configuring workspace-related containers
 	// +optional
-	Container *ContainerComponentParentOverride `json:"container,omitempty"`
+	Container *ContainerComponentParentOverride `json:"container,omitempty" yaml:"container,omitempty"`
 
 	// Allows importing into the workspace the Kubernetes resources
 	// defined in a given manifest. For example this allows reusing the Kubernetes
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Kubernetes *KubernetesComponentParentOverride `json:"kubernetes,omitempty"`
+	Kubernetes *KubernetesComponentParentOverride `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 
 	// Allows importing into the workspace the OpenShift resources
 	// defined in a given manifest. For example this allows reusing the OpenShift
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Openshift *OpenshiftComponentParentOverride `json:"openshift,omitempty"`
+	Openshift *OpenshiftComponentParentOverride `json:"openshift,omitempty" yaml:"openshift,omitempty"`
 
 	// Allows specifying the definition of a volume
 	// shared by several other components
 	// +optional
-	Volume *VolumeComponentParentOverride `json:"volume,omitempty"`
+	Volume *VolumeComponentParentOverride `json:"volume,omitempty" yaml:"volume,omitempty"`
 
 	// Allows importing a plugin.
 	//
@@ -129,7 +129,7 @@ type ComponentUnionParentOverride struct {
 	// or as `DevWorkspaceTemplate` Kubernetes Custom Resources
 	// +optional
 	// +devfile:overrides:include:omitInPlugin=true
-	Plugin *PluginComponentParentOverride `json:"plugin,omitempty"`
+	Plugin *PluginComponentParentOverride `json:"plugin,omitempty" yaml:"plugin,omitempty"`
 }
 
 // +union
@@ -140,19 +140,19 @@ type ProjectSourceParentOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	SourceType ProjectSourceTypeParentOverride `json:"sourceType,omitempty"`
+	SourceType ProjectSourceTypeParentOverride `json:"sourceType,omitempty" yaml:"sourceType,omitempty"`
 
 	// Project's Git source
 	// +optional
-	Git *GitProjectSourceParentOverride `json:"git,omitempty"`
+	Git *GitProjectSourceParentOverride `json:"git,omitempty" yaml:"git,omitempty"`
 
 	// Project's GitHub source
 	// +optional
-	Github *GithubProjectSourceParentOverride `json:"github,omitempty"`
+	Github *GithubProjectSourceParentOverride `json:"github,omitempty" yaml:"github,omitempty"`
 
 	// Project's Zip source
 	// +optional
-	Zip *ZipProjectSourceParentOverride `json:"zip,omitempty"`
+	Zip *ZipProjectSourceParentOverride `json:"zip,omitempty" yaml:"zip,omitempty"`
 }
 
 // +union
@@ -162,11 +162,11 @@ type CommandUnionParentOverride struct {
 	// Type of workspace command
 	// +unionDiscriminator
 	// +optional
-	CommandType CommandTypeParentOverride `json:"commandType,omitempty"`
+	CommandType CommandTypeParentOverride `json:"commandType,omitempty" yaml:"commandType,omitempty"`
 
 	// CLI Command executed in an existing component container
 	// +optional
-	Exec *ExecCommandParentOverride `json:"exec,omitempty"`
+	Exec *ExecCommandParentOverride `json:"exec,omitempty" yaml:"exec,omitempty"`
 
 	// Command that consists in applying a given component definition,
 	// typically bound to a workspace event.
@@ -180,20 +180,20 @@ type CommandUnionParentOverride struct {
 	// it is assumed the component will be applied at workspace start
 	// by default.
 	// +optional
-	Apply *ApplyCommandParentOverride `json:"apply,omitempty"`
+	Apply *ApplyCommandParentOverride `json:"apply,omitempty" yaml:"apply,omitempty"`
 
 	// Command providing the definition of a VsCode Task
 	// +optional
-	VscodeTask *VscodeConfigurationCommandParentOverride `json:"vscodeTask,omitempty"`
+	VscodeTask *VscodeConfigurationCommandParentOverride `json:"vscodeTask,omitempty" yaml:"vscodeTask,omitempty"`
 
 	// Command providing the definition of a VsCode launch action
 	// +optional
-	VscodeLaunch *VscodeConfigurationCommandParentOverride `json:"vscodeLaunch,omitempty"`
+	VscodeLaunch *VscodeConfigurationCommandParentOverride `json:"vscodeLaunch,omitempty" yaml:"vscodeLaunch,omitempty"`
 
 	// Composite command that allows executing several sub-commands
 	// either sequentially or concurrently
 	// +optional
-	Composite *CompositeCommandParentOverride `json:"composite,omitempty"`
+	Composite *CompositeCommandParentOverride `json:"composite,omitempty" yaml:"composite,omitempty"`
 }
 
 // ComponentType describes the type of component.
@@ -202,31 +202,31 @@ type ComponentTypeParentOverride string
 
 // Component that allows the developer to add a configured container into his workspace
 type ContainerComponentParentOverride struct {
-	BaseComponentParentOverride `json:",inline"`
-	ContainerParentOverride     `json:",inline"`
-	Endpoints                   []EndpointParentOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponentParentOverride `json:",inline" yaml:",inline"`
+	ContainerParentOverride     `json:",inline" yaml:",inline"`
+	Endpoints                   []EndpointParentOverride `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Component that allows partly importing Kubernetes resources into the workspace POD
 type KubernetesComponentParentOverride struct {
-	K8sLikeComponentParentOverride `json:",inline"`
+	K8sLikeComponentParentOverride `json:",inline" yaml:",inline"`
 }
 
 // Component that allows partly importing Openshift resources into the workspace POD
 type OpenshiftComponentParentOverride struct {
-	K8sLikeComponentParentOverride `json:",inline"`
+	K8sLikeComponentParentOverride `json:",inline" yaml:",inline"`
 }
 
 // Component that allows the developer to declare and configure a volume into his workspace
 type VolumeComponentParentOverride struct {
-	BaseComponentParentOverride `json:",inline"`
-	VolumeParentOverride        `json:",inline"`
+	BaseComponentParentOverride `json:",inline" yaml:",inline"`
+	VolumeParentOverride        `json:",inline" yaml:",inline"`
 }
 
 type PluginComponentParentOverride struct {
-	BaseComponentParentOverride   `json:",inline"`
-	ImportReferenceParentOverride `json:",inline"`
-	PluginOverridesParentOverride `json:",inline"`
+	BaseComponentParentOverride   `json:",inline" yaml:",inline"`
+	ImportReferenceParentOverride `json:",inline" yaml:",inline"`
+	PluginOverridesParentOverride `json:",inline" yaml:",inline"`
 }
 
 // ProjectSourceType describes the type of Project sources.
@@ -236,19 +236,19 @@ type PluginComponentParentOverride struct {
 type ProjectSourceTypeParentOverride string
 
 type GitProjectSourceParentOverride struct {
-	GitLikeProjectSourceParentOverride `json:",inline"`
+	GitLikeProjectSourceParentOverride `json:",inline" yaml:",inline"`
 }
 
 type GithubProjectSourceParentOverride struct {
-	GitLikeProjectSourceParentOverride `json:",inline"`
+	GitLikeProjectSourceParentOverride `json:",inline" yaml:",inline"`
 }
 
 type ZipProjectSourceParentOverride struct {
-	CommonProjectSourceParentOverride `json:",inline"`
+	CommonProjectSourceParentOverride `json:",inline" yaml:",inline"`
 
 	// Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH
 	// +required
-	Location string `json:"location,omitempty"`
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
 }
 
 // CommandType describes the type of command.
@@ -256,7 +256,7 @@ type ZipProjectSourceParentOverride struct {
 type CommandTypeParentOverride string
 
 type ExecCommandParentOverride struct {
-	LabeledCommandParentOverride `json:",inline"`
+	LabeledCommandParentOverride `json:",inline" yaml:",inline"`
 
 	//  +optional
 	// The actual command-line string
@@ -266,12 +266,12 @@ type ExecCommandParentOverride struct {
 	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
-	CommandLine string `json:"commandLine,omitempty"`
+	CommandLine string `json:"commandLine,omitempty" yaml:"commandLine,omitempty"`
 
 	//  +optional
 	// Describes component to which given action relates
 	//
-	Component string `json:"component,omitempty"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
 
 	// Working directory where the command should be executed
 	//
@@ -281,46 +281,46 @@ type ExecCommandParentOverride struct {
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
-	WorkingDir string `json:"workingDir,omitempty"`
+	WorkingDir string `json:"workingDir,omitempty" yaml:"workingDir,omitempty"`
 
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Optional list of environment variables that have to be set
 	// before running the command
-	Env []EnvVarParentOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVarParentOverride `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// Whether the command is capable to reload itself when source code changes.
 	// If set to `true` the command won't be restarted and it is expected to handle file changes on its own.
 	//
 	// Default value is `false`
-	HotReloadCapable bool `json:"hotReloadCapable,omitempty"`
+	HotReloadCapable bool `json:"hotReloadCapable,omitempty" yaml:"hotReloadCapable,omitempty"`
 }
 
 type ApplyCommandParentOverride struct {
-	LabeledCommandParentOverride `json:",inline"`
+	LabeledCommandParentOverride `json:",inline" yaml:",inline"`
 
 	//  +optional
 	// Describes component that will be applied
 	//
-	Component string `json:"component,omitempty"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
 }
 
 type VscodeConfigurationCommandParentOverride struct {
-	BaseCommandParentOverride                        `json:",inline"`
-	VscodeConfigurationCommandLocationParentOverride `json:",inline"`
+	BaseCommandParentOverride                        `json:",inline" yaml:",inline"`
+	VscodeConfigurationCommandLocationParentOverride `json:",inline" yaml:",inline"`
 }
 
 type CompositeCommandParentOverride struct {
-	LabeledCommandParentOverride `json:",inline"`
+	LabeledCommandParentOverride `json:",inline" yaml:",inline"`
 
 	// The commands that comprise this composite command
-	Commands []string `json:"commands,omitempty" patchStrategy:"replace"`
+	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"replace"`
 
 	// Indicates if the sub-commands should be executed concurrently
 	// +optional
-	Parallel bool `json:"parallel,omitempty"`
+	Parallel bool `json:"parallel,omitempty" yaml:"parallel,omitempty"`
 }
 
 // Workspace component: Anything that will bring additional features / tooling / behaviour / context
@@ -330,7 +330,7 @@ type BaseComponentParentOverride struct {
 
 type ContainerParentOverride struct {
 	//  +optional
-	Image string `json:"image,omitempty"`
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
 
 	// +optional
 	// +patchMergeKey=name
@@ -342,53 +342,53 @@ type ContainerParentOverride struct {
 	//  - `$PROJECTS_ROOT`
 	//
 	//  - `$PROJECT_SOURCE`
-	Env []EnvVarParentOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVarParentOverride `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// List of volumes mounts that should be mounted is this container.
-	VolumeMounts []VolumeMountParentOverride `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	VolumeMounts []VolumeMountParentOverride `json:"volumeMounts,omitempty" yaml:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
-	MemoryLimit string `json:"memoryLimit,omitempty"`
+	MemoryLimit string `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`
 
 	// The command to run in the dockerimage component instead of the default one provided in the image.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Command []string `json:"command,omitempty" patchStrategy:"replace"`
+	Command []string `json:"command,omitempty" yaml:"command,omitempty" patchStrategy:"replace"`
 
 	// The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Args []string `json:"args,omitempty" patchStrategy:"replace"`
+	Args []string `json:"args,omitempty" yaml:"args,omitempty" patchStrategy:"replace"`
 
 	// Toggles whether or not the project source code should
 	// be mounted in the component.
 	//
 	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
-	MountSources *bool `json:"mountSources,omitempty"`
+	MountSources *bool `json:"mountSources,omitempty" yaml:"mountSources,omitempty"`
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
 	// When omitted, the default value of /projects is used.
 	// +optional
-	SourceMapping string `json:"sourceMapping,omitempty"`
+	SourceMapping string `json:"sourceMapping,omitempty" yaml:"sourceMapping,omitempty"`
 
 	// Specify if a container should run in its own separated pod,
 	// instead of running as part of the main development environment pod.
 	//
 	// Default value is `false`
 	// +optional
-	DedicatedPod bool `json:"dedicatedPod,omitempty"`
+	DedicatedPod bool `json:"dedicatedPod,omitempty" yaml:"dedicatedPod,omitempty"`
 }
 
 type EndpointParentOverride struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	//  +optional
-	TargetPort int `json:"targetPort,omitempty"`
+	TargetPort int `json:"targetPort,omitempty" yaml:"targetPort,omitempty"`
 
 	// Describes how the endpoint should be exposed on the network.
 	//
@@ -404,7 +404,7 @@ type EndpointParentOverride struct {
 	//
 	// Default value is `public`
 	// +optional
-	Exposure EndpointExposureParentOverride `json:"exposure,omitempty"`
+	Exposure EndpointExposureParentOverride `json:"exposure,omitempty" yaml:"exposure,omitempty"`
 
 	// Describes the application and transport protocols of the traffic that will go through this endpoint.
 	//
@@ -424,16 +424,16 @@ type EndpointParentOverride struct {
 	//
 	// Default value is `http`
 	// +optional
-	Protocol string `json:"protocol,omitempty"`
+	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
 
 	// Describes whether the endpoint should be secured and protected by some
 	// authentication process
 	// +optional
-	Secure bool `json:"secure,omitempty"`
+	Secure bool `json:"secure,omitempty" yaml:"secure,omitempty"`
 
 	// Path of the endpoint URL
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 
 	// Map of implementation-dependant string-based free-form attributes.
 	//
@@ -443,13 +443,13 @@ type EndpointParentOverride struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
 type K8sLikeComponentParentOverride struct {
-	BaseComponentParentOverride            `json:",inline"`
-	K8sLikeComponentLocationParentOverride `json:",inline"`
-	Endpoints                              []EndpointParentOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponentParentOverride            `json:",inline" yaml:",inline"`
+	K8sLikeComponentLocationParentOverride `json:",inline" yaml:",inline"`
+	Endpoints                              []EndpointParentOverride `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Volume that should be mounted to a component container
@@ -457,14 +457,14 @@ type VolumeParentOverride struct {
 
 	// +optional
 	// Size of the volume
-	Size string `json:"size,omitempty"`
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
 }
 
 type ImportReferenceParentOverride struct {
-	ImportReferenceUnionParentOverride `json:",inline"`
+	ImportReferenceUnionParentOverride `json:",inline" yaml:",inline"`
 
 	// +optional
-	RegistryUrl string `json:"registryUrl,omitempty"`
+	RegistryUrl string `json:"registryUrl,omitempty" yaml:"registryUrl,omitempty"`
 }
 
 type PluginOverridesParentOverride struct {
@@ -476,7 +476,7 @@ type PluginOverridesParentOverride struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	Components []ComponentPluginOverrideParentOverride `json:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Components []ComponentPluginOverrideParentOverride `json:"components,omitempty" yaml:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Overrides of commands encapsulated in a parent devfile or a plugin.
 	// Overriding is done according to K8S strategic merge patch standard rules.
@@ -484,47 +484,47 @@ type PluginOverridesParentOverride struct {
 	// +patchMergeKey=id
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	Commands []CommandPluginOverrideParentOverride `json:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
+	Commands []CommandPluginOverrideParentOverride `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
 }
 
 type GitLikeProjectSourceParentOverride struct {
-	CommonProjectSourceParentOverride `json:",inline"`
+	CommonProjectSourceParentOverride `json:",inline" yaml:",inline"`
 
 	// Defines from what the project should be checked out. Required if there are more than one remote configured
 	// +optional
-	CheckoutFrom *CheckoutFromParentOverride `json:"checkoutFrom,omitempty"`
+	CheckoutFrom *CheckoutFromParentOverride `json:"checkoutFrom,omitempty" yaml:"checkoutFrom,omitempty"`
 
 	//  +optional
 	// The remotes map which should be initialized in the git project. Must have at least one remote configured
-	Remotes map[string]string `json:"remotes,omitempty"`
+	Remotes map[string]string `json:"remotes,omitempty" yaml:"remotes,omitempty"`
 }
 
 type CommonProjectSourceParentOverride struct {
 }
 
 type LabeledCommandParentOverride struct {
-	BaseCommandParentOverride `json:",inline"`
+	BaseCommandParentOverride `json:",inline" yaml:",inline"`
 
 	// +optional
 	// Optional label that provides a label for this command
 	// to be used in Editor UI menus for example
-	Label string `json:"label,omitempty"`
+	Label string `json:"label,omitempty" yaml:"label,omitempty"`
 }
 
 type EnvVarParentOverride struct {
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name" yaml:"name"`
 	//  +optional
-	Value string `json:"value,omitempty" yaml:"value"`
+	Value string `json:"value,omitempty" yaml:"value,omitempty" yaml:"value"`
 }
 
 type BaseCommandParentOverride struct {
 
 	// +optional
 	// Defines the group this command is part of
-	Group *CommandGroupParentOverride `json:"group,omitempty"`
+	Group *CommandGroupParentOverride `json:"group,omitempty" yaml:"group,omitempty"`
 
 	// Optional map of free-form additional command attributes
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
 // +union
@@ -535,16 +535,16 @@ type VscodeConfigurationCommandLocationParentOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType VscodeConfigurationCommandLocationTypeParentOverride `json:"locationType,omitempty"`
+	LocationType VscodeConfigurationCommandLocationTypeParentOverride `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location as an absolute of relative URI
 	// the VsCode configuration will be fetched from
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined content of the VsCode configuration
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 // Volume that should be mounted to a component container
@@ -553,12 +553,12 @@ type VolumeMountParentOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// The path in the component container where the volume should be mounted.
 	// If not path is mentioned, default path is the is `/<name>`.
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 // EndpointExposure describes the way an endpoint is exposed on the network.
@@ -574,15 +574,15 @@ type K8sLikeComponentLocationParentOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType K8sLikeComponentLocationTypeParentOverride `json:"locationType,omitempty"`
+	LocationType K8sLikeComponentLocationTypeParentOverride `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location in a file fetched from a uri.
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined manifest
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 // Location from where the an import reference is retrieved
@@ -594,19 +594,19 @@ type ImportReferenceUnionParentOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	ImportReferenceType ImportReferenceTypeParentOverride `json:"importReferenceType,omitempty"`
+	ImportReferenceType ImportReferenceTypeParentOverride `json:"importReferenceType,omitempty" yaml:"importReferenceType,omitempty"`
 
 	// Uri of a Devfile yaml file
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Id in a registry that contains a Devfile yaml file
 	// +optional
-	Id string `json:"id,omitempty"`
+	Id string `json:"id,omitempty" yaml:"id,omitempty"`
 
 	// Reference to a Kubernetes CRD of type DevWorkspaceTemplate
 	// +optional
-	Kubernetes *KubernetesCustomResourceImportReferenceParentOverride `json:"kubernetes,omitempty"`
+	Kubernetes *KubernetesCustomResourceImportReferenceParentOverride `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 }
 
 // OverridesBase is used in the Overrides generator in order to provide a common base for the generated Overrides
@@ -619,8 +619,8 @@ type ComponentPluginOverrideParentOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	Name                                       string `json:"name"`
-	ComponentUnionPluginOverrideParentOverride `json:",inline"`
+	Name                                       string `json:"name" yaml:"name"`
+	ComponentUnionPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 }
 
 type CommandPluginOverrideParentOverride struct {
@@ -628,8 +628,8 @@ type CommandPluginOverrideParentOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	Id                                       string `json:"id"`
-	CommandUnionPluginOverrideParentOverride `json:",inline"`
+	Id                                       string `json:"id" yaml:"id"`
+	CommandUnionPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 }
 
 type CheckoutFromParentOverride struct {
@@ -637,22 +637,22 @@ type CheckoutFromParentOverride struct {
 	// The revision to checkout from. Should be branch name, tag or commit id.
 	// Default branch is used if missing or specified revision is not found.
 	// +optional
-	Revision string `json:"revision,omitempty"`
+	Revision string `json:"revision,omitempty" yaml:"revision,omitempty"`
 
 	// The remote name should be used as init. Required if there are more than one remote configured
 	// +optional
-	Remote string `json:"remote,omitempty"`
+	Remote string `json:"remote,omitempty" yaml:"remote,omitempty"`
 }
 
 type CommandGroupParentOverride struct {
 
 	//  +optional
 	// Kind of group the command is part of
-	Kind CommandGroupKindParentOverride `json:"kind,omitempty"`
+	Kind CommandGroupKindParentOverride `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	// +optional
 	// Identifies the default command for a given group kind
-	IsDefault bool `json:"isDefault,omitempty"`
+	IsDefault bool `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
 }
 
 // VscodeConfigurationCommandLocationType describes the type of
@@ -672,10 +672,10 @@ type ImportReferenceTypeParentOverride string
 
 type KubernetesCustomResourceImportReferenceParentOverride struct {
 	//  +optional
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// +optional
-	Namespace string `json:"namespace,omitempty"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 }
 
 // +union
@@ -686,30 +686,30 @@ type ComponentUnionPluginOverrideParentOverride struct {
 	//
 	// +unionDiscriminator
 	// +optional
-	ComponentType ComponentTypePluginOverrideParentOverride `json:"componentType,omitempty"`
+	ComponentType ComponentTypePluginOverrideParentOverride `json:"componentType,omitempty" yaml:"componentType,omitempty"`
 
 	// Allows adding and configuring workspace-related containers
 	// +optional
-	Container *ContainerComponentPluginOverrideParentOverride `json:"container,omitempty"`
+	Container *ContainerComponentPluginOverrideParentOverride `json:"container,omitempty" yaml:"container,omitempty"`
 
 	// Allows importing into the workspace the Kubernetes resources
 	// defined in a given manifest. For example this allows reusing the Kubernetes
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Kubernetes *KubernetesComponentPluginOverrideParentOverride `json:"kubernetes,omitempty"`
+	Kubernetes *KubernetesComponentPluginOverrideParentOverride `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 
 	// Allows importing into the workspace the OpenShift resources
 	// defined in a given manifest. For example this allows reusing the OpenShift
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Openshift *OpenshiftComponentPluginOverrideParentOverride `json:"openshift,omitempty"`
+	Openshift *OpenshiftComponentPluginOverrideParentOverride `json:"openshift,omitempty" yaml:"openshift,omitempty"`
 
 	// Allows specifying the definition of a volume
 	// shared by several other components
 	// +optional
-	Volume *VolumeComponentPluginOverrideParentOverride `json:"volume,omitempty"`
+	Volume *VolumeComponentPluginOverrideParentOverride `json:"volume,omitempty" yaml:"volume,omitempty"`
 }
 
 // +union
@@ -719,11 +719,11 @@ type CommandUnionPluginOverrideParentOverride struct {
 	// Type of workspace command
 	// +unionDiscriminator
 	// +optional
-	CommandType CommandTypePluginOverrideParentOverride `json:"commandType,omitempty"`
+	CommandType CommandTypePluginOverrideParentOverride `json:"commandType,omitempty" yaml:"commandType,omitempty"`
 
 	// CLI Command executed in an existing component container
 	// +optional
-	Exec *ExecCommandPluginOverrideParentOverride `json:"exec,omitempty"`
+	Exec *ExecCommandPluginOverrideParentOverride `json:"exec,omitempty" yaml:"exec,omitempty"`
 
 	// Command that consists in applying a given component definition,
 	// typically bound to a workspace event.
@@ -737,20 +737,20 @@ type CommandUnionPluginOverrideParentOverride struct {
 	// it is assumed the component will be applied at workspace start
 	// by default.
 	// +optional
-	Apply *ApplyCommandPluginOverrideParentOverride `json:"apply,omitempty"`
+	Apply *ApplyCommandPluginOverrideParentOverride `json:"apply,omitempty" yaml:"apply,omitempty"`
 
 	// Command providing the definition of a VsCode Task
 	// +optional
-	VscodeTask *VscodeConfigurationCommandPluginOverrideParentOverride `json:"vscodeTask,omitempty"`
+	VscodeTask *VscodeConfigurationCommandPluginOverrideParentOverride `json:"vscodeTask,omitempty" yaml:"vscodeTask,omitempty"`
 
 	// Command providing the definition of a VsCode launch action
 	// +optional
-	VscodeLaunch *VscodeConfigurationCommandPluginOverrideParentOverride `json:"vscodeLaunch,omitempty"`
+	VscodeLaunch *VscodeConfigurationCommandPluginOverrideParentOverride `json:"vscodeLaunch,omitempty" yaml:"vscodeLaunch,omitempty"`
 
 	// Composite command that allows executing several sub-commands
 	// either sequentially or concurrently
 	// +optional
-	Composite *CompositeCommandPluginOverrideParentOverride `json:"composite,omitempty"`
+	Composite *CompositeCommandPluginOverrideParentOverride `json:"composite,omitempty" yaml:"composite,omitempty"`
 }
 
 // CommandGroupKind describes the kind of command group.
@@ -763,25 +763,25 @@ type ComponentTypePluginOverrideParentOverride string
 
 // Component that allows the developer to add a configured container into his workspace
 type ContainerComponentPluginOverrideParentOverride struct {
-	BaseComponentPluginOverrideParentOverride `json:",inline"`
-	ContainerPluginOverrideParentOverride     `json:",inline"`
-	Endpoints                                 []EndpointPluginOverrideParentOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponentPluginOverrideParentOverride `json:",inline" yaml:",inline"`
+	ContainerPluginOverrideParentOverride     `json:",inline" yaml:",inline"`
+	Endpoints                                 []EndpointPluginOverrideParentOverride `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Component that allows partly importing Kubernetes resources into the workspace POD
 type KubernetesComponentPluginOverrideParentOverride struct {
-	K8sLikeComponentPluginOverrideParentOverride `json:",inline"`
+	K8sLikeComponentPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 }
 
 // Component that allows partly importing Openshift resources into the workspace POD
 type OpenshiftComponentPluginOverrideParentOverride struct {
-	K8sLikeComponentPluginOverrideParentOverride `json:",inline"`
+	K8sLikeComponentPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 }
 
 // Component that allows the developer to declare and configure a volume into his workspace
 type VolumeComponentPluginOverrideParentOverride struct {
-	BaseComponentPluginOverrideParentOverride `json:",inline"`
-	VolumePluginOverrideParentOverride        `json:",inline"`
+	BaseComponentPluginOverrideParentOverride `json:",inline" yaml:",inline"`
+	VolumePluginOverrideParentOverride        `json:",inline" yaml:",inline"`
 }
 
 // CommandType describes the type of command.
@@ -789,7 +789,7 @@ type VolumeComponentPluginOverrideParentOverride struct {
 type CommandTypePluginOverrideParentOverride string
 
 type ExecCommandPluginOverrideParentOverride struct {
-	LabeledCommandPluginOverrideParentOverride `json:",inline"`
+	LabeledCommandPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 
 	//  +optional
 	// The actual command-line string
@@ -799,12 +799,12 @@ type ExecCommandPluginOverrideParentOverride struct {
 	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
-	CommandLine string `json:"commandLine,omitempty"`
+	CommandLine string `json:"commandLine,omitempty" yaml:"commandLine,omitempty"`
 
 	//  +optional
 	// Describes component to which given action relates
 	//
-	Component string `json:"component,omitempty"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
 
 	// Working directory where the command should be executed
 	//
@@ -814,46 +814,46 @@ type ExecCommandPluginOverrideParentOverride struct {
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
-	WorkingDir string `json:"workingDir,omitempty"`
+	WorkingDir string `json:"workingDir,omitempty" yaml:"workingDir,omitempty"`
 
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Optional list of environment variables that have to be set
 	// before running the command
-	Env []EnvVarPluginOverrideParentOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVarPluginOverrideParentOverride `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// Whether the command is capable to reload itself when source code changes.
 	// If set to `true` the command won't be restarted and it is expected to handle file changes on its own.
 	//
 	// Default value is `false`
-	HotReloadCapable bool `json:"hotReloadCapable,omitempty"`
+	HotReloadCapable bool `json:"hotReloadCapable,omitempty" yaml:"hotReloadCapable,omitempty"`
 }
 
 type ApplyCommandPluginOverrideParentOverride struct {
-	LabeledCommandPluginOverrideParentOverride `json:",inline"`
+	LabeledCommandPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 
 	//  +optional
 	// Describes component that will be applied
 	//
-	Component string `json:"component,omitempty"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
 }
 
 type VscodeConfigurationCommandPluginOverrideParentOverride struct {
-	BaseCommandPluginOverrideParentOverride                        `json:",inline"`
-	VscodeConfigurationCommandLocationPluginOverrideParentOverride `json:",inline"`
+	BaseCommandPluginOverrideParentOverride                        `json:",inline" yaml:",inline"`
+	VscodeConfigurationCommandLocationPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 }
 
 type CompositeCommandPluginOverrideParentOverride struct {
-	LabeledCommandPluginOverrideParentOverride `json:",inline"`
+	LabeledCommandPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 
 	// The commands that comprise this composite command
-	Commands []string `json:"commands,omitempty" patchStrategy:"replace"`
+	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"replace"`
 
 	// Indicates if the sub-commands should be executed concurrently
 	// +optional
-	Parallel bool `json:"parallel,omitempty"`
+	Parallel bool `json:"parallel,omitempty" yaml:"parallel,omitempty"`
 }
 
 // Workspace component: Anything that will bring additional features / tooling / behaviour / context
@@ -864,7 +864,7 @@ type BaseComponentPluginOverrideParentOverride struct {
 type ContainerPluginOverrideParentOverride struct {
 
 	//  +optional
-	Image string `json:"image,omitempty"`
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
 
 	// +optional
 	// +patchMergeKey=name
@@ -876,53 +876,53 @@ type ContainerPluginOverrideParentOverride struct {
 	//  - `$PROJECTS_ROOT`
 	//
 	//  - `$PROJECT_SOURCE`
-	Env []EnvVarPluginOverrideParentOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVarPluginOverrideParentOverride `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// List of volumes mounts that should be mounted is this container.
-	VolumeMounts []VolumeMountPluginOverrideParentOverride `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	VolumeMounts []VolumeMountPluginOverrideParentOverride `json:"volumeMounts,omitempty" yaml:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
-	MemoryLimit string `json:"memoryLimit,omitempty"`
+	MemoryLimit string `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`
 
 	// The command to run in the dockerimage component instead of the default one provided in the image.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Command []string `json:"command,omitempty" patchStrategy:"replace"`
+	Command []string `json:"command,omitempty" yaml:"command,omitempty" patchStrategy:"replace"`
 
 	// The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Args []string `json:"args,omitempty" patchStrategy:"replace"`
+	Args []string `json:"args,omitempty" yaml:"args,omitempty" patchStrategy:"replace"`
 
 	// Toggles whether or not the project source code should
 	// be mounted in the component.
 	//
 	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
-	MountSources *bool `json:"mountSources,omitempty"`
+	MountSources *bool `json:"mountSources,omitempty" yaml:"mountSources,omitempty"`
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
 	// When omitted, the default value of /projects is used.
 	// +optional
-	SourceMapping string `json:"sourceMapping,omitempty"`
+	SourceMapping string `json:"sourceMapping,omitempty" yaml:"sourceMapping,omitempty"`
 
 	// Specify if a container should run in its own separated pod,
 	// instead of running as part of the main development environment pod.
 	//
 	// Default value is `false`
 	// +optional
-	DedicatedPod bool `json:"dedicatedPod,omitempty"`
+	DedicatedPod bool `json:"dedicatedPod,omitempty" yaml:"dedicatedPod,omitempty"`
 }
 
 type EndpointPluginOverrideParentOverride struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	//  +optional
-	TargetPort int `json:"targetPort,omitempty"`
+	TargetPort int `json:"targetPort,omitempty" yaml:"targetPort,omitempty"`
 
 	// Describes how the endpoint should be exposed on the network.
 	//
@@ -938,7 +938,7 @@ type EndpointPluginOverrideParentOverride struct {
 	//
 	// Default value is `public`
 	// +optional
-	Exposure EndpointExposurePluginOverrideParentOverride `json:"exposure,omitempty"`
+	Exposure EndpointExposurePluginOverrideParentOverride `json:"exposure,omitempty" yaml:"exposure,omitempty"`
 
 	// Describes the application and transport protocols of the traffic that will go through this endpoint.
 	//
@@ -958,16 +958,16 @@ type EndpointPluginOverrideParentOverride struct {
 	//
 	// Default value is `http`
 	// +optional
-	Protocol string `json:"protocol,omitempty"`
+	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
 
 	// Describes whether the endpoint should be secured and protected by some
 	// authentication process
 	// +optional
-	Secure bool `json:"secure,omitempty"`
+	Secure bool `json:"secure,omitempty" yaml:"secure,omitempty"`
 
 	// Path of the endpoint URL
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 
 	// Map of implementation-dependant string-based free-form attributes.
 	//
@@ -977,13 +977,13 @@ type EndpointPluginOverrideParentOverride struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
 type K8sLikeComponentPluginOverrideParentOverride struct {
-	BaseComponentPluginOverrideParentOverride            `json:",inline"`
-	K8sLikeComponentLocationPluginOverrideParentOverride `json:",inline"`
-	Endpoints                                            []EndpointPluginOverrideParentOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponentPluginOverrideParentOverride            `json:",inline" yaml:",inline"`
+	K8sLikeComponentLocationPluginOverrideParentOverride `json:",inline" yaml:",inline"`
+	Endpoints                                            []EndpointPluginOverrideParentOverride `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Volume that should be mounted to a component container
@@ -991,33 +991,33 @@ type VolumePluginOverrideParentOverride struct {
 
 	// +optional
 	// Size of the volume
-	Size string `json:"size,omitempty"`
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
 }
 
 type LabeledCommandPluginOverrideParentOverride struct {
-	BaseCommandPluginOverrideParentOverride `json:",inline"`
+	BaseCommandPluginOverrideParentOverride `json:",inline" yaml:",inline"`
 
 	// +optional
 	// Optional label that provides a label for this command
 	// to be used in Editor UI menus for example
-	Label string `json:"label,omitempty"`
+	Label string `json:"label,omitempty" yaml:"label,omitempty"`
 }
 
 type EnvVarPluginOverrideParentOverride struct {
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name" yaml:"name"`
 
 	//  +optional
-	Value string `json:"value,omitempty" yaml:"value"`
+	Value string `json:"value,omitempty" yaml:"value,omitempty" yaml:"value"`
 }
 
 type BaseCommandPluginOverrideParentOverride struct {
 
 	// +optional
 	// Defines the group this command is part of
-	Group *CommandGroupPluginOverrideParentOverride `json:"group,omitempty"`
+	Group *CommandGroupPluginOverrideParentOverride `json:"group,omitempty" yaml:"group,omitempty"`
 
 	// Optional map of free-form additional command attributes
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
 // +union
@@ -1028,16 +1028,16 @@ type VscodeConfigurationCommandLocationPluginOverrideParentOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType VscodeConfigurationCommandLocationTypePluginOverrideParentOverride `json:"locationType,omitempty"`
+	LocationType VscodeConfigurationCommandLocationTypePluginOverrideParentOverride `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location as an absolute of relative URI
 	// the VsCode configuration will be fetched from
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined content of the VsCode configuration
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 // Volume that should be mounted to a component container
@@ -1046,12 +1046,12 @@ type VolumeMountPluginOverrideParentOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// The path in the component container where the volume should be mounted.
 	// If not path is mentioned, default path is the is `/<name>`.
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 // EndpointExposure describes the way an endpoint is exposed on the network.
@@ -1067,26 +1067,26 @@ type K8sLikeComponentLocationPluginOverrideParentOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType K8sLikeComponentLocationTypePluginOverrideParentOverride `json:"locationType,omitempty"`
+	LocationType K8sLikeComponentLocationTypePluginOverrideParentOverride `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location in a file fetched from a uri.
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined manifest
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 type CommandGroupPluginOverrideParentOverride struct {
 
 	//  +optional
 	// Kind of group the command is part of
-	Kind CommandGroupKindPluginOverrideParentOverride `json:"kind,omitempty"`
+	Kind CommandGroupKindPluginOverrideParentOverride `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	// +optional
 	// Identifies the default command for a given group kind
-	IsDefault bool `json:"isDefault,omitempty"`
+	IsDefault bool `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
 }
 
 // VscodeConfigurationCommandLocationType describes the type of

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -10,7 +10,7 @@ type PluginOverrides struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	Components []ComponentPluginOverride `json:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Components []ComponentPluginOverride `json:"components,omitempty" yaml:"components,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// Overrides of commands encapsulated in a parent devfile or a plugin.
 	// Overriding is done according to K8S strategic merge patch standard rules.
@@ -18,7 +18,7 @@ type PluginOverrides struct {
 	// +patchMergeKey=id
 	// +patchStrategy=merge
 	// +devfile:toplevellist
-	Commands []CommandPluginOverride `json:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
+	Commands []CommandPluginOverride `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
 }
 
 //+k8s:openapi-gen=true
@@ -27,8 +27,8 @@ type ComponentPluginOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	Name                         string `json:"name"`
-	ComponentUnionPluginOverride `json:",inline"`
+	Name                         string `json:"name" yaml:"name"`
+	ComponentUnionPluginOverride `json:",inline" yaml:",inline"`
 }
 
 type CommandPluginOverride struct {
@@ -36,8 +36,8 @@ type CommandPluginOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	Id                         string `json:"id"`
-	CommandUnionPluginOverride `json:",inline"`
+	Id                         string `json:"id" yaml:"id"`
+	CommandUnionPluginOverride `json:",inline" yaml:",inline"`
 }
 
 // +union
@@ -48,30 +48,30 @@ type ComponentUnionPluginOverride struct {
 	//
 	// +unionDiscriminator
 	// +optional
-	ComponentType ComponentTypePluginOverride `json:"componentType,omitempty"`
+	ComponentType ComponentTypePluginOverride `json:"componentType,omitempty" yaml:"componentType,omitempty"`
 
 	// Allows adding and configuring workspace-related containers
 	// +optional
-	Container *ContainerComponentPluginOverride `json:"container,omitempty"`
+	Container *ContainerComponentPluginOverride `json:"container,omitempty" yaml:"container,omitempty"`
 
 	// Allows importing into the workspace the Kubernetes resources
 	// defined in a given manifest. For example this allows reusing the Kubernetes
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Kubernetes *KubernetesComponentPluginOverride `json:"kubernetes,omitempty"`
+	Kubernetes *KubernetesComponentPluginOverride `json:"kubernetes,omitempty" yaml:"kubernetes,omitempty"`
 
 	// Allows importing into the workspace the OpenShift resources
 	// defined in a given manifest. For example this allows reusing the OpenShift
 	// definitions used to deploy some runtime components in production.
 	//
 	// +optional
-	Openshift *OpenshiftComponentPluginOverride `json:"openshift,omitempty"`
+	Openshift *OpenshiftComponentPluginOverride `json:"openshift,omitempty" yaml:"openshift,omitempty"`
 
 	// Allows specifying the definition of a volume
 	// shared by several other components
 	// +optional
-	Volume *VolumeComponentPluginOverride `json:"volume,omitempty"`
+	Volume *VolumeComponentPluginOverride `json:"volume,omitempty" yaml:"volume,omitempty"`
 }
 
 // +union
@@ -81,11 +81,11 @@ type CommandUnionPluginOverride struct {
 	// Type of workspace command
 	// +unionDiscriminator
 	// +optional
-	CommandType CommandTypePluginOverride `json:"commandType,omitempty"`
+	CommandType CommandTypePluginOverride `json:"commandType,omitempty" yaml:"commandType,omitempty"`
 
 	// CLI Command executed in an existing component container
 	// +optional
-	Exec *ExecCommandPluginOverride `json:"exec,omitempty"`
+	Exec *ExecCommandPluginOverride `json:"exec,omitempty" yaml:"exec,omitempty"`
 
 	// Command that consists in applying a given component definition,
 	// typically bound to a workspace event.
@@ -99,20 +99,20 @@ type CommandUnionPluginOverride struct {
 	// it is assumed the component will be applied at workspace start
 	// by default.
 	// +optional
-	Apply *ApplyCommandPluginOverride `json:"apply,omitempty"`
+	Apply *ApplyCommandPluginOverride `json:"apply,omitempty" yaml:"apply,omitempty"`
 
 	// Command providing the definition of a VsCode Task
 	// +optional
-	VscodeTask *VscodeConfigurationCommandPluginOverride `json:"vscodeTask,omitempty"`
+	VscodeTask *VscodeConfigurationCommandPluginOverride `json:"vscodeTask,omitempty" yaml:"vscodeTask,omitempty"`
 
 	// Command providing the definition of a VsCode launch action
 	// +optional
-	VscodeLaunch *VscodeConfigurationCommandPluginOverride `json:"vscodeLaunch,omitempty"`
+	VscodeLaunch *VscodeConfigurationCommandPluginOverride `json:"vscodeLaunch,omitempty" yaml:"vscodeLaunch,omitempty"`
 
 	// Composite command that allows executing several sub-commands
 	// either sequentially or concurrently
 	// +optional
-	Composite *CompositeCommandPluginOverride `json:"composite,omitempty"`
+	Composite *CompositeCommandPluginOverride `json:"composite,omitempty" yaml:"composite,omitempty"`
 }
 
 // ComponentType describes the type of component.
@@ -121,25 +121,25 @@ type ComponentTypePluginOverride string
 
 // Component that allows the developer to add a configured container into his workspace
 type ContainerComponentPluginOverride struct {
-	BaseComponentPluginOverride `json:",inline"`
-	ContainerPluginOverride     `json:",inline"`
-	Endpoints                   []EndpointPluginOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponentPluginOverride `json:",inline" yaml:",inline"`
+	ContainerPluginOverride     `json:",inline" yaml:",inline"`
+	Endpoints                   []EndpointPluginOverride `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Component that allows partly importing Kubernetes resources into the workspace POD
 type KubernetesComponentPluginOverride struct {
-	K8sLikeComponentPluginOverride `json:",inline"`
+	K8sLikeComponentPluginOverride `json:",inline" yaml:",inline"`
 }
 
 // Component that allows partly importing Openshift resources into the workspace POD
 type OpenshiftComponentPluginOverride struct {
-	K8sLikeComponentPluginOverride `json:",inline"`
+	K8sLikeComponentPluginOverride `json:",inline" yaml:",inline"`
 }
 
 // Component that allows the developer to declare and configure a volume into his workspace
 type VolumeComponentPluginOverride struct {
-	BaseComponentPluginOverride `json:",inline"`
-	VolumePluginOverride        `json:",inline"`
+	BaseComponentPluginOverride `json:",inline" yaml:",inline"`
+	VolumePluginOverride        `json:",inline" yaml:",inline"`
 }
 
 // CommandType describes the type of command.
@@ -147,7 +147,7 @@ type VolumeComponentPluginOverride struct {
 type CommandTypePluginOverride string
 
 type ExecCommandPluginOverride struct {
-	LabeledCommandPluginOverride `json:",inline"`
+	LabeledCommandPluginOverride `json:",inline" yaml:",inline"`
 
 	//  +optional
 	// The actual command-line string
@@ -157,12 +157,12 @@ type ExecCommandPluginOverride struct {
 	//  - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
-	CommandLine string `json:"commandLine,omitempty"`
+	CommandLine string `json:"commandLine,omitempty" yaml:"commandLine,omitempty"`
 
 	//  +optional
 	// Describes component to which given action relates
 	//
-	Component string `json:"component,omitempty"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
 
 	// Working directory where the command should be executed
 	//
@@ -172,46 +172,46 @@ type ExecCommandPluginOverride struct {
 	//
 	//  - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/<project-name>). If there are multiple projects, this will point to the directory of the first one.
 	// +optional
-	WorkingDir string `json:"workingDir,omitempty"`
+	WorkingDir string `json:"workingDir,omitempty" yaml:"workingDir,omitempty"`
 
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// Optional list of environment variables that have to be set
 	// before running the command
-	Env []EnvVarPluginOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVarPluginOverride `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// Whether the command is capable to reload itself when source code changes.
 	// If set to `true` the command won't be restarted and it is expected to handle file changes on its own.
 	//
 	// Default value is `false`
-	HotReloadCapable bool `json:"hotReloadCapable,omitempty"`
+	HotReloadCapable bool `json:"hotReloadCapable,omitempty" yaml:"hotReloadCapable,omitempty"`
 }
 
 type ApplyCommandPluginOverride struct {
-	LabeledCommandPluginOverride `json:",inline"`
+	LabeledCommandPluginOverride `json:",inline" yaml:",inline"`
 
 	//  +optional
 	// Describes component that will be applied
 	//
-	Component string `json:"component,omitempty"`
+	Component string `json:"component,omitempty" yaml:"component,omitempty"`
 }
 
 type VscodeConfigurationCommandPluginOverride struct {
-	BaseCommandPluginOverride                        `json:",inline"`
-	VscodeConfigurationCommandLocationPluginOverride `json:",inline"`
+	BaseCommandPluginOverride                        `json:",inline" yaml:",inline"`
+	VscodeConfigurationCommandLocationPluginOverride `json:",inline" yaml:",inline"`
 }
 
 type CompositeCommandPluginOverride struct {
-	LabeledCommandPluginOverride `json:",inline"`
+	LabeledCommandPluginOverride `json:",inline" yaml:",inline"`
 
 	// The commands that comprise this composite command
-	Commands []string `json:"commands,omitempty" patchStrategy:"replace"`
+	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty" patchStrategy:"replace"`
 
 	// Indicates if the sub-commands should be executed concurrently
 	// +optional
-	Parallel bool `json:"parallel,omitempty"`
+	Parallel bool `json:"parallel,omitempty" yaml:"parallel,omitempty"`
 }
 
 // Workspace component: Anything that will bring additional features / tooling / behaviour / context
@@ -221,7 +221,7 @@ type BaseComponentPluginOverride struct {
 
 type ContainerPluginOverride struct {
 	//  +optional
-	Image string `json:"image,omitempty"`
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
 
 	// +optional
 	// +patchMergeKey=name
@@ -233,53 +233,53 @@ type ContainerPluginOverride struct {
 	//  - `$PROJECTS_ROOT`
 	//
 	//  - `$PROJECT_SOURCE`
-	Env []EnvVarPluginOverride `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	Env []EnvVarPluginOverride `json:"env,omitempty" yaml:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
 	// List of volumes mounts that should be mounted is this container.
-	VolumeMounts []VolumeMountPluginOverride `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	VolumeMounts []VolumeMountPluginOverride `json:"volumeMounts,omitempty" yaml:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// +optional
-	MemoryLimit string `json:"memoryLimit,omitempty"`
+	MemoryLimit string `json:"memoryLimit,omitempty" yaml:"memoryLimit,omitempty"`
 
 	// The command to run in the dockerimage component instead of the default one provided in the image.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Command []string `json:"command,omitempty" patchStrategy:"replace"`
+	Command []string `json:"command,omitempty" yaml:"command,omitempty" patchStrategy:"replace"`
 
 	// The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.
 	//
 	// Defaults to an empty array, meaning use whatever is defined in the image.
 	// +optional
-	Args []string `json:"args,omitempty" patchStrategy:"replace"`
+	Args []string `json:"args,omitempty" yaml:"args,omitempty" patchStrategy:"replace"`
 
 	// Toggles whether or not the project source code should
 	// be mounted in the component.
 	//
 	// Defaults to true for all component types except plugins and components that set `dedicatedPod` to true.
 	// +optional
-	MountSources *bool `json:"mountSources,omitempty"`
+	MountSources *bool `json:"mountSources,omitempty" yaml:"mountSources,omitempty"`
 
 	// Optional specification of the path in the container where
 	// project sources should be transferred/mounted when `mountSources` is `true`.
 	// When omitted, the default value of /projects is used.
 	// +optional
-	SourceMapping string `json:"sourceMapping,omitempty"`
+	SourceMapping string `json:"sourceMapping,omitempty" yaml:"sourceMapping,omitempty"`
 
 	// Specify if a container should run in its own separated pod,
 	// instead of running as part of the main development environment pod.
 	//
 	// Default value is `false`
 	// +optional
-	DedicatedPod bool `json:"dedicatedPod,omitempty"`
+	DedicatedPod bool `json:"dedicatedPod,omitempty" yaml:"dedicatedPod,omitempty"`
 }
 
 type EndpointPluginOverride struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	//  +optional
-	TargetPort int `json:"targetPort,omitempty"`
+	TargetPort int `json:"targetPort,omitempty" yaml:"targetPort,omitempty"`
 
 	// Describes how the endpoint should be exposed on the network.
 	//
@@ -295,7 +295,7 @@ type EndpointPluginOverride struct {
 	//
 	// Default value is `public`
 	// +optional
-	Exposure EndpointExposurePluginOverride `json:"exposure,omitempty"`
+	Exposure EndpointExposurePluginOverride `json:"exposure,omitempty" yaml:"exposure,omitempty"`
 
 	// Describes the application and transport protocols of the traffic that will go through this endpoint.
 	//
@@ -315,16 +315,16 @@ type EndpointPluginOverride struct {
 	//
 	// Default value is `http`
 	// +optional
-	Protocol string `json:"protocol,omitempty"`
+	Protocol string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
 
 	// Describes whether the endpoint should be secured and protected by some
 	// authentication process
 	// +optional
-	Secure bool `json:"secure,omitempty"`
+	Secure bool `json:"secure,omitempty" yaml:"secure,omitempty"`
 
 	// Path of the endpoint URL
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 
 	// Map of implementation-dependant string-based free-form attributes.
 	//
@@ -334,13 +334,13 @@ type EndpointPluginOverride struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
 type K8sLikeComponentPluginOverride struct {
-	BaseComponentPluginOverride            `json:",inline"`
-	K8sLikeComponentLocationPluginOverride `json:",inline"`
-	Endpoints                              []EndpointPluginOverride `json:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	BaseComponentPluginOverride            `json:",inline" yaml:",inline"`
+	K8sLikeComponentLocationPluginOverride `json:",inline" yaml:",inline"`
+	Endpoints                              []EndpointPluginOverride `json:"endpoints,omitempty" yaml:"endpoints,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // Volume that should be mounted to a component container
@@ -348,32 +348,32 @@ type VolumePluginOverride struct {
 
 	// +optional
 	// Size of the volume
-	Size string `json:"size,omitempty"`
+	Size string `json:"size,omitempty" yaml:"size,omitempty"`
 }
 
 type LabeledCommandPluginOverride struct {
-	BaseCommandPluginOverride `json:",inline"`
+	BaseCommandPluginOverride `json:",inline" yaml:",inline"`
 
 	// +optional
 	// Optional label that provides a label for this command
 	// to be used in Editor UI menus for example
-	Label string `json:"label,omitempty"`
+	Label string `json:"label,omitempty" yaml:"label,omitempty"`
 }
 
 type EnvVarPluginOverride struct {
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name" yaml:"name"`
 	//  +optional
-	Value string `json:"value,omitempty" yaml:"value"`
+	Value string `json:"value,omitempty" yaml:"value,omitempty" yaml:"value"`
 }
 
 type BaseCommandPluginOverride struct {
 
 	// +optional
 	// Defines the group this command is part of
-	Group *CommandGroupPluginOverride `json:"group,omitempty"`
+	Group *CommandGroupPluginOverride `json:"group,omitempty" yaml:"group,omitempty"`
 
 	// Optional map of free-form additional command attributes
-	Attributes map[string]string `json:"attributes,omitempty"`
+	Attributes map[string]string `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
 // +union
@@ -384,16 +384,16 @@ type VscodeConfigurationCommandLocationPluginOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType VscodeConfigurationCommandLocationTypePluginOverride `json:"locationType,omitempty"`
+	LocationType VscodeConfigurationCommandLocationTypePluginOverride `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location as an absolute of relative URI
 	// the VsCode configuration will be fetched from
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined content of the VsCode configuration
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 // Volume that should be mounted to a component container
@@ -402,12 +402,12 @@ type VolumeMountPluginOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// The path in the component container where the volume should be mounted.
 	// If not path is mentioned, default path is the is `/<name>`.
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
 }
 
 // EndpointExposure describes the way an endpoint is exposed on the network.
@@ -423,26 +423,26 @@ type K8sLikeComponentLocationPluginOverride struct {
 	// +
 	// +unionDiscriminator
 	// +optional
-	LocationType K8sLikeComponentLocationTypePluginOverride `json:"locationType,omitempty"`
+	LocationType K8sLikeComponentLocationTypePluginOverride `json:"locationType,omitempty" yaml:"locationType,omitempty"`
 
 	// Location in a file fetched from a uri.
 	// +optional
-	Uri string `json:"uri,omitempty"`
+	Uri string `json:"uri,omitempty" yaml:"uri,omitempty"`
 
 	// Inlined manifest
 	// +optional
-	Inlined string `json:"inlined,omitempty"`
+	Inlined string `json:"inlined,omitempty" yaml:"inlined,omitempty"`
 }
 
 type CommandGroupPluginOverride struct {
 
 	//  +optional
 	// Kind of group the command is part of
-	Kind CommandGroupKindPluginOverride `json:"kind,omitempty"`
+	Kind CommandGroupKindPluginOverride `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	// +optional
 	// Identifies the default command for a given group kind
-	IsDefault bool `json:"isDefault,omitempty"`
+	IsDefault bool `json:"isDefault,omitempty" yaml:"isDefault,omitempty"`
 }
 
 // VscodeConfigurationCommandLocationType describes the type of

--- a/pkg/devfile/header.go
+++ b/pkg/devfile/header.go
@@ -5,21 +5,21 @@ package devfile
 type DevfileHeader struct {
 	// Devfile schema version
 	// +kubebuilder:validation:Pattern=^([2-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$
-	SchemaVersion string `json:"schemaVersion"`
+	SchemaVersion string `json:"schemaVersion" yaml:"schemaVersion"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	// Optional metadata
-	Metadata DevfileMetadata `json:"metadata,omitempty"`
+	Metadata DevfileMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 type DevfileMetadata struct {
 	// Optional devfile name
 	// +optional
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// Optional semver-compatible version
 	// +optional
 	// +kubebuilder:validation:Pattern=^([0-9]+)\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$
-	Version string `json:"version,omitempty"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 }


### PR DESCRIPTION
PR is opened as a draft PR as discussion/agreement hasn't yet taken place on the issue. It was a quick enough change that I figured I'd make it available now rather than waiting.

### What does this PR do?
Add matching `yaml` tags to fields that have a json struct tag, to support serializating/deserializing the devfile api as yaml. Also updates the overrides generator to include yaml tags.

This PR is the result of doing the following
- Executing 
    ```bash
    sed -i -E 's|`json:"([^ ]*)"|`json:"\1" yaml:"\1"|g' \
        $(grep -rnw "json:" . --exclude-dir vendor --exclude "zz*" -l)
    ```
    in this repo
- Updating `generator/overrides/gen.go` to generate `yaml` tags as well
- Regenerating auto-generated files.

### What issues does this PR fix or reference?
Fixes https://github.com/devfile/api/issues/202

### Is your PR tested? Consider putting some instruction how to test your changes
Tested using the sample code from #202 

#### Docs PR
(No functional changes to the API)
