### PR TITLE
Add pattern validation and maxlength validation to name and id

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -4335,6 +4335,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -4516,6 +4518,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4602,6 +4606,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -4678,6 +4684,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4737,6 +4745,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -4780,6 +4790,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5037,6 +5049,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -5222,6 +5236,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5314,6 +5330,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -5373,6 +5391,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5437,6 +5457,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -5485,6 +5507,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5825,6 +5849,8 @@ spec:
                               description: Mandatory identifier that allows referencing
                                 this command in composite commands, from a parent,
                                 or in events.
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -6005,6 +6031,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6093,6 +6121,8 @@ spec:
                                           If several containers mount the same volume
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -6148,6 +6178,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6208,6 +6240,8 @@ spec:
                                 the component from other elements (such as commands)
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -6252,6 +6286,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6516,6 +6552,8 @@ spec:
                                         description: Mandatory identifier that allows
                                           referencing this command in composite commands,
                                           from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -6705,6 +6743,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6806,6 +6846,8 @@ spec:
                                                     they will reuse the same volume
                                                     and will be able to access to
                                                     the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -6866,6 +6908,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6936,6 +6980,8 @@ spec:
                                           as commands) or from an external devfile
                                           that may reference this component through
                                           a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -6985,6 +7031,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -7206,6 +7254,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7313,6 +7363,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7441,6 +7493,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7563,6 +7617,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -24,6 +24,8 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
+    shortNames:
+    - dw
     singular: devworkspace
   preserveUnknownFields: false
   scope: Namespaced
@@ -4334,7 +4336,7 @@ spec:
                             this command in composite commands, from a parent, or
                             in events.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -4516,8 +4518,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4605,7 +4607,7 @@ spec:
                                       will reuse the same volume and will be able
                                       to access to the same files.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -4682,8 +4684,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4744,7 +4746,7 @@ spec:
                             an external devfile that may reference this component
                             through a parent or a plugin.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -4788,8 +4790,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5048,7 +5050,7 @@ spec:
                                       referencing this command in composite commands,
                                       from a parent, or in events.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -5234,8 +5236,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5329,7 +5331,7 @@ spec:
                                                 same volume and will be able to access
                                                 to the same files.
                                               maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -5389,8 +5391,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5456,7 +5458,7 @@ spec:
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -5505,8 +5507,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5848,7 +5850,7 @@ spec:
                                 this command in composite commands, from a parent,
                                 or in events.
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -6029,8 +6031,8 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        maxLength: 15
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6120,7 +6122,7 @@ spec:
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
                                         maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -6176,8 +6178,8 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        maxLength: 15
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6239,7 +6241,7 @@ spec:
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -6284,8 +6286,8 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        maxLength: 15
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6551,7 +6553,7 @@ spec:
                                           referencing this command in composite commands,
                                           from a parent, or in events.
                                         maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -6741,8 +6743,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  maxLength: 15
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6845,7 +6847,7 @@ spec:
                                                     and will be able to access to
                                                     the same files.
                                                   maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -6906,8 +6908,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  maxLength: 15
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6979,7 +6981,7 @@ spec:
                                           that may reference this component through
                                           a parent or a plugin.
                                         maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -7029,8 +7031,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  maxLength: 15
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -7253,7 +7255,7 @@ spec:
                             name:
                               description: Project name
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7362,7 +7364,7 @@ spec:
                             name:
                               description: Project name
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7492,7 +7494,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7616,7 +7618,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -24,8 +24,6 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
-    shortNames:
-    - dw
     singular: devworkspace
   preserveUnknownFields: false
   scope: Namespaced

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -11,8 +11,6 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
-    shortNames:
-    - dw
     singular: devworkspace
   scope: Namespaced
   versions:

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -4346,6 +4346,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -4528,6 +4530,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4616,6 +4620,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -4693,6 +4699,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4753,6 +4761,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -4797,6 +4807,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5055,6 +5067,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -5240,6 +5254,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5332,6 +5348,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -5391,6 +5409,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5455,6 +5475,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -5503,6 +5525,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5843,6 +5867,8 @@ spec:
                               description: Mandatory identifier that allows referencing
                                 this command in composite commands, from a parent,
                                 or in events.
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -6023,6 +6049,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6111,6 +6139,8 @@ spec:
                                           If several containers mount the same volume
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -6166,6 +6196,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6226,6 +6258,8 @@ spec:
                                 the component from other elements (such as commands)
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -6270,6 +6304,8 @@ spec:
                                         - none
                                         type: string
                                       name:
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6534,6 +6570,8 @@ spec:
                                         description: Mandatory identifier that allows
                                           referencing this command in composite commands,
                                           from a parent, or in events.
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -6723,6 +6761,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6824,6 +6864,8 @@ spec:
                                                     they will reuse the same volume
                                                     and will be able to access to
                                                     the same files.
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -6884,6 +6926,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6954,6 +6998,8 @@ spec:
                                           as commands) or from an external devfile
                                           that may reference this component through
                                           a parent or a plugin.
+                                        maxLength: 63
+                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -7003,6 +7049,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
+                                                  maxLength: 63
+                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -7224,6 +7272,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7331,6 +7381,8 @@ spec:
                               type: object
                             name:
                               description: Project name
+                              maxLength: 63
+                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7459,6 +7511,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7581,6 +7635,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
+    shortNames:
+    - dw
     singular: devworkspace
   scope: Namespaced
   versions:
@@ -4345,7 +4347,7 @@ spec:
                             this command in composite commands, from a parent, or
                             in events.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -4528,8 +4530,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4619,7 +4621,7 @@ spec:
                                       will reuse the same volume and will be able
                                       to access to the same files.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -4697,8 +4699,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -4760,7 +4762,7 @@ spec:
                             an external devfile that may reference this component
                             through a parent or a plugin.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -4805,8 +4807,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5066,7 +5068,7 @@ spec:
                                       referencing this command in composite commands,
                                       from a parent, or in events.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -5252,8 +5254,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5347,7 +5349,7 @@ spec:
                                                 same volume and will be able to access
                                                 to the same files.
                                               maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -5407,8 +5409,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5474,7 +5476,7 @@ spec:
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -5523,8 +5525,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -5866,7 +5868,7 @@ spec:
                                 this command in composite commands, from a parent,
                                 or in events.
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             vscodeLaunch:
                               description: Command providing the definition of a VsCode
@@ -6047,8 +6049,8 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        maxLength: 15
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6138,7 +6140,7 @@ spec:
                                           name then they will reuse the same volume
                                           and will be able to access to the same files.
                                         maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: The path in the component container
@@ -6194,8 +6196,8 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        maxLength: 15
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6257,7 +6259,7 @@ spec:
                                 or from an external devfile that may reference this
                                 component through a parent or a plugin.
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             openshift:
                               description: Allows importing into the workspace the
@@ -6302,8 +6304,8 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        maxLength: 15
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
                                         description: Path of the endpoint URL
@@ -6569,7 +6571,7 @@ spec:
                                           referencing this command in composite commands,
                                           from a parent, or in events.
                                         maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       vscodeLaunch:
                                         description: Command providing the definition
@@ -6759,8 +6761,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  maxLength: 15
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6863,7 +6865,7 @@ spec:
                                                     and will be able to access to
                                                     the same files.
                                                   maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: The path in the component
@@ -6924,8 +6926,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  maxLength: 15
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -6997,7 +6999,7 @@ spec:
                                           that may reference this component through
                                           a parent or a plugin.
                                         maxLength: 63
-                                        pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       openshift:
                                         description: Allows importing into the workspace
@@ -7047,8 +7049,8 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 63
-                                                  pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                                  maxLength: 15
+                                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
                                                   description: Path of the endpoint
@@ -7271,7 +7273,7 @@ spec:
                             name:
                               description: Project name
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7380,7 +7382,7 @@ spec:
                             name:
                               description: Project name
                               maxLength: 63
-                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                               type: string
                             sourceType:
                               description: Type of project source
@@ -7510,7 +7512,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7634,7 +7636,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -4114,6 +4114,8 @@ spec:
                     id:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -4288,6 +4290,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4371,6 +4375,8 @@ spec:
                                   mount the same volume name then they will reuse
                                   the same volume and will be able to access to the
                                   same files.
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -4445,6 +4451,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4502,6 +4510,8 @@ spec:
                         from other elements (such as commands) or from an external
                         devfile that may reference this component through a parent
                         or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -4543,6 +4553,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4795,6 +4807,8 @@ spec:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
                                   or in events.
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -4974,6 +4988,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5064,6 +5080,8 @@ spec:
                                             name then they will reuse the same volume
                                             and will be able to access to the same
                                             files.
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -5119,6 +5137,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5181,6 +5201,8 @@ spec:
                                   the component from other elements (such as commands)
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -5225,6 +5247,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5554,6 +5578,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -5729,6 +5755,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5813,6 +5841,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -5866,6 +5896,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5924,6 +5956,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -5967,6 +6001,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -6223,6 +6259,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -6408,6 +6446,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6500,6 +6540,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -6559,6 +6601,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6623,6 +6667,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -6671,6 +6717,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6883,6 +6931,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -6988,6 +7038,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7109,6 +7161,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -7224,6 +7278,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -4115,7 +4115,7 @@ spec:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -4290,8 +4290,8 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                maxLength: 15
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4376,7 +4376,7 @@ spec:
                                   the same volume and will be able to access to the
                                   same files.
                                 maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -4451,8 +4451,8 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                maxLength: 15
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4511,7 +4511,7 @@ spec:
                         devfile that may reference this component through a parent
                         or a plugin.
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -4553,8 +4553,8 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                maxLength: 15
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4808,7 +4808,7 @@ spec:
                                   this command in composite commands, from a parent,
                                   or in events.
                                 maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -4988,8 +4988,8 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          maxLength: 15
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5081,7 +5081,7 @@ spec:
                                             and will be able to access to the same
                                             files.
                                           maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -5137,8 +5137,8 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          maxLength: 15
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5202,7 +5202,7 @@ spec:
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
                                 maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -5247,8 +5247,8 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          maxLength: 15
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5579,7 +5579,7 @@ spec:
                             this command in composite commands, from a parent, or
                             in events.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -5755,8 +5755,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5842,7 +5842,7 @@ spec:
                                       will reuse the same volume and will be able
                                       to access to the same files.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -5896,8 +5896,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5957,7 +5957,7 @@ spec:
                             an external devfile that may reference this component
                             through a parent or a plugin.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -6001,8 +6001,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -6260,7 +6260,7 @@ spec:
                                       referencing this command in composite commands,
                                       from a parent, or in events.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -6446,8 +6446,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6541,7 +6541,7 @@ spec:
                                                 same volume and will be able to access
                                                 to the same files.
                                               maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -6601,8 +6601,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6668,7 +6668,7 @@ spec:
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -6717,8 +6717,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6932,7 +6932,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7039,7 +7039,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7162,7 +7162,7 @@ spec:
                     name:
                       description: Project name
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -7279,7 +7279,7 @@ spec:
                     name:
                       description: Project name
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -4113,7 +4113,7 @@ spec:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -4289,8 +4289,8 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                maxLength: 15
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4377,7 +4377,7 @@ spec:
                                   the same volume and will be able to access to the
                                   same files.
                                 maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -4453,8 +4453,8 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                maxLength: 15
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4514,7 +4514,7 @@ spec:
                         devfile that may reference this component through a parent
                         or a plugin.
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -4557,8 +4557,8 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                maxLength: 15
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4813,7 +4813,7 @@ spec:
                                   this command in composite commands, from a parent,
                                   or in events.
                                 maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -4993,8 +4993,8 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          maxLength: 15
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5086,7 +5086,7 @@ spec:
                                             and will be able to access to the same
                                             files.
                                           maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -5142,8 +5142,8 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          maxLength: 15
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5207,7 +5207,7 @@ spec:
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
                                 maxLength: 63
-                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -5252,8 +5252,8 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 63
-                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                          maxLength: 15
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5584,7 +5584,7 @@ spec:
                             this command in composite commands, from a parent, or
                             in events.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -5760,8 +5760,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5847,7 +5847,7 @@ spec:
                                       will reuse the same volume and will be able
                                       to access to the same files.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -5901,8 +5901,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5962,7 +5962,7 @@ spec:
                             an external devfile that may reference this component
                             through a parent or a plugin.
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -6006,8 +6006,8 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    maxLength: 15
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -6265,7 +6265,7 @@ spec:
                                       referencing this command in composite commands,
                                       from a parent, or in events.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -6451,8 +6451,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6546,7 +6546,7 @@ spec:
                                                 same volume and will be able to access
                                                 to the same files.
                                               maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -6606,8 +6606,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6673,7 +6673,7 @@ spec:
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
                                     maxLength: 63
-                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -6722,8 +6722,8 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 63
-                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                                              maxLength: 15
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6937,7 +6937,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7044,7 +7044,7 @@ spec:
                         name:
                           description: Project name
                           maxLength: 63
-                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7167,7 +7167,7 @@ spec:
                     name:
                       description: Project name
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -7284,7 +7284,7 @@ spec:
                     name:
                       description: Project name
                       maxLength: 63
-                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -4112,6 +4112,8 @@ spec:
                     id:
                       description: Mandatory identifier that allows referencing this
                         command in composite commands, from a parent, or in events.
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     vscodeLaunch:
                       description: Command providing the definition of a VsCode launch
@@ -4287,6 +4289,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4372,6 +4376,8 @@ spec:
                                   mount the same volume name then they will reuse
                                   the same volume and will be able to access to the
                                   same files.
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: The path in the component container where
@@ -4447,6 +4453,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4505,6 +4513,8 @@ spec:
                         from other elements (such as commands) or from an external
                         devfile that may reference this component through a parent
                         or a plugin.
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     openshift:
                       description: Allows importing into the workspace the OpenShift
@@ -4547,6 +4557,8 @@ spec:
                                 - none
                                 type: string
                               name:
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
                                 description: Path of the endpoint URL
@@ -4800,6 +4812,8 @@ spec:
                                 description: Mandatory identifier that allows referencing
                                   this command in composite commands, from a parent,
                                   or in events.
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               vscodeLaunch:
                                 description: Command providing the definition of a
@@ -4979,6 +4993,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5069,6 +5085,8 @@ spec:
                                             name then they will reuse the same volume
                                             and will be able to access to the same
                                             files.
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: The path in the component container
@@ -5124,6 +5142,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5186,6 +5206,8 @@ spec:
                                   the component from other elements (such as commands)
                                   or from an external devfile that may reference this
                                   component through a parent or a plugin.
+                                maxLength: 63
+                                pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               openshift:
                                 description: Allows importing into the workspace the
@@ -5230,6 +5252,8 @@ spec:
                                           - none
                                           type: string
                                         name:
+                                          maxLength: 63
+                                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
                                           description: Path of the endpoint URL
@@ -5559,6 +5583,8 @@ spec:
                           description: Mandatory identifier that allows referencing
                             this command in composite commands, from a parent, or
                             in events.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         vscodeLaunch:
                           description: Command providing the definition of a VsCode
@@ -5734,6 +5760,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5818,6 +5846,8 @@ spec:
                                       containers mount the same volume name then they
                                       will reuse the same volume and will be able
                                       to access to the same files.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: The path in the component container
@@ -5871,6 +5901,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -5929,6 +5961,8 @@ spec:
                             component from other elements (such as commands) or from
                             an external devfile that may reference this component
                             through a parent or a plugin.
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         openshift:
                           description: Allows importing into the workspace the OpenShift
@@ -5972,6 +6006,8 @@ spec:
                                     - none
                                     type: string
                                   name:
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
                                     description: Path of the endpoint URL
@@ -6228,6 +6264,8 @@ spec:
                                     description: Mandatory identifier that allows
                                       referencing this command in composite commands,
                                       from a parent, or in events.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   vscodeLaunch:
                                     description: Command providing the definition
@@ -6413,6 +6451,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6505,6 +6545,8 @@ spec:
                                                 volume name then they will reuse the
                                                 same volume and will be able to access
                                                 to the same files.
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: The path in the component
@@ -6564,6 +6606,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6628,6 +6672,8 @@ spec:
                                       the component from other elements (such as commands)
                                       or from an external devfile that may reference
                                       this component through a parent or a plugin.
+                                    maxLength: 63
+                                    pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   openshift:
                                     description: Allows importing into the workspace
@@ -6676,6 +6722,8 @@ spec:
                                               - none
                                               type: string
                                             name:
+                                              maxLength: 63
+                                              pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
                                               description: Path of the endpoint URL
@@ -6888,6 +6936,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -6993,6 +7043,8 @@ spec:
                           type: object
                         name:
                           description: Project name
+                          maxLength: 63
+                          pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         sourceType:
                           description: Type of project source
@@ -7114,6 +7166,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source
@@ -7229,6 +7283,8 @@ spec:
                       type: object
                     name:
                       description: Project name
+                      maxLength: 63
+                      pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     sourceType:
                       description: Type of project source

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -58,7 +58,7 @@ type Command struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 	// Map of implementation-dependant free-form YAML attributes.

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -58,6 +58,8 @@ type Command struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/components.go
+++ b/pkg/apis/workspaces/v1alpha2/components.go
@@ -29,6 +29,8 @@ type Component struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional

--- a/pkg/apis/workspaces/v1alpha2/components.go
+++ b/pkg/apis/workspaces/v1alpha2/components.go
@@ -29,7 +29,7 @@ type Component struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 	// Map of implementation-dependant free-form YAML attributes.

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -73,7 +73,7 @@ type VolumeMount struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 

--- a/pkg/apis/workspaces/v1alpha2/containerComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/containerComponent.go
@@ -73,6 +73,8 @@ type VolumeMount struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// The path in the component container where the volume should be mounted.

--- a/pkg/apis/workspaces/v1alpha2/endpoint.go
+++ b/pkg/apis/workspaces/v1alpha2/endpoint.go
@@ -47,8 +47,8 @@ const (
 )
 
 type Endpoint struct {
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=15
 	Name string `json:"name"`
 
 	TargetPort int `json:"targetPort"`

--- a/pkg/apis/workspaces/v1alpha2/endpoint.go
+++ b/pkg/apis/workspaces/v1alpha2/endpoint.go
@@ -47,6 +47,8 @@ const (
 )
 
 type Endpoint struct {
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	TargetPort int `json:"targetPort"`

--- a/pkg/apis/workspaces/v1alpha2/projects.go
+++ b/pkg/apis/workspaces/v1alpha2/projects.go
@@ -7,7 +7,7 @@ import (
 
 type Project struct {
 	// Project name
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
@@ -28,7 +28,7 @@ type Project struct {
 
 type StarterProject struct {
 	// Project name
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 

--- a/pkg/apis/workspaces/v1alpha2/projects.go
+++ b/pkg/apis/workspaces/v1alpha2/projects.go
@@ -7,6 +7,8 @@ import (
 
 type Project struct {
 	// Project name
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -26,6 +28,8 @@ type Project struct {
 
 type StarterProject struct {
 	// Project name
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Map of implementation-dependant free-form YAML attributes.

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -47,6 +47,8 @@ type ComponentParentOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -58,6 +60,8 @@ type ComponentParentOverride struct {
 type ProjectParentOverride struct {
 
 	// Project name
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -78,6 +82,8 @@ type ProjectParentOverride struct {
 type StarterProjectParentOverride struct {
 
 	// Project name
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -100,6 +106,8 @@ type CommandParentOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -405,6 +413,9 @@ type ContainerParentOverride struct {
 }
 
 type EndpointParentOverride struct {
+
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	//  +optional
@@ -570,6 +581,8 @@ type VolumeMountParentOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// The path in the component container where the volume should be mounted.
@@ -641,6 +654,8 @@ type ComponentPluginOverrideParentOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -654,6 +669,8 @@ type CommandPluginOverrideParentOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -949,6 +966,9 @@ type ContainerPluginOverrideParentOverride struct {
 }
 
 type EndpointPluginOverrideParentOverride struct {
+
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	//  +optional
@@ -1073,6 +1093,8 @@ type VolumeMountPluginOverrideParentOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// The path in the component container where the volume should be mounted.

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -47,7 +47,7 @@ type ComponentParentOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
@@ -60,7 +60,7 @@ type ComponentParentOverride struct {
 type ProjectParentOverride struct {
 
 	// Project name
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
@@ -82,7 +82,7 @@ type ProjectParentOverride struct {
 type StarterProjectParentOverride struct {
 
 	// Project name
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
@@ -106,7 +106,7 @@ type CommandParentOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 
@@ -414,8 +414,8 @@ type ContainerParentOverride struct {
 
 type EndpointParentOverride struct {
 
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=15
 	Name string `json:"name"`
 
 	//  +optional
@@ -581,7 +581,7 @@ type VolumeMountParentOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
@@ -654,7 +654,7 @@ type ComponentPluginOverrideParentOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
@@ -669,7 +669,7 @@ type CommandPluginOverrideParentOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 
@@ -967,8 +967,8 @@ type ContainerPluginOverrideParentOverride struct {
 
 type EndpointPluginOverrideParentOverride struct {
 
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=15
 	Name string `json:"name"`
 
 	//  +optional
@@ -1093,7 +1093,7 @@ type VolumeMountPluginOverrideParentOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -31,7 +31,7 @@ type ComponentPluginOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
@@ -46,7 +46,7 @@ type CommandPluginOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 
@@ -293,8 +293,8 @@ type ContainerPluginOverride struct {
 
 type EndpointPluginOverride struct {
 
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=15
 	Name string `json:"name"`
 
 	//  +optional
@@ -418,7 +418,7 @@ type VolumeMountPluginOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
-	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -31,6 +31,8 @@ type ComponentPluginOverride struct {
 	// Mandatory name that allows referencing the component
 	// from other elements (such as commands) or from an external
 	// devfile that may reference this component through a parent or a plugin.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -44,6 +46,8 @@ type CommandPluginOverride struct {
 	// Mandatory identifier that allows referencing
 	// this command in composite commands, from
 	// a parent, or in events.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Id string `json:"id"`
 
 	// Map of implementation-dependant free-form YAML attributes.
@@ -288,6 +292,9 @@ type ContainerPluginOverride struct {
 }
 
 type EndpointPluginOverride struct {
+
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	//  +optional
@@ -411,6 +418,8 @@ type VolumeMountPluginOverride struct {
 	// The volume mount name is the name of an existing `Volume` component.
 	// If several containers mount the same volume name
 	// then they will reuse the same volume and will be able to access to the same files.
+	// +kubebuilder:validation:Pattern=^[a-z]([-a-z0-9]*[a-z0-9])?$
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// The path in the component container where the volume should be mounted.

--- a/samples/devfile-registry/redhat-theia-vsx-template.devfile.yaml
+++ b/samples/devfile-registry/redhat-theia-vsx-template.devfile.yaml
@@ -19,9 +19,9 @@ components:
   - name: vsx
     volume: {}
 commands:
- - id: copyVsx
+ - id: copyvsx
    apply:
      component: vsx-installer
 events:
   preStart:
-    - copyVsx
+    - copyvsx

--- a/samples/devfiles/nodejs-stack.devfile.yaml
+++ b/samples/devfiles/nodejs-stack.devfile.yaml
@@ -17,7 +17,7 @@ components:
     plugin:
       id: che-incubator/typescript/1.30.2
       components:
-        - name: "??"
+        - name: "somename"
           container:
             memoryLimit: 512Mi
   - name: nodejs
@@ -30,14 +30,14 @@ components:
           targetPort: 3000
       mountSources: true
 commands:
-  - id: download dependencies
+  - id: download-dependencies
     exec:
       component: nodejs
       commandLine: npm install
       workingDir: ${PROJECTS_ROOT}/project/app
       group:
         kind: build
-  - id: run the app
+  - id: run-the-app
     exec:
       component: nodejs
       commandLine: nodemon app.js
@@ -45,21 +45,21 @@ commands:
       group:
         kind: run
         isDefault: true
-  - id: run the app (debugging enabled)
+  - id: run-the-app-debugging-enabled
     exec:
       component: nodejs
       commandLine: nodemon --inspect app.js
       workingDir: ${PROJECTS_ROOT}/project/app
       group:
         kind: run
-  - id: stop the app
+  - id: stop-the-app
     exec:
       component: nodejs
       commandLine: >-
           node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
           echo "Stopping node server with PIDs: ${node_server_pids}" && 
           kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
-  - id: Attach remote debugger
+  - id: attach-remote-debugger
     vscodeLaunch:
       inlined: |
         {

--- a/samples/devfiles/sample-devfile.yaml
+++ b/samples/devfiles/sample-devfile.yaml
@@ -18,11 +18,11 @@ components:
         "": ""
     plugin:
       id: eclipse/che-theia/latest
-  - name: "ownPlugin"
+  - name: "ownplugin"
     plugin:
       id: acme/newPlugin/latest
       registryUrl: "https://acme.com/registry/"
-  - name: "myPlugin"
+  - name: "myplugin"
     plugin:
       uri: "https://github.com/johndoe/che-plugins/blob/master/cool-plugin/0.0.1/meta.yaml"
   - name: "mycontainer"

--- a/samples/devfiles/simple-devfile.yaml
+++ b/samples/devfiles/simple-devfile.yaml
@@ -8,7 +8,7 @@ projects:
       remotes:
         origin: "https://github.com/devfile/api"
 commands:
-  - id: buildSchema
+  - id: buildschema
     exec:
       label: Build the schema
       commandLine: "./buildSchema.sh"
@@ -16,18 +16,18 @@ commands:
       group:
         kind: build
         isDefault: true
-  - id: openDevfile
+  - id: opendevfile
     vscodeTask:
       inlined:
         json        
-  - id: buildSchemaAndOpenDevfile
+  - id: build-schema-and-open-devfile
     composite:
       label: Build schema and open devfile
       commands:
-        - buildSchema
-        - openDevfile
+        - buildschema
+        - opendevfile
       parallel: false
-  - id: helloWorld
+  - id: helloworld
     exec:
       env:
         - name: "USER"
@@ -36,7 +36,7 @@ commands:
       component: build-tools
 events:
   postStart:
-    - "buildSchemaAndOpenDevfile"
+    - "build-schema-and-open-devfile"
 components:
   - name: yaml-support
     plugin:

--- a/samples/devfiles/spring-boot-http-booster-devfile.yaml
+++ b/samples/devfiles/spring-boot-http-booster-devfile.yaml
@@ -39,7 +39,7 @@ components:
         - name: MAVEN_OPTS
           value: $(JAVA_OPTS)
       endpoints:
-        - name: 8080-tcp
+        - name: tcp-8080
           targetPort: 8080
           exposure: public
       volumeMounts:
@@ -54,7 +54,7 @@ commands:
       env:
         - name: MAVEN_OPTS
           value: "-Xmx200m"
-  - id: debug remote java application
+  - id: debug-remote-java-application
     vscodeLaunch:
       inlined: |
         {
@@ -99,7 +99,7 @@ commands:
         ${HOME}/stack-analysis.sh -f
         ${PROJECTS_ROOT}/spring-boot-http-booster/pom.xml -p
         ${PROJECTS_ROOT}/spring-boot-http-booster
-  - id: deploy to OpenShift 
+  - id: deploy-to-openshift 
     exec:
       component: maven
       commandLine: 'mvn fabric8:deploy -Popenshift -DskipTests'

--- a/samples/devfiles/spring-boot-http-booster-devfile.yaml.devfile-1.0.yaml
+++ b/samples/devfiles/spring-boot-http-booster-devfile.yaml.devfile-1.0.yaml
@@ -42,7 +42,7 @@ commands:
           MAVEN_OPTS="-Xmx200m" && mvn -Duser.home=${HOME} -DskipTests clean
           install
         component: maven
-  - name: Debug remote java application
+  - name: debug-remote-java-application
     actions:
       - referenceContent: |
           {
@@ -86,7 +86,7 @@ commands:
           ${PROJECTS_ROOT}/spring-boot-http-booster/pom.xml -p
           ${PROJECTS_ROOT}/spring-boot-http-booster
         component: maven
-  - name: deploy to OpenShift
+  - name: deploy-to-openshift
     actions:
       - workdir: '${PROJECTS_ROOT}/spring-boot-http-booster'
         type: exec

--- a/samples/devfiles/with-nodejs-parent.devfile.yaml
+++ b/samples/devfiles/with-nodejs-parent.devfile.yaml
@@ -9,7 +9,7 @@ parent:
         checkoutFrom:
           revision: 'mybranch'
 commands:
-  - id: sayHello
+  - id: sayhello
     exec:
       label: Say Hello
       commandLine: echo "hello"

--- a/samples/devworkspace-templates/nodejs.devworkspacetemplate.yaml
+++ b/samples/devworkspace-templates/nodejs.devworkspacetemplate.yaml
@@ -19,7 +19,7 @@ spec:
       plugin:
         id: che-incubator/typescript/1.30.2
         components:
-          - name: ""
+          - name: random-name
             container:
               memoryLimit: 512Mi
     - name: nodejs
@@ -32,29 +32,29 @@ spec:
             targetPort: 3000
         mountSources: true
   commands:
-    - id: download dependencies
+    - id: download-dependencies
       exec:
         component: nodejs
         commandLine: npm install
         workingDir: ${PROJECTS_ROOT}/project/app
-    - id: run the app
+    - id: run-the-app
       exec:
         component: nodejs
         commandLine: nodemon app.js
         workingDir: ${PROJECTS_ROOT}/project/app
-    - id: run the app (debugging enabled)
+    - id: run-the-app-debugging-enabled
       exec:
         component: nodejs
         commandLine: nodemon --inspect app.js
         workingDir: ${PROJECTS_ROOT}/project/app
-    - id: stop the app
+    - id: stop-the-app
       exec:
         component: nodejs
         commandLine: >-
             node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
             echo "Stopping node server with PIDs: ${node_server_pids}" && 
             kill -15 ${node_server_pids} &>/dev/null && echo 'Done.'
-    - id: Attach remote debugger
+    - id: attach-remote-debugger
       vscodeLaunch:
         inlined: |
           {

--- a/samples/devworkspaces/custom.devworkspace.yaml
+++ b/samples/devworkspaces/custom.devworkspace.yaml
@@ -16,7 +16,7 @@ spec:
       - name: "production"
         kubernetes:
           uri: "https://somewhere/production-environment.yaml"
-      - name: "myNewComponent"
+      - name: "mynewcomponent"
         custom:
           componentClass: "NewComponentType"
           embeddedResource:
@@ -25,7 +25,7 @@ spec:
               config2-1: "" 
               config2-2: "" 
     commands:
-      - id: myCustomCommand
+      - id: mycustomcommand
         custom:
           commandClass: myCommandType
           embeddedResource:

--- a/samples/devworkspaces/example.devworkspace.yaml
+++ b/samples/devworkspaces/example.devworkspace.yaml
@@ -17,11 +17,11 @@ spec:
       - name: editor
         plugin:
           id: eclipse/che-theia/latest
-      - name: "ownPlugin"
+      - name: "ownplugin"
         plugin:
           id: acme/newPlugin/latest
           registryUrl: "https://acme.com/registry/"
-      - name: "myPlugin"
+      - name: "myplugin"
         plugin:
           uri: "https://github.com/johndoe/che-plugins/blob/master/cool-plugin/0.0.1/meta.yaml"
       - name: "mycontainer"
@@ -35,7 +35,7 @@ spec:
               attributes:
                 type: terminal
               targetPort: 4000
-      - name: "myNewComponent"
+      - name: "mynewcomponent"
         custom:
           componentClass: "NewComponentType"
           embeddedResource:

--- a/samples/devworkspaces/with-nodejs-parent-devfile.devworkspace.yaml
+++ b/samples/devworkspaces/with-nodejs-parent-devfile.devworkspace.yaml
@@ -8,7 +8,7 @@ spec:
     parent:
       uri: https://raw.githubusercontent.com/che-incubator/devworkspace-api/proposal-25-variant-1-define-stacks/devfile-support/samples/nodejs-stack.devfile.yaml
     commands:
-      - id: sayHello
+      - id: sayhello
         exec:
           label: Say Hello
           commandLine: echo "hello"

--- a/samples/devworkspaces/with-nodejs-parent-template.devworkspace.yaml
+++ b/samples/devworkspaces/with-nodejs-parent-template.devworkspace.yaml
@@ -9,7 +9,7 @@ spec:
       kubernetes:
         name: nodejs-stack
     commands:
-      - id: sayHello
+      - id: sayhello
         exec:
           label: Say Hello
           commandLine: echo "hello"

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -264,7 +264,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -469,8 +469,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -547,7 +547,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -622,8 +622,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -666,7 +666,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -710,8 +710,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -962,7 +962,7 @@
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "vscodeLaunch": {
                       "description": "Command providing the definition of a VsCode launch action",
@@ -1146,8 +1146,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1221,7 +1221,7 @@
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
                                 "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1274,8 +1274,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1317,7 +1317,7 @@
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "openshift": {
                       "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1359,8 +1359,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1705,7 +1705,7 @@
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "vscodeLaunch": {
                 "description": "Command providing the definition of a VsCode launch action",
@@ -1894,8 +1894,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1969,7 +1969,7 @@
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2022,8 +2022,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2065,7 +2065,7 @@
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "openshift": {
                 "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2107,8 +2107,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2358,7 +2358,7 @@
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "vscodeLaunch": {
                           "description": "Command providing the definition of a VsCode launch action",
@@ -2542,8 +2542,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2617,7 +2617,7 @@
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
                                     "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2670,8 +2670,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2713,7 +2713,7 @@
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "openshift": {
                           "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2755,8 +2755,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2968,7 +2968,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "sparseCheckoutDirs": {
                 "description": "Populate the project sparsely with selected directories.",
@@ -3092,7 +3092,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "subDir": {
                 "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3246,7 +3246,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "sparseCheckoutDirs": {
             "description": "Populate the project sparsely with selected directories.",
@@ -3396,7 +3396,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "subDir": {
             "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -262,7 +262,9 @@
           },
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -466,7 +468,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -541,7 +545,9 @@
                   "properties": {
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -615,7 +621,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -656,7 +664,9 @@
           },
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -699,7 +709,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -948,7 +960,9 @@
                     },
                     "id": {
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "vscodeLaunch": {
                       "description": "Command providing the definition of a VsCode launch action",
@@ -1131,7 +1145,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1203,7 +1219,9 @@
                             "properties": {
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1255,7 +1273,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1295,7 +1315,9 @@
                     },
                     "name": {
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "openshift": {
                       "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1336,7 +1358,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1679,7 +1703,9 @@
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "vscodeLaunch": {
                 "description": "Command providing the definition of a VsCode launch action",
@@ -1867,7 +1893,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1939,7 +1967,9 @@
                       "properties": {
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1991,7 +2021,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2031,7 +2063,9 @@
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "openshift": {
                 "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2072,7 +2106,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2320,7 +2356,9 @@
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "vscodeLaunch": {
                           "description": "Command providing the definition of a VsCode launch action",
@@ -2503,7 +2541,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2575,7 +2615,9 @@
                                 "properties": {
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2627,7 +2669,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2667,7 +2711,9 @@
                         },
                         "name": {
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "openshift": {
                           "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2708,7 +2754,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2918,7 +2966,9 @@
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "sparseCheckoutDirs": {
                 "description": "Populate the project sparsely with selected directories.",
@@ -3040,7 +3090,9 @@
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "subDir": {
                 "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3192,7 +3244,9 @@
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sparseCheckoutDirs": {
             "description": "Populate the project sparsely with selected directories.",
@@ -3340,7 +3394,9 @@
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "subDir": {
             "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -429,7 +429,7 @@
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "vscodeLaunch": {
                 "description": "Command providing the definition of a VsCode launch action",
@@ -634,8 +634,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -712,7 +712,7 @@
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -787,8 +787,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -831,7 +831,7 @@
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "openshift": {
                 "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -875,8 +875,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1127,7 +1127,7 @@
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "vscodeLaunch": {
                           "description": "Command providing the definition of a VsCode launch action",
@@ -1311,8 +1311,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1386,7 +1386,7 @@
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
                                     "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1439,8 +1439,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1482,7 +1482,7 @@
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "openshift": {
                           "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1524,8 +1524,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1870,7 +1870,7 @@
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "vscodeLaunch": {
                     "description": "Command providing the definition of a VsCode launch action",
@@ -2059,8 +2059,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2134,7 +2134,7 @@
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2187,8 +2187,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2230,7 +2230,7 @@
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "openshift": {
                     "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2272,8 +2272,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2523,7 +2523,7 @@
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "vscodeLaunch": {
                               "description": "Command providing the definition of a VsCode launch action",
@@ -2707,8 +2707,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -2782,7 +2782,7 @@
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
                                         "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2835,8 +2835,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -2878,7 +2878,7 @@
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "openshift": {
                               "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2920,8 +2920,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3133,7 +3133,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "sparseCheckoutDirs": {
                     "description": "Populate the project sparsely with selected directories.",
@@ -3257,7 +3257,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "subDir": {
                     "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3411,7 +3411,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "sparseCheckoutDirs": {
                 "description": "Populate the project sparsely with selected directories.",
@@ -3561,7 +3561,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "subDir": {
                 "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -427,7 +427,9 @@
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "vscodeLaunch": {
                 "description": "Command providing the definition of a VsCode launch action",
@@ -631,7 +633,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -706,7 +710,9 @@
                       "properties": {
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -780,7 +786,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -821,7 +829,9 @@
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "openshift": {
                 "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -864,7 +874,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1113,7 +1125,9 @@
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "vscodeLaunch": {
                           "description": "Command providing the definition of a VsCode launch action",
@@ -1296,7 +1310,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1368,7 +1384,9 @@
                                 "properties": {
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1420,7 +1438,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1460,7 +1480,9 @@
                         },
                         "name": {
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "openshift": {
                           "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1501,7 +1523,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1844,7 +1868,9 @@
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "vscodeLaunch": {
                     "description": "Command providing the definition of a VsCode launch action",
@@ -2032,7 +2058,9 @@
                               ]
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2104,7 +2132,9 @@
                           "properties": {
                             "name": {
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2156,7 +2186,9 @@
                               ]
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2196,7 +2228,9 @@
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "openshift": {
                     "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2237,7 +2271,9 @@
                               ]
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2485,7 +2521,9 @@
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "vscodeLaunch": {
                               "description": "Command providing the definition of a VsCode launch action",
@@ -2668,7 +2706,9 @@
                                         ]
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -2740,7 +2780,9 @@
                                     "properties": {
                                       "name": {
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2792,7 +2834,9 @@
                                         ]
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -2832,7 +2876,9 @@
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "openshift": {
                               "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2873,7 +2919,9 @@
                                         ]
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3083,7 +3131,9 @@
                   },
                   "name": {
                     "description": "Project name",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "sparseCheckoutDirs": {
                     "description": "Populate the project sparsely with selected directories.",
@@ -3205,7 +3255,9 @@
                   },
                   "name": {
                     "description": "Project name",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "subDir": {
                     "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3357,7 +3409,9 @@
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "sparseCheckoutDirs": {
                 "description": "Populate the project sparsely with selected directories.",
@@ -3505,7 +3559,9 @@
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "subDir": {
                 "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -440,7 +440,9 @@
                   },
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "vscodeLaunch": {
                     "description": "Command providing the definition of a VsCode launch action",
@@ -644,7 +646,9 @@
                               ]
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -719,7 +723,9 @@
                           "properties": {
                             "name": {
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -793,7 +799,9 @@
                               ]
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -834,7 +842,9 @@
                   },
                   "name": {
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "openshift": {
                     "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -877,7 +887,9 @@
                               ]
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -1126,7 +1138,9 @@
                             },
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "vscodeLaunch": {
                               "description": "Command providing the definition of a VsCode launch action",
@@ -1309,7 +1323,9 @@
                                         ]
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1381,7 +1397,9 @@
                                     "properties": {
                                       "name": {
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1433,7 +1451,9 @@
                                         ]
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1473,7 +1493,9 @@
                             },
                             "name": {
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "openshift": {
                               "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1514,7 +1536,9 @@
                                         ]
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1857,7 +1881,9 @@
                       },
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "vscodeLaunch": {
                         "description": "Command providing the definition of a VsCode launch action",
@@ -2045,7 +2071,9 @@
                                   ]
                                 },
                                 "name": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2117,7 +2145,9 @@
                               "properties": {
                                 "name": {
                                   "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2169,7 +2199,9 @@
                                   ]
                                 },
                                 "name": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2209,7 +2241,9 @@
                       },
                       "name": {
                         "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "openshift": {
                         "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2250,7 +2284,9 @@
                                   ]
                                 },
                                 "name": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2498,7 +2534,9 @@
                                 },
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "vscodeLaunch": {
                                   "description": "Command providing the definition of a VsCode launch action",
@@ -2681,7 +2719,9 @@
                                             ]
                                           },
                                           "name": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -2753,7 +2793,9 @@
                                         "properties": {
                                           "name": {
                                             "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                            "type": "string"
+                                            "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2805,7 +2847,9 @@
                                             ]
                                           },
                                           "name": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -2845,7 +2889,9 @@
                                 },
                                 "name": {
                                   "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "openshift": {
                                   "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2886,7 +2932,9 @@
                                             ]
                                           },
                                           "name": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3096,7 +3144,9 @@
                       },
                       "name": {
                         "description": "Project name",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "sparseCheckoutDirs": {
                         "description": "Populate the project sparsely with selected directories.",
@@ -3218,7 +3268,9 @@
                       },
                       "name": {
                         "description": "Project name",
-                        "type": "string"
+                        "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "subDir": {
                         "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3370,7 +3422,9 @@
                   },
                   "name": {
                     "description": "Project name",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "sparseCheckoutDirs": {
                     "description": "Populate the project sparsely with selected directories.",
@@ -3518,7 +3572,9 @@
                   },
                   "name": {
                     "description": "Project name",
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "subDir": {
                     "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -442,7 +442,7 @@
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "vscodeLaunch": {
                     "description": "Command providing the definition of a VsCode launch action",
@@ -647,8 +647,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -725,7 +725,7 @@
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -800,8 +800,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -844,7 +844,7 @@
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "openshift": {
                     "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -888,8 +888,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -1140,7 +1140,7 @@
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "vscodeLaunch": {
                               "description": "Command providing the definition of a VsCode launch action",
@@ -1324,8 +1324,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1399,7 +1399,7 @@
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
                                         "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1452,8 +1452,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1495,7 +1495,7 @@
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "openshift": {
                               "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1537,8 +1537,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1883,7 +1883,7 @@
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "vscodeLaunch": {
                         "description": "Command providing the definition of a VsCode launch action",
@@ -2072,8 +2072,8 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "maxLength": 15,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2147,7 +2147,7 @@
                                   "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                   "type": "string",
                                   "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2200,8 +2200,8 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "maxLength": 15,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2243,7 +2243,7 @@
                         "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "openshift": {
                         "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2285,8 +2285,8 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "maxLength": 15,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2536,7 +2536,7 @@
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                                   "type": "string",
                                   "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "vscodeLaunch": {
                                   "description": "Command providing the definition of a VsCode launch action",
@@ -2720,8 +2720,8 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                            "maxLength": 15,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -2795,7 +2795,7 @@
                                             "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                             "type": "string",
                                             "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2848,8 +2848,8 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                            "maxLength": 15,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -2891,7 +2891,7 @@
                                   "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                                   "type": "string",
                                   "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "openshift": {
                                   "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2933,8 +2933,8 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                            "maxLength": 15,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3146,7 +3146,7 @@
                         "description": "Project name",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "sparseCheckoutDirs": {
                         "description": "Populate the project sparsely with selected directories.",
@@ -3270,7 +3270,7 @@
                         "description": "Project name",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                       },
                       "subDir": {
                         "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3424,7 +3424,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "sparseCheckoutDirs": {
                     "description": "Populate the project sparsely with selected directories.",
@@ -3574,7 +3574,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "subDir": {
                     "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -214,7 +214,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -414,8 +414,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -492,7 +492,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -547,8 +547,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -591,7 +591,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -635,8 +635,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -887,7 +887,7 @@
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "vscodeLaunch": {
                       "description": "Command providing the definition of a VsCode launch action",
@@ -1071,8 +1071,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1146,7 +1146,7 @@
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
                                 "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1199,8 +1199,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1242,7 +1242,7 @@
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "openshift": {
                       "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1284,8 +1284,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1651,7 +1651,7 @@
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "vscodeLaunch": {
                 "description": "Command providing the definition of a VsCode launch action",
@@ -1840,8 +1840,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1915,7 +1915,7 @@
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1968,8 +1968,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2011,7 +2011,7 @@
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "openshift": {
                 "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2053,8 +2053,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2304,7 +2304,7 @@
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "vscodeLaunch": {
                           "description": "Command providing the definition of a VsCode launch action",
@@ -2488,8 +2488,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2563,7 +2563,7 @@
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
                                     "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2616,8 +2616,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2659,7 +2659,7 @@
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "openshift": {
                           "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2701,8 +2701,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2914,7 +2914,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "sparseCheckoutDirs": {
                 "description": "Populate the project sparsely with selected directories.",
@@ -3038,7 +3038,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "subDir": {
                 "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3169,7 +3169,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "sparseCheckoutDirs": {
             "description": "Populate the project sparsely with selected directories.",
@@ -3301,7 +3301,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "subDir": {
             "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -212,7 +212,9 @@
           },
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -411,7 +413,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -486,7 +490,9 @@
                   "properties": {
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -540,7 +546,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -581,7 +589,9 @@
           },
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -624,7 +634,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -873,7 +885,9 @@
                     },
                     "id": {
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "vscodeLaunch": {
                       "description": "Command providing the definition of a VsCode launch action",
@@ -1056,7 +1070,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1128,7 +1144,9 @@
                             "properties": {
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1180,7 +1198,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1220,7 +1240,9 @@
                     },
                     "name": {
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "openshift": {
                       "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1261,7 +1283,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1625,7 +1649,9 @@
               },
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "vscodeLaunch": {
                 "description": "Command providing the definition of a VsCode launch action",
@@ -1813,7 +1839,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1885,7 +1913,9 @@
                       "properties": {
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1937,7 +1967,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1977,7 +2009,9 @@
               },
               "name": {
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "openshift": {
                 "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2018,7 +2052,9 @@
                           ]
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2266,7 +2302,9 @@
                         },
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "vscodeLaunch": {
                           "description": "Command providing the definition of a VsCode launch action",
@@ -2449,7 +2487,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2521,7 +2561,9 @@
                                 "properties": {
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -2573,7 +2615,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2613,7 +2657,9 @@
                         },
                         "name": {
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "openshift": {
                           "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -2654,7 +2700,9 @@
                                     ]
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2864,7 +2912,9 @@
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "sparseCheckoutDirs": {
                 "description": "Populate the project sparsely with selected directories.",
@@ -2986,7 +3036,9 @@
               },
               "name": {
                 "description": "Project name",
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
               },
               "subDir": {
                 "description": "Sub-directory from a starter project to be used as root for starter project.",
@@ -3115,7 +3167,9 @@
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sparseCheckoutDirs": {
             "description": "Populate the project sparsely with selected directories.",
@@ -3245,7 +3299,9 @@
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "subDir": {
             "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -295,7 +295,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -519,8 +519,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -601,7 +601,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -685,8 +685,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -734,7 +734,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -780,8 +780,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -1061,7 +1061,7 @@
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                     },
                     "vscodeLaunch": {
@@ -1265,8 +1265,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1346,7 +1346,7 @@
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
                                 "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                 "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
@@ -1406,8 +1406,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1455,7 +1455,7 @@
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                     },
                     "openshift": {
@@ -1500,8 +1500,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1891,7 +1891,7 @@
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "vscodeLaunch": {
@@ -2100,8 +2100,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2181,7 +2181,7 @@
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
@@ -2241,8 +2241,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2290,7 +2290,7 @@
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
               },
               "openshift": {
@@ -2335,8 +2335,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2616,7 +2616,7 @@
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "vscodeLaunch": {
@@ -2820,8 +2820,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2901,7 +2901,7 @@
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
                                     "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
@@ -2961,8 +2961,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -3010,7 +3010,7 @@
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                         },
                         "openshift": {
@@ -3055,8 +3055,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -3298,7 +3298,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "sparseCheckoutDirs": {
@@ -3439,7 +3439,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "subDir": {
@@ -3613,7 +3613,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "sparseCheckoutDirs": {
@@ -3781,7 +3781,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "subDir": {

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -294,6 +294,8 @@
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -516,7 +518,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -596,6 +600,8 @@
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -678,7 +684,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -725,6 +733,8 @@
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -769,7 +779,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -1048,6 +1060,8 @@
                     "id": {
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                     },
                     "vscodeLaunch": {
@@ -1250,7 +1264,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1329,6 +1345,8 @@
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                 "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
@@ -1387,7 +1405,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1434,6 +1454,8 @@
                     "name": {
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                     },
                     "openshift": {
@@ -1477,7 +1499,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1866,6 +1890,8 @@
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "vscodeLaunch": {
@@ -2073,7 +2099,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2152,6 +2180,8 @@
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
@@ -2210,7 +2240,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2257,6 +2289,8 @@
               "name": {
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
               },
               "openshift": {
@@ -2300,7 +2334,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2579,6 +2615,8 @@
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "vscodeLaunch": {
@@ -2781,7 +2819,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2860,6 +2900,8 @@
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                     "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
@@ -2918,7 +2960,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2965,6 +3009,8 @@
                         "name": {
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                         },
                         "openshift": {
@@ -3008,7 +3054,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -3249,6 +3297,8 @@
               "name": {
                 "description": "Project name",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "sparseCheckoutDirs": {
@@ -3388,6 +3438,8 @@
               "name": {
                 "description": "Project name",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "subDir": {
@@ -3560,6 +3612,8 @@
           "name": {
             "description": "Project name",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "sparseCheckoutDirs": {
@@ -3726,6 +3780,8 @@
           "name": {
             "description": "Project name",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "subDir": {

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -493,7 +493,7 @@
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "vscodeLaunch": {
@@ -717,8 +717,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -799,7 +799,7 @@
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
@@ -883,8 +883,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -932,7 +932,7 @@
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
               },
               "openshift": {
@@ -978,8 +978,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1259,7 +1259,7 @@
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "vscodeLaunch": {
@@ -1463,8 +1463,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1544,7 +1544,7 @@
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
                                     "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
@@ -1604,8 +1604,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1653,7 +1653,7 @@
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                         },
                         "openshift": {
@@ -1698,8 +1698,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2089,7 +2089,7 @@
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "vscodeLaunch": {
@@ -2298,8 +2298,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2379,7 +2379,7 @@
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
@@ -2439,8 +2439,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2488,7 +2488,7 @@
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                   },
                   "openshift": {
@@ -2533,8 +2533,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2814,7 +2814,7 @@
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "vscodeLaunch": {
@@ -3018,8 +3018,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3099,7 +3099,7 @@
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
                                         "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                         "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
@@ -3159,8 +3159,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3208,7 +3208,7 @@
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                             },
                             "openshift": {
@@ -3253,8 +3253,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3496,7 +3496,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "sparseCheckoutDirs": {
@@ -3637,7 +3637,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "subDir": {
@@ -3811,7 +3811,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "sparseCheckoutDirs": {
@@ -3979,7 +3979,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "subDir": {

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -492,6 +492,8 @@
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "vscodeLaunch": {
@@ -714,7 +716,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -794,6 +798,8 @@
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
@@ -876,7 +882,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -923,6 +931,8 @@
               "name": {
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
               },
               "openshift": {
@@ -967,7 +977,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -1246,6 +1258,8 @@
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "vscodeLaunch": {
@@ -1448,7 +1462,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1527,6 +1543,8 @@
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                     "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
@@ -1585,7 +1603,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -1632,6 +1652,8 @@
                         "name": {
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                         },
                         "openshift": {
@@ -1675,7 +1697,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2064,6 +2088,8 @@
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "vscodeLaunch": {
@@ -2271,7 +2297,9 @@
                               "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2350,6 +2378,8 @@
                             "name": {
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
@@ -2408,7 +2438,9 @@
                               "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2455,6 +2487,8 @@
                   "name": {
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                   },
                   "openshift": {
@@ -2498,7 +2532,9 @@
                               "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -2777,6 +2813,8 @@
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "vscodeLaunch": {
@@ -2979,7 +3017,9 @@
                                         "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3058,6 +3098,8 @@
                                       "name": {
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                         "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
@@ -3116,7 +3158,9 @@
                                         "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3163,6 +3207,8 @@
                             "name": {
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                               "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                             },
                             "openshift": {
@@ -3206,7 +3252,9 @@
                                         "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -3447,6 +3495,8 @@
                   "name": {
                     "description": "Project name",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "sparseCheckoutDirs": {
@@ -3586,6 +3636,8 @@
                   "name": {
                     "description": "Project name",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "subDir": {
@@ -3758,6 +3810,8 @@
               "name": {
                 "description": "Project name",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "sparseCheckoutDirs": {
@@ -3924,6 +3978,8 @@
               "name": {
                 "description": "Project name",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "subDir": {

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -505,6 +505,8 @@
                   "id": {
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "vscodeLaunch": {
@@ -727,7 +729,9 @@
                               "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -807,6 +811,8 @@
                             "name": {
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
@@ -889,7 +895,9 @@
                               "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -936,6 +944,8 @@
                   "name": {
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                   },
                   "openshift": {
@@ -980,7 +990,9 @@
                               "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                             },
                             "name": {
-                              "type": "string"
+                              "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -1259,6 +1271,8 @@
                             "id": {
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "vscodeLaunch": {
@@ -1461,7 +1475,9 @@
                                         "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1540,6 +1556,8 @@
                                       "name": {
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                         "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
@@ -1598,7 +1616,9 @@
                                         "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1645,6 +1665,8 @@
                             "name": {
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                               "type": "string",
+                              "maxLength": 63,
+                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                             },
                             "openshift": {
@@ -1688,7 +1710,9 @@
                                         "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                       },
                                       "name": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "maxLength": 63,
+                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -2077,6 +2101,8 @@
                       "id": {
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                         "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "vscodeLaunch": {
@@ -2284,7 +2310,9 @@
                                   "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                 },
                                 "name": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2363,6 +2391,8 @@
                                 "name": {
                                   "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                   "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                   "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                 },
                                 "path": {
@@ -2421,7 +2451,9 @@
                                   "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                 },
                                 "name": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2468,6 +2500,8 @@
                       "name": {
                         "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                         "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                       },
                       "openshift": {
@@ -2511,7 +2545,9 @@
                                   "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                 },
                                 "name": {
-                                  "type": "string"
+                                  "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2790,6 +2826,8 @@
                                 "id": {
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                                   "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                   "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "vscodeLaunch": {
@@ -2992,7 +3030,9 @@
                                             "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                           },
                                           "name": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3071,6 +3111,8 @@
                                           "name": {
                                             "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                             "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                             "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                           },
                                           "path": {
@@ -3129,7 +3171,9 @@
                                             "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                           },
                                           "name": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3176,6 +3220,8 @@
                                 "name": {
                                   "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                                   "type": "string",
+                                  "maxLength": 63,
+                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                   "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                                 },
                                 "openshift": {
@@ -3219,7 +3265,9 @@
                                             "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                           },
                                           "name": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "maxLength": 63,
+                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3460,6 +3508,8 @@
                       "name": {
                         "description": "Project name",
                         "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Project name"
                       },
                       "sparseCheckoutDirs": {
@@ -3599,6 +3649,8 @@
                       "name": {
                         "description": "Project name",
                         "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Project name"
                       },
                       "subDir": {
@@ -3771,6 +3823,8 @@
                   "name": {
                     "description": "Project name",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "sparseCheckoutDirs": {
@@ -3937,6 +3991,8 @@
                   "name": {
                     "description": "Project name",
                     "type": "string",
+                    "maxLength": 63,
+                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "subDir": {

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -506,7 +506,7 @@
                     "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                   },
                   "vscodeLaunch": {
@@ -730,8 +730,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -812,7 +812,7 @@
                               "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                             },
                             "path": {
@@ -896,8 +896,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -945,7 +945,7 @@
                     "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                   },
                   "openshift": {
@@ -991,8 +991,8 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                              "maxLength": 15,
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
                               "description": "Path of the endpoint URL",
@@ -1272,7 +1272,7 @@
                               "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                             },
                             "vscodeLaunch": {
@@ -1476,8 +1476,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1557,7 +1557,7 @@
                                         "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                         "type": "string",
                                         "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                         "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                       },
                                       "path": {
@@ -1617,8 +1617,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -1666,7 +1666,7 @@
                               "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                               "type": "string",
                               "maxLength": 63,
-                              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                               "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                             },
                             "openshift": {
@@ -1711,8 +1711,8 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 63,
-                                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                        "maxLength": 15,
+                                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
                                         "description": "Path of the endpoint URL",
@@ -2102,7 +2102,7 @@
                         "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                       },
                       "vscodeLaunch": {
@@ -2311,8 +2311,8 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "maxLength": 15,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2392,7 +2392,7 @@
                                   "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                   "type": "string",
                                   "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                   "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                 },
                                 "path": {
@@ -2452,8 +2452,8 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "maxLength": 15,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2501,7 +2501,7 @@
                         "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                       },
                       "openshift": {
@@ -2546,8 +2546,8 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                  "maxLength": 15,
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
                                   "description": "Path of the endpoint URL",
@@ -2827,7 +2827,7 @@
                                   "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                                   "type": "string",
                                   "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                   "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                                 },
                                 "vscodeLaunch": {
@@ -3031,8 +3031,8 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                            "maxLength": 15,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3112,7 +3112,7 @@
                                             "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                             "type": "string",
                                             "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                             "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                           },
                                           "path": {
@@ -3172,8 +3172,8 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                            "maxLength": 15,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3221,7 +3221,7 @@
                                   "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                                   "type": "string",
                                   "maxLength": 63,
-                                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                   "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                                 },
                                 "openshift": {
@@ -3266,8 +3266,8 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 63,
-                                            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                            "maxLength": 15,
+                                            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
                                             "description": "Path of the endpoint URL",
@@ -3509,7 +3509,7 @@
                         "description": "Project name",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Project name"
                       },
                       "sparseCheckoutDirs": {
@@ -3650,7 +3650,7 @@
                         "description": "Project name",
                         "type": "string",
                         "maxLength": 63,
-                        "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                        "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Project name"
                       },
                       "subDir": {
@@ -3824,7 +3824,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "sparseCheckoutDirs": {
@@ -3992,7 +3992,7 @@
                     "description": "Project name",
                     "type": "string",
                     "maxLength": 63,
-                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
                   "subDir": {

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -237,6 +237,8 @@
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -454,7 +456,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -534,6 +538,8 @@
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -593,7 +599,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -640,6 +648,8 @@
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -684,7 +694,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -963,6 +975,8 @@
                     "id": {
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                     },
                     "vscodeLaunch": {
@@ -1165,7 +1179,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1244,6 +1260,8 @@
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                 "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
@@ -1302,7 +1320,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1349,6 +1369,8 @@
                     "name": {
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                     },
                     "openshift": {
@@ -1392,7 +1414,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1806,6 +1830,8 @@
               "id": {
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "vscodeLaunch": {
@@ -2013,7 +2039,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2092,6 +2120,8 @@
                         "name": {
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
@@ -2150,7 +2180,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2197,6 +2229,8 @@
               "name": {
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
               },
               "openshift": {
@@ -2240,7 +2274,9 @@
                           "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                         },
                         "name": {
-                          "type": "string"
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2519,6 +2555,8 @@
                         "id": {
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "vscodeLaunch": {
@@ -2721,7 +2759,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2800,6 +2840,8 @@
                                   "name": {
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                     "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
@@ -2858,7 +2900,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2905,6 +2949,8 @@
                         "name": {
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                         },
                         "openshift": {
@@ -2948,7 +2994,9 @@
                                     "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                                   },
                                   "name": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -3189,6 +3237,8 @@
               "name": {
                 "description": "Project name",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "sparseCheckoutDirs": {
@@ -3328,6 +3378,8 @@
               "name": {
                 "description": "Project name",
                 "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "subDir": {
@@ -3476,6 +3528,8 @@
           "name": {
             "description": "Project name",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "sparseCheckoutDirs": {
@@ -3624,6 +3678,8 @@
           "name": {
             "description": "Project name",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "subDir": {

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -238,7 +238,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -457,8 +457,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -539,7 +539,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -600,8 +600,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -649,7 +649,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -695,8 +695,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -976,7 +976,7 @@
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                     },
                     "vscodeLaunch": {
@@ -1180,8 +1180,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1261,7 +1261,7 @@
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
                                 "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                 "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
@@ -1321,8 +1321,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1370,7 +1370,7 @@
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                     },
                     "openshift": {
@@ -1415,8 +1415,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1831,7 +1831,7 @@
                 "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
               },
               "vscodeLaunch": {
@@ -2040,8 +2040,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2121,7 +2121,7 @@
                           "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                         },
                         "path": {
@@ -2181,8 +2181,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2230,7 +2230,7 @@
                 "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
               },
               "openshift": {
@@ -2275,8 +2275,8 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                          "maxLength": 15,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
                           "description": "Path of the endpoint URL",
@@ -2556,7 +2556,7 @@
                           "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                         },
                         "vscodeLaunch": {
@@ -2760,8 +2760,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2841,7 +2841,7 @@
                                     "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                     "type": "string",
                                     "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                     "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                                   },
                                   "path": {
@@ -2901,8 +2901,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -2950,7 +2950,7 @@
                           "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                           "type": "string",
                           "maxLength": 63,
-                          "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                           "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                         },
                         "openshift": {
@@ -2995,8 +2995,8 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 63,
-                                    "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                    "maxLength": 15,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
                                     "description": "Path of the endpoint URL",
@@ -3238,7 +3238,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "sparseCheckoutDirs": {
@@ -3379,7 +3379,7 @@
                 "description": "Project name",
                 "type": "string",
                 "maxLength": 63,
-                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
               "subDir": {
@@ -3529,7 +3529,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "sparseCheckoutDirs": {
@@ -3679,7 +3679,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "subDir": {

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -218,7 +218,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -427,8 +427,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -508,7 +508,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -568,8 +568,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -617,7 +617,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -662,8 +662,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -943,7 +943,7 @@
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                     },
                     "vscodeLaunch": {
@@ -1147,8 +1147,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1228,7 +1228,7 @@
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
                                 "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                                 "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
@@ -1288,8 +1288,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1337,7 +1337,7 @@
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                     },
                     "openshift": {
@@ -1382,8 +1382,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1603,7 +1603,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "sparseCheckoutDirs": {
@@ -1741,7 +1741,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "subDir": {

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -217,6 +217,8 @@
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -424,7 +426,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -503,6 +507,8 @@
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -561,7 +567,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -608,6 +616,8 @@
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -651,7 +661,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -930,6 +942,8 @@
                     "id": {
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
                     },
                     "vscodeLaunch": {
@@ -1132,7 +1146,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1211,6 +1227,8 @@
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                                 "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                               },
                               "path": {
@@ -1269,7 +1287,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1316,6 +1336,8 @@
                     "name": {
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
                     },
                     "openshift": {
@@ -1359,7 +1381,9 @@
                                 "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1578,6 +1602,8 @@
           "name": {
             "description": "Project name",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "sparseCheckoutDirs": {
@@ -1714,6 +1740,8 @@
           "name": {
             "description": "Project name",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
           "subDir": {

--- a/schemas/latest/ide-targeted/plugin-overrides.json
+++ b/schemas/latest/ide-targeted/plugin-overrides.json
@@ -218,7 +218,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -422,8 +422,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -503,7 +503,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -563,8 +563,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -612,7 +612,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -657,8 +657,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",

--- a/schemas/latest/ide-targeted/plugin-overrides.json
+++ b/schemas/latest/ide-targeted/plugin-overrides.json
@@ -217,6 +217,8 @@
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events."
           },
           "vscodeLaunch": {
@@ -419,7 +421,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -498,6 +502,8 @@
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                       "markdownDescription": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files."
                     },
                     "path": {
@@ -556,7 +562,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -603,6 +611,8 @@
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin."
           },
           "openshift": {
@@ -646,7 +656,9 @@
                       "markdownDescription": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`"
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -191,7 +191,9 @@
           },
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -379,7 +381,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -451,7 +455,9 @@
                   "properties": {
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -503,7 +509,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -543,7 +551,9 @@
           },
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -584,7 +594,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -832,7 +844,9 @@
                     },
                     "id": {
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "vscodeLaunch": {
                       "description": "Command providing the definition of a VsCode launch action",
@@ -1015,7 +1029,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1087,7 +1103,9 @@
                             "properties": {
                               "name": {
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1139,7 +1157,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1179,7 +1199,9 @@
                     },
                     "name": {
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "openshift": {
                       "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1220,7 +1242,9 @@
                                 ]
                               },
                               "name": {
-                                "type": "string"
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1410,7 +1434,9 @@
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "sparseCheckoutDirs": {
             "description": "Populate the project sparsely with selected directories.",
@@ -1529,7 +1555,9 @@
           },
           "name": {
             "description": "Project name",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "subDir": {
             "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -193,7 +193,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -382,8 +382,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -457,7 +457,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -510,8 +510,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -553,7 +553,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -595,8 +595,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -846,7 +846,7 @@
                       "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "vscodeLaunch": {
                       "description": "Command providing the definition of a VsCode launch action",
@@ -1030,8 +1030,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1105,7 +1105,7 @@
                                 "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                                 "type": "string",
                                 "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -1158,8 +1158,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1201,7 +1201,7 @@
                       "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "openshift": {
                       "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -1243,8 +1243,8 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 63,
-                                "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                                "maxLength": 15,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
                                 "description": "Path of the endpoint URL",
@@ -1436,7 +1436,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "sparseCheckoutDirs": {
             "description": "Populate the project sparsely with selected directories.",
@@ -1557,7 +1557,7 @@
             "description": "Project name",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "subDir": {
             "description": "Sub-directory from a starter project to be used as root for starter project.",

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -193,7 +193,7 @@
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -377,8 +377,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -452,7 +452,7 @@
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
                       "type": "string",
                       "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -505,8 +505,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -548,7 +548,7 @@
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
             "type": "string",
             "maxLength": 63,
-            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -590,8 +590,8 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 63,
-                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+                      "maxLength": 15,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -191,7 +191,9 @@
           },
           "id": {
             "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "vscodeLaunch": {
             "description": "Command providing the definition of a VsCode launch action",
@@ -374,7 +376,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -446,7 +450,9 @@
                   "properties": {
                     "name": {
                       "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
@@ -498,7 +504,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",
@@ -538,7 +546,9 @@
           },
           "name": {
             "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
           },
           "openshift": {
             "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
@@ -579,7 +589,9 @@
                       ]
                     },
                     "name": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
                       "description": "Path of the endpoint URL",


### PR DESCRIPTION
### What does this PR do?
This PR adds pattern validation and maxlength validation to devfile name and id, to validation the following rule during schema validation

```
^([a-z0-9]([-a-z0-9]*[a-z0-9]))?$

limit to lowercase chars i.e.; no uppercase allowed
limit within 63 chars
no special chars allowed, only dash(-)
start with an alphanumeric character
end with an alphanumeric character

```

### What issues does this PR fix or reference?
#201 

### Is your PR tested? Consider putting some instruction how to test your changes
Yes.
Tested with name: `runtime@runtimeruntimeruntimeruntimeruntimeruntimeruntimeruntimeruntimeruntime`
got error:
```
invalid devfile schema. errors :
- components.0.name: String length must be less than or equal to 63
- components.0.name: Does not match pattern '^([a-z0-9]([-a-z0-9]*[a-z0-9]))?$'
```

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
