### PR TITLE
Add additional field to devworkspace status for showing info to users

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -6,19 +6,6 @@ metadata:
   creationTimestamp: null
   name: devworkspaces.workspace.devfile.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.workspaceId
-    description: The workspace's unique id
-    name: Workspace ID
-    type: string
-  - JSONPath: .status.phase
-    description: The current workspace startup phase
-    name: Phase
-    type: string
-  - JSONPath: .status.ideUrl
-    description: Url endpoint for accessing workspace
-    name: URL
-    type: string
   group: workspace.devfile.io
   names:
     kind: DevWorkspace
@@ -33,7 +20,20 @@ spec:
     status: {}
   version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - JSONPath: .status.workspaceId
+      description: The workspace's unique id
+      name: Workspace ID
+      type: string
+    - JSONPath: .status.phase
+      description: The current workspace startup phase
+      name: Phase
+      type: string
+    - JSONPath: .status.ideUrl
+      description: Url endpoint for accessing workspace
+      name: URL
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DevWorkspace is the Schema for the devworkspaces API
@@ -4063,6 +4063,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -4074,7 +4078,24 @@ spec:
         type: object
     served: true
     storage: false
-  - name: v1alpha2
+  - additionalPrinterColumns:
+    - JSONPath: .status.workspaceId
+      description: The workspace's unique id
+      name: Workspace ID
+      type: string
+    - JSONPath: .status.phase
+      description: The current workspace startup phase
+      name: Phase
+      type: string
+    - JSONPath: .status.message
+      description: Additional information about workspace state
+      name: Info
+      type: string
+    - JSONPath: .status.ideUrl
+      description: Url endpoint for accessing workspace
+      name: URL
+      type: string
+    name: v1alpha2
     schema:
       openAPIV3Schema:
         description: DevWorkspace is the Schema for the devworkspaces API
@@ -7724,6 +7745,10 @@ spec:
                 type: array
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
+                type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
                 type: string
               phase:
                 type: string

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -4059,6 +4059,10 @@ spec:
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
                 type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
+                type: string
               phase:
                 type: string
               workspaceId:
@@ -4080,6 +4084,10 @@ spec:
     - description: The current workspace startup phase
       jsonPath: .status.phase
       name: Phase
+      type: string
+    - description: Additional information about workspace state
+      jsonPath: .status.message
+      name: Info
       type: string
     - description: Url endpoint for accessing workspace
       jsonPath: .status.ideUrl
@@ -7742,6 +7750,10 @@ spec:
                 type: array
               ideUrl:
                 description: URL at which the Worksace Editor can be joined
+                type: string
+              message:
+                description: Message is a short user-readable message giving additional
+                  information about an object's state
                 type: string
               phase:
                 type: string

--- a/pkg/apis/workspaces/v1alpha1/conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/conversion.go
@@ -9,6 +9,7 @@ func convertDevWorkspaceTo_v1alpha2(src *DevWorkspace, dest *v1alpha2.DevWorkspa
 	dest.Status.WorkspaceId = src.Status.WorkspaceId
 	dest.Status.IdeUrl = src.Status.IdeUrl
 	dest.Status.Phase = v1alpha2.WorkspacePhase(src.Status.Phase)
+	dest.Status.Message = src.Status.Message
 	convertConditionsTo_v1alpha2(src, dest)
 	dest.Spec.RoutingClass = src.Spec.RoutingClass
 	dest.Spec.Started = src.Spec.Started
@@ -21,6 +22,7 @@ func convertDevWorkspaceFrom_v1alpha2(src *v1alpha2.DevWorkspace, dest *DevWorks
 	dest.Status.WorkspaceId = src.Status.WorkspaceId
 	dest.Status.IdeUrl = src.Status.IdeUrl
 	dest.Status.Phase = WorkspacePhase(src.Status.Phase)
+	dest.Status.Message = src.Status.Message
 	convertConditionsFrom_v1alpha2(src, dest)
 	dest.Spec.RoutingClass = src.Spec.RoutingClass
 	dest.Spec.Started = src.Spec.Started

--- a/pkg/apis/workspaces/v1alpha1/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha1/devworkspace_types.go
@@ -23,6 +23,9 @@ type DevWorkspaceStatus struct {
 	Phase  WorkspacePhase `json:"phase,omitempty"`
 	// Conditions represent the latest available observations of an object's state
 	Conditions []WorkspaceCondition `json:"conditions,omitempty"`
+	// Message is a short user-readable message giving additional information
+	// about an object's state
+	Message string `json:"message,omitempty"`
 }
 
 type WorkspacePhase string

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -21,6 +21,9 @@ type DevWorkspaceStatus struct {
 	Phase  WorkspacePhase `json:"phase,omitempty"`
 	// Conditions represent the latest available observations of an object's state
 	Conditions []WorkspaceCondition `json:"conditions,omitempty"`
+	// Message is a short user-readable message giving additional information
+	// about an object's state
+	Message string `json:"message,omitempty"`
 }
 
 type WorkspacePhase string
@@ -67,6 +70,7 @@ const (
 // +kubebuilder:resource:path=devworkspaces,scope=Namespaced,shortName=dw
 // +kubebuilder:printcolumn:name="Workspace ID",type="string",JSONPath=".status.workspaceId",description="The workspace's unique id"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current workspace startup phase"
+// +kubebuilder:printcolumn:name="Info",type="string",JSONPath=".status.message",description="Additional information about workspace state"
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"
 // +devfile:jsonschema:generate
 // +kubebuilder:storageversion

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -3672,6 +3672,10 @@
           "description": "URL at which the Worksace Editor can be joined",
           "type": "string"
         },
+        "message": {
+          "description": "Message is a short user-readable message giving additional information about an object's state",
+          "type": "string"
+        },
         "phase": {
           "type": "string"
         },

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -4105,6 +4105,11 @@
           "type": "string",
           "markdownDescription": "URL at which the Worksace Editor can be joined"
         },
+        "message": {
+          "description": "Message is a short user-readable message giving additional information about an object's state",
+          "type": "string",
+          "markdownDescription": "Message is a short user-readable message giving additional information about an object's state"
+        },
         "phase": {
           "type": "string"
         },


### PR DESCRIPTION
### What does this PR do?
Adds a field to the status subresource of DevWorkspaces which can be used to provide additional information about e.g. workspace failures and is printed in the short-form output of commands like `kuberctl get devworkspaces`

### What issues does this PR fix or reference?
Resolves https://github.com/devfile/api/issues/220, but should not be merged without discussion in the issue. I just wrote the PR since it's no effort to implement.

### Is your PR tested? Consider putting some instruction how to test your changes
When applied to a cluster, output of `kubectl get devworkspaces` is something like 
```
kc get devworkspace
NAME    WORKSPACE ID                PHASE    INFO   URL
theia   workspaceb8b430aa340343da   Failed
```
(propagating failure reason to the status is not yet implemented on the controller side)
