### PR TITLE
Fixing `Attributes` overriding failure when overriding for non primitive attributes

### DIFF
--- a/pkg/utils/overriding/overriding.go
+++ b/pkg/utils/overriding/overriding.go
@@ -138,16 +138,15 @@ var _ strategicpatch.LookupPatchMeta = mapEnabledPatchMetaFromStruct{
 	strategicpatch.PatchMetaFromStruct{},
 }
 
-
 func (s *mapEnabledPatchMetaFromStruct) replaceMapWithSingleKeyStruct(key string, elementIsSlice bool) {
-	t := s.T	
+	t := s.T
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
 
 	if t.Kind() == reflect.Map {
 		typeName := t.Name()
-		tag := `json:"` + key + `"` 
+		tag := `json:"` + key + `"`
 		elemType := t.Elem()
 		if typeName == "Attributes" {
 			if elementIsSlice {
@@ -158,13 +157,13 @@ func (s *mapEnabledPatchMetaFromStruct) replaceMapWithSingleKeyStruct(key string
 			}
 		}
 
-		s.T = reflect.StructOf([]reflect.StructField{{ Name: strings.Title(key), Type: elemType, Tag: reflect.StructTag(tag) }})
+		s.T = reflect.StructOf([]reflect.StructField{{Name: strings.Title(key), Type: elemType, Tag: reflect.StructTag(tag)}})
 	}
 }
 
 func (s mapEnabledPatchMetaFromStruct) LookupPatchMetadataForStruct(key string) (strategicpatch.LookupPatchMeta, strategicpatch.PatchMeta, error) {
 	s.replaceMapWithSingleKeyStruct(key, false)
-	
+
 	schema, patchMeta, err := s.PatchMetaFromStruct.LookupPatchMetadataForStruct(key)
 	var lookupPatchMeta strategicpatch.LookupPatchMeta = nil
 	if schema != nil {
@@ -175,7 +174,7 @@ func (s mapEnabledPatchMetaFromStruct) LookupPatchMetadataForStruct(key string) 
 
 func (s mapEnabledPatchMetaFromStruct) LookupPatchMetadataForSlice(key string) (strategicpatch.LookupPatchMeta, strategicpatch.PatchMeta, error) {
 	s.replaceMapWithSingleKeyStruct(key, true)
-	
+
 	schema, patchMeta, err := s.PatchMetaFromStruct.LookupPatchMetadataForSlice(key)
 	var lookupPatchMeta strategicpatch.LookupPatchMeta = nil
 	if schema != nil {

--- a/pkg/utils/overriding/overriding.go
+++ b/pkg/utils/overriding/overriding.go
@@ -2,6 +2,7 @@ package overriding
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	workspaces "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
@@ -91,7 +92,7 @@ func OverrideDevWorkspaceTemplateSpec(original *workspaces.DevWorkspaceTemplateS
 		return nil, err
 	}
 
-	patchedMap, err := strategicpatch.StrategicMergeMapPatchUsingLookupPatchMeta(originalMap, patchMap, schema)
+	patchedMap, err := strategicpatch.StrategicMergeMapPatchUsingLookupPatchMeta(originalMap, patchMap, mapEnabledPatchMetaFromStruct{schema})
 	if err != nil {
 		return nil, err
 	}
@@ -127,4 +128,58 @@ func ensureOnlyExistingElementsAreOverridden(spec *workspaces.DevWorkspaceTempla
 		return []error{}
 	},
 		spec, overrides)
+}
+
+type mapEnabledPatchMetaFromStruct struct {
+	strategicpatch.PatchMetaFromStruct
+}
+
+var _ strategicpatch.LookupPatchMeta = mapEnabledPatchMetaFromStruct{
+	strategicpatch.PatchMetaFromStruct{},
+}
+
+
+func (s *mapEnabledPatchMetaFromStruct) replaceMapWithSingleKeyStruct(key string, elementIsSlice bool) {
+	t := s.T	
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() == reflect.Map {
+		typeName := t.Name()
+		tag := `json:"` + key + `"` 
+		elemType := t.Elem()
+		if typeName == "Attributes" {
+			if elementIsSlice {
+				elemType = reflect.SliceOf(reflect.StructOf([]reflect.StructField{}))
+			} else {
+				tag = tag + ` patchStrategy:"replace"`
+				elemType = reflect.StructOf([]reflect.StructField{})
+			}
+		}
+
+		s.T = reflect.StructOf([]reflect.StructField{{ Name: strings.Title(key), Type: elemType, Tag: reflect.StructTag(tag) }})
+	}
+}
+
+func (s mapEnabledPatchMetaFromStruct) LookupPatchMetadataForStruct(key string) (strategicpatch.LookupPatchMeta, strategicpatch.PatchMeta, error) {
+	s.replaceMapWithSingleKeyStruct(key, false)
+	
+	schema, patchMeta, err := s.PatchMetaFromStruct.LookupPatchMetadataForStruct(key)
+	var lookupPatchMeta strategicpatch.LookupPatchMeta = nil
+	if schema != nil {
+		lookupPatchMeta = mapEnabledPatchMetaFromStruct{schema.(strategicpatch.PatchMetaFromStruct)}
+	}
+	return lookupPatchMeta, patchMeta, err
+}
+
+func (s mapEnabledPatchMetaFromStruct) LookupPatchMetadataForSlice(key string) (strategicpatch.LookupPatchMeta, strategicpatch.PatchMeta, error) {
+	s.replaceMapWithSingleKeyStruct(key, true)
+	
+	schema, patchMeta, err := s.PatchMetaFromStruct.LookupPatchMetadataForSlice(key)
+	var lookupPatchMeta strategicpatch.LookupPatchMeta = nil
+	if schema != nil {
+		lookupPatchMeta = mapEnabledPatchMetaFromStruct{schema.(strategicpatch.PatchMetaFromStruct)}
+	}
+	return lookupPatchMeta, patchMeta, err
 }

--- a/pkg/utils/overriding/overriding_test.go
+++ b/pkg/utils/overriding/overriding_test.go
@@ -308,7 +308,7 @@ func TestMerging(t *testing.T) {
 // in a weaker way than asserting string equality.
 func compareErrorMessages(t *testing.T, expected, actual string, failReason string) {
 	if expected == "" {
-		t.Error("Received error but did not expect one")
+		t.Error("Received error but did not expect one: " + actual)
 		return
 	}
 	expectedLines := strings.Split(strings.TrimSpace(expected), "\n")

--- a/pkg/utils/overriding/test-fixtures/patches/command-with-attributes/original.yaml
+++ b/pkg/utils/overriding/test-fixtures/patches/command-with-attributes/original.yaml
@@ -1,0 +1,24 @@
+commands:
+  - attributes:
+      boolAttributeToChange: true
+      stringAttributeToKeep: stringValue
+      
+      objectAttributeToReplaceFully:
+        attributeField: 9.9
+        objectAttributeField:
+          objectAttributeSubField: 10
+
+          
+      arrayAttributeToReplaceFully:
+        - stringElement
+        - objectElementNew:
+            objectElementField: objectElementFieldValue
+        - arrayElement:
+          - subArray1:
+            - a
+            - b
+          - subArray2:
+            - c
+    apply:
+      component: "mycomponent"
+    id: command-with-attributes-changed

--- a/pkg/utils/overriding/test-fixtures/patches/command-with-attributes/patch.yaml
+++ b/pkg/utils/overriding/test-fixtures/patches/command-with-attributes/patch.yaml
@@ -1,0 +1,24 @@
+commands:
+  - attributes:
+      boolAttributeToChange: false
+
+      newAttribute: true
+      objectAttributeToReplaceFully:
+      
+        objectAttributeField:
+          objectAttributeSubField: 11
+          newObjectAttributeSubField: newObjectAttributeFieldValue
+        newAttributeField: newAttributeFieldValue
+      arrayAttributeToReplaceFully:
+        - stringElementNew
+        - objectElementNew:
+            objectElementNewField: objectElementNewFieldValue
+        - arrayElementNew:
+          - subArray1:
+            - d
+          - subArray2:
+            - e
+            - f
+    apply: {}
+    
+    id: command-with-attributes-changed

--- a/pkg/utils/overriding/test-fixtures/patches/command-with-attributes/result.yaml
+++ b/pkg/utils/overriding/test-fixtures/patches/command-with-attributes/result.yaml
@@ -1,0 +1,24 @@
+commands:
+  - attributes:
+      boolAttributeToChange: false
+      stringAttributeToKeep: stringValue
+      newAttribute: true
+      objectAttributeToReplaceFully:
+      
+        objectAttributeField:
+          objectAttributeSubField: 11
+          newObjectAttributeSubField: newObjectAttributeFieldValue
+        newAttributeField: newAttributeFieldValue
+      arrayAttributeToReplaceFully:
+        - stringElementNew
+        - objectElementNew:
+            objectElementNewField: objectElementNewFieldValue
+        - arrayElementNew:
+          - subArray1:
+            - d
+          - subArray2:
+            - e
+            - f
+    apply:
+      component: "mycomponent"
+    id: command-with-attributes-changed


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug that prevents overriding non-primitive (arrays or objects) elements of an `attributes` field.

### What issues does this PR fix or reference?

https://github.com/devfile/api/issues/263

### Is your PR tested? Consider putting some instruction how to test your changes

Yes, tests are added in the PR itself.
