### PR TITLE
Fix push docs issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
         with:
           name: devfile-json-schema
       - name: Overwrite Next Json Schema in Docs
-        run: cp -f devfile.json docs-repo/docs/modules/ROOT/attachments/jsonschemas/next/devfile.json
+        run: cp -f devfile.json docs-repo/docs/modules/user-guide/attachments/jsonschemas/next/devfile.json
       - name: Push to the devfile/docs repo
         working-directory: docs-repo/
         run: |


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

### What does this PR do?
The docs repo changes the file system structure, API repo needs to accommodate that change as API repo is responsible for automatically pushing devfile.json to docs repo.

### What issues does this PR fix or reference?
Fix the issue below
![image](https://user-images.githubusercontent.com/15131537/101225083-8c15d980-365e-11eb-97c6-e5c45ea3d7e0.png)

