### PR TITLE
Add design proposal on registry structure

### DIFF
--- a/docs/proposals/registry/registry-structure.md
+++ b/docs/proposals/registry/registry-structure.md
@@ -1,0 +1,101 @@
+# Devfile Registry Structure
+This document outlines the structure of a Devfile Registry Repository that’s used as the basis for an OCI Devfile Registry, hosted on Kubernetes. It also outlines how individual files in each stack will get pushed up to the OCI registry.
+
+This design proposal is a follow up to [Devfile Registry Packaging](https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md) and I recommend reading that first.
+
+## Terminology
+
+Some of the following terms will be used throughout this design proposal:
+
+**Devfile Registry Repository:** The GitHub repository that hosts the devfile stacks for consumption within an OCI registry. For example, [devfile/registry](https://github.com/devfile/registry).
+
+**Devfile Index Image:** The container image containing the devfile stacks and index.json used to bootstrap the OCI registry with devfile stacks
+
+**Registry Build:** The process that takes the devfile registry repository, generates the index.json and builds it up into the devfile index container image.
+
+**Registry Bootstrap:** The process that pushes the devfile stacks on the devfile index container to the OCI registry.
+
+## As-is Today
+Currently, the top-level structure of a devfile registry’s repository is unwritten, but it usually consists of a **devfiles** or **stacks** folder, and any associated files specific to that registry
+
+[devfile/registry](https://github.com/devfile/registry):
+<img width="914" alt="Screen Shot 2020-11-30 at 2 12 13 PM" src="https://user-images.githubusercontent.com/6880023/100653219-12a48100-3316-11eb-949c-38073a19acbc.png">
+
+Inside each **stacks** or **devfiles** folder, each folder corresponds to a devfile stack, containing usually just the devfile.yaml and a meta.yaml:
+<img width="1232" alt="Screen Shot 2020-11-30 at 2 10 50 PM" src="https://user-images.githubusercontent.com/6880023/100653095-e2f57900-3315-11eb-8c3f-86e56896ef15.png">
+
+<img width="1229" alt="Screen Shot 2020-11-30 at 2 11 20 PM" src="https://user-images.githubusercontent.com/6880023/100653133-f0aafe80-3315-11eb-8393-dbabfd8ce0d6.png">
+
+As part of the registry build, the index.json is generated based off of the stacks in the repository, and a devfile index image is generated containing the index.json and stacks.
+
+When deploying the OCI registry, the registry bootstrap process parses the index.json to find the devfile.yaml for each stack, and pushes the devfile up to the registry as a single layer. No other stack artifacts are pushed up as part of the layer, or as separate layer.
+
+## Problem
+Our approach of pushing only the devfile.yaml works fine currently because the stacks we’re pushing only have a devfile.yaml in them. However, devfile stacks may contain more than _just_ the devfile, and may also contains resources that are re-used across multiple stacks (such as certain vsx plugins).
+
+We need a defined way of knowing what files in a stack to push up in a, what layers each file in the stack should belong to, and where the stack's file should located. 
+
+## Proposal
+
+To solve the issue listed above, we should:
+1) Formally the expected structure of the Devfile Regisry Repository.
+2) Define the layers that compose a devfile stack on an OCI registry, and what each layer contains.
+
+### Repository Structure
+The structure of the “Devfile Registry Repository” should impose the following requirements:
+1) A top-level folder called `stacks`, which contains folders for each devfile stack.
+2) Each devfile stack folder must contain a `devfile.yaml`. Other files such as vsx plugins, stack logos, etc. can be included as needed.
+3) A Dockerfile to package the stacks and index.json (see https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md)
+4) Build scripts or tools for the registry (see https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md)
+
+### Layer Media types
+Currently, when we push devfile stacks to an OCI registry, it's pushed as a single layer, using the `application/vnd.devfileio.devfile.layer.v2+yaml` media type. We should instead be pushing the stack as a multi-layer artifact, adding the additional layers:
+
+**VSX Plugins**
+
+*.vsx - `application/vnd.devfileio.vsx.layer.v1.tar`
+
+**Stack logos**
+
+logo.svg - `image/svg+xml` or
+
+logo.png - `image/png`
+
+**Everything else**
+
+archive.tar - `application/x-tar`
+
+As part of the registry build process that packages the stacks into a container image, any files not belonging to the devfile, vsx or logo media types will be lumped together in a tar archive (using the media type `application/x-tar`).
+
+When the registry bootstrap process pushes the stack up to the OCI registry, each file belonging to one of the above media types (`devfile.yaml`, `*.vsx`, `logo.svg`/`logo.png`, `archive.tar`) will be treated as separate layers in the artifact.
+
+
+### Index.json Modification
+The index.json already includes a link to a stack’s devfile, which the registry bootstrap process parses when pushing devfiles up to the registry. 
+
+To make it easier to bootstrap the registry, and to avoid having to programmatically find which files to push individually; as part of the registry build process, include a new `layers` array in the index.json that tells the registry bootstrap process which layers the stack is composed of:
+```
+{
+    "name": "java-maven",
+    "displayName": "Maven Java",
+    "description": "Upstream Maven and OpenJDK 11",
+    "tags": [
+      "Java",
+      "Maven"
+    ],
+    "projectType": "maven",
+    "language": "java",
+    "layers": [
+      "devfile.yaml",
+      "java-lsp.vsx",
+      "xml-lsp.vsx",
+      "archive.tar",
+    ],
+    "links": {
+      "self": “catalog/java-maven:latest”,
+    }
+  },
+```
+
+
+

--- a/docs/proposals/registry/registry-structure.md
+++ b/docs/proposals/registry/registry-structure.md
@@ -3,18 +3,6 @@ This document outlines the structure of a Devfile Registry Repository that’s u
 
 This design proposal is a follow up to [Devfile Registry Packaging](https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md) and I recommend reading that first.
 
-## Terminology
-
-Some of the following terms will be used throughout this design proposal:
-
-**Devfile Registry Repository:** The GitHub repository that hosts the devfile stacks for consumption within an OCI registry. For example, [devfile/registry](https://github.com/devfile/registry).
-
-**Devfile Index Image:** The container image containing the devfile stacks and index.json used to bootstrap the OCI registry with devfile stacks
-
-**Registry Build:** The process that takes the devfile registry repository, generates the index.json and builds it up into the devfile index container image.
-
-**Registry Bootstrap:** The process that pushes the devfile stacks on the devfile index container to the OCI registry.
-
 ## As-is Today
 Currently, the top-level structure of a devfile registry’s repository is unwritten, but it usually consists of a **devfiles** or **stacks** folder, and any associated files specific to that registry
 
@@ -26,27 +14,26 @@ Inside each **stacks** or **devfiles** folder, each folder corresponds to a devf
 
 <img width="1229" alt="Screen Shot 2020-11-30 at 2 11 20 PM" src="https://user-images.githubusercontent.com/6880023/100653133-f0aafe80-3315-11eb-8393-dbabfd8ce0d6.png">
 
-As part of the registry build, the index.json is generated based off of the stacks in the repository, and a devfile index image is generated containing the index.json and stacks.
+As part of the registry build, the index.json is generated based on the stacks in the repository, and a devfile index image is generated containing the index.json and stacks.
 
 When deploying the OCI registry, the registry bootstrap process parses the index.json to find the devfile.yaml for each stack, and pushes the devfile up to the registry as a single layer. No other stack artifacts are pushed up as part of the layer, or as separate layer.
 
 ## Problem
 Our approach of pushing only the devfile.yaml works fine currently because the stacks we’re pushing only have a devfile.yaml in them. However, devfile stacks may contain more than _just_ the devfile, and may also contains resources that are re-used across multiple stacks (such as certain vsx plugins).
 
-We need a defined way of knowing what files in a stack to push up in a, what layers each file in the stack should belong to, and where the stack's files should located. 
+We need a defined way of knowing what files in a stack to push up, what layers each file in the stack should belong to, and where the stack's files should located. 
 
 ## Proposal
 
 To solve the issue listed above, we should:
-1) Formally the expected structure of the Devfile Regisry Repository.
+1) Formalize the expected structure of the Devfile Registry Repository.
 2) Define the layers that compose a devfile stack on an OCI registry, and what each layer contains.
 
 ### Repository Structure
-The structure of the “Devfile Registry Repository” should impose the following requirements:
+In addition to the registry's Dockerfile and build tools (for those, see [Devfile Registry Packaging](https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md)), the following requirements are imposed on the devfile registry repository:
+
 1) A top-level folder called `stacks`, which contains folders for each devfile stack.
-2) Each devfile stack folder must contain a `devfile.yaml`. Other files such as vsx plugins, stack logos, etc. can be included as needed.
-3) A Dockerfile to package the stacks and index.json (see https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md)
-4) Build scripts or tools for the registry (see https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md)
+2) Each devfile stack folder must contain a `devfile.yaml`. Other files such as vsx plugins, stack logos, etc. can be included as needed. 
 
 ### Layer Media types
 Currently, when we push devfile stacks to an OCI registry, it's pushed as a single layer, using the `application/vnd.devfileio.devfile.layer.v2+yaml` media type. We should instead be pushing the stack as a multi-layer artifact, adding the additional layers:
@@ -83,8 +70,6 @@ To make it easier to bootstrap the registry, and to avoid having to programmatic
       "Java",
       "Maven"
     ],
-    "projectType": "maven",
-    "language": "java",
     "layers": [
       "devfile.yaml",
       "java-lsp.vsx",

--- a/docs/proposals/registry/registry-structure.md
+++ b/docs/proposals/registry/registry-structure.md
@@ -30,10 +30,11 @@ To solve the issue listed above, we should:
 2) Define the layers that compose a devfile stack on an OCI registry, and what each layer contains.
 
 ### Repository Structure
-In addition to the registry's Dockerfile and build tools (for those, see [Devfile Registry Packaging](https://github.com/devfile/api/blob/master/docs/proposals/registry/devfile-packaging.md)), the following requirements are imposed on the devfile registry repository:
+The following requirements are imposed on the devfile registry repository:
 
 1) A top-level folder called `stacks`, which contains folders for each devfile stack.
 2) Each devfile stack folder must contain a `devfile.yaml`. Other files such as vsx plugins, stack logos, etc. can be included as needed. 
+3) Any build tools for the registry (such as scripts or Dockerfiles) should not be located at the top-level of the stack, and should reside in their own folder.
 
 ### Layer Media types
 Currently, when we push devfile stacks to an OCI registry, it's pushed as a single layer, using the `application/vnd.devfileio.devfile.layer.v2+yaml` media type. We should instead be pushing the stack as a multi-layer artifact, adding the additional layers:
@@ -60,7 +61,7 @@ When the registry bootstrap process pushes the stack up to the OCI registry, eac
 ### Index.json Modification
 The index.json already includes a link to a stack’s devfile, which the registry bootstrap process parses when pushing devfiles up to the registry. 
 
-To make it easier to bootstrap the registry, and to avoid having to programmatically find which files to push individually; as part of the registry build process, include a new `layers` array in the index.json that tells the registry bootstrap process which layers the stack is composed of:
+To make it easier to bootstrap the registry, and to avoid having to programmatically find which files to push individually; as part of the registry build process, include a new `resources` array in the index.json that tells the registry bootstrap process which resources the stack is composed of:
 ```
 {
     "name": "java-maven",
@@ -70,7 +71,7 @@ To make it easier to bootstrap the registry, and to avoid having to programmatic
       "Java",
       "Maven"
     ],
-    "layers": [
+    "resources": [
       "devfile.yaml",
       "java-lsp.vsx",
       "xml-lsp.vsx",

--- a/docs/proposals/registry/registry-structure.md
+++ b/docs/proposals/registry/registry-structure.md
@@ -33,7 +33,7 @@ When deploying the OCI registry, the registry bootstrap process parses the index
 ## Problem
 Our approach of pushing only the devfile.yaml works fine currently because the stacks we’re pushing only have a devfile.yaml in them. However, devfile stacks may contain more than _just_ the devfile, and may also contains resources that are re-used across multiple stacks (such as certain vsx plugins).
 
-We need a defined way of knowing what files in a stack to push up in a, what layers each file in the stack should belong to, and where the stack's file should located. 
+We need a defined way of knowing what files in a stack to push up in a, what layers each file in the stack should belong to, and where the stack's files should located. 
 
 ## Proposal
 
@@ -53,17 +53,17 @@ Currently, when we push devfile stacks to an OCI registry, it's pushed as a sing
 
 **VSX Plugins**
 
-*.vsx - `application/vnd.devfileio.vsx.layer.v1.tar`
+`*.vsx` -> `application/vnd.devfileio.vsx.layer.v1.tar`
 
 **Stack logos**
 
-logo.svg - `image/svg+xml` or
+`logo.svg` -> `image/svg+xml` or
 
-logo.png - `image/png`
+`logo.png` -> `image/png`
 
 **Everything else**
 
-archive.tar - `application/x-tar`
+`archive.tar` - `application/x-tar`
 
 As part of the registry build process that packages the stacks into a container image, any files not belonging to the devfile, vsx or logo media types will be lumped together in a tar archive (using the media type `application/x-tar`).
 

--- a/docs/proposals/registry/terminology.md
+++ b/docs/proposals/registry/terminology.md
@@ -1,0 +1,23 @@
+# Devfile Registry Terminology
+
+The following terms may be used throughout design proposals for devfile registries
+
+## Devfile Index Image
+
+The container image containing the devfile stacks and index.json used to bootstrap the OCI registry with devfile stacks
+
+## Devfile Registry Repository 
+
+The GitHub repository that hosts the devfile stacks for consumption within an OCI registry. For example, [devfile/registry](https://github.com/devfile/registry).
+
+## Devfile Registry Support Repository 
+
+The GitHub repository that hosts tooling for OCI devfile registries. This includes the [index generator tool](https://github.com/johnmcollier/registry-support/tree/master/index/generator), and the [index container base image](https://github.com/johnmcollier/registry-support/tree/master/oci-devfile-registry-metadata)
+
+## Registry Build 
+
+The process that takes the devfile registry repository, generates the index.json and builds it up into the devfile index container image.
+
+## Registry Bootstrap
+
+The process that pushes the devfile stacks on the devfile index container to the OCI registry.

--- a/docs/proposals/registry/terminology.md
+++ b/docs/proposals/registry/terminology.md
@@ -4,7 +4,7 @@ The following terms may be used throughout design proposals for devfile registri
 
 ## Devfile Index Image
 
-The container image containing the devfile stacks and index.json used to bootstrap the OCI registry with devfile stacks
+The container image containing the devfile stacks and index.json used to bootstrap the OCI registry with devfile stacks. It also runs the webserver that functions as a proxy to the OCI registry, and hosts the index.json.
 
 ## Devfile Registry Repository 
 
@@ -12,11 +12,11 @@ The GitHub repository that hosts the devfile stacks for consumption within an OC
 
 ## Devfile Registry Support Repository 
 
-The GitHub repository that hosts tooling for OCI devfile registries. This includes the [index generator tool](https://github.com/johnmcollier/registry-support/tree/master/index/generator), and the [index container base image](https://github.com/johnmcollier/registry-support/tree/master/oci-devfile-registry-metadata)
+The GitHub repository that hosts toolings for OCI devfile registries. This includes the [index generator tool](https://github.com/johnmcollier/registry-support/tree/master/index/generator), and the [index container base image](https://github.com/johnmcollier/registry-support/tree/master/index/server). It also contains the [build tools](https://github.com/johnmcollier/registry-support/tree/master/build-tools) and Dockerfile for creating the Devfile index image.
 
 ## Registry Build 
 
-The process that takes the devfile registry repository, generates the index.json and builds it up into the devfile index container image.
+The process that takes the devfile registry repository, generates the index.json and builds it up into the devfile index image.
 
 ## Registry Bootstrap
 


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

### What does this PR do?
Adds a design proposal outlining the structure of the devfile registry, as well as the required layer media types that make up a devfile stack stored in an OCI registry.

Once this proposal has been agreed upon, https://github.com/devfile/api/issues/191 will cover the work to include this information (mainly repository structure and supported media types) in public facing documentation for the devfile registry.

### What issues does this PR fix or reference?
https://github.com/devfile/api/issues/226. 


### Is your PR tested? Consider putting some instruction how to test your changes
N/A

#### Docs PR
N/A
