### PR TITLE
Add devworkspaces shortname: dw

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -26,6 +26,7 @@ spec:
     plural: devworkspaces
     shortNames:
     - dev
+    - dw
     singular: devworkspace
   preserveUnknownFields: false
   scope: Namespaced

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -25,7 +25,6 @@ spec:
     listKind: DevWorkspaceList
     plural: devworkspaces
     shortNames:
-    - dev
     - dw
     singular: devworkspace
   preserveUnknownFields: false

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -24,6 +24,8 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
+    shortNames:
+    - dev
     singular: devworkspace
   preserveUnknownFields: false
   scope: Namespaced

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -13,6 +13,7 @@ spec:
     plural: devworkspaces
     shortNames:
     - dev
+    - dw
     singular: devworkspace
   scope: Namespaced
   versions:

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -12,7 +12,6 @@ spec:
     listKind: DevWorkspaceList
     plural: devworkspaces
     shortNames:
-    - dev
     - dw
     singular: devworkspace
   scope: Namespaced

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
+    shortNames:
+    - dev
     singular: devworkspace
   scope: Namespaced
   versions:

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -64,7 +64,7 @@ const (
 
 // DevWorkspace is the Schema for the devworkspaces API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=devworkspaces,scope=Namespaced,shortName=dev
+// +kubebuilder:resource:path=devworkspaces,scope=Namespaced,shortName=dev;dw
 // +kubebuilder:printcolumn:name="Workspace ID",type="string",JSONPath=".status.workspaceId",description="The workspace's unique id"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current workspace startup phase"
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -64,7 +64,7 @@ const (
 
 // DevWorkspace is the Schema for the devworkspaces API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=devworkspaces,scope=Namespaced
+// +kubebuilder:resource:path=devworkspaces,scope=Namespaced,shortName=dev
 // +kubebuilder:printcolumn:name="Workspace ID",type="string",JSONPath=".status.workspaceId",description="The workspace's unique id"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current workspace startup phase"
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -64,7 +64,7 @@ const (
 
 // DevWorkspace is the Schema for the devworkspaces API
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=devworkspaces,scope=Namespaced,shortName=dev;dw
+// +kubebuilder:resource:path=devworkspaces,scope=Namespaced,shortName=dw
 // +kubebuilder:printcolumn:name="Workspace ID",type="string",JSONPath=".status.workspaceId",description="The workspace's unique id"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current workspace startup phase"
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"


### PR DESCRIPTION
### What does this PR do?

Add a shortname for the `DevWorkspace` Custom Resource so that we can:

```bash 
$ kubectl get dw 
$ kubectl get devworkspaces 
```

### What issues does this PR fix or reference?

Make it easier to manage devworkspaces with kubectl.


### Is your PR tested? Consider putting some instruction how to test your changes

```
$ kubectl apply -f crds/workspace.devfile.io_devworkspaces.v1beta1.yaml 
customresourcedefinition.apiextensions.k8s.io/devworkspaces.workspace.devfile.io created 
$ kubectl api-resources 
(...) 
devworkspaces                     dw          workspace.devfile.io           true         DevWorkspace
```

