### PR TITLE
Fix docs push issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
           git config --global user.email "${lastCommitterEmail}"
           git config --global user.name "${lastCommitterName}"
           
-          git add docs/modules/ROOT/attachments/jsonschemas/next/devfile.json
+          git add docs/modules/user-guide/attachments/jsonschemas/next/devfile.json
           git commit -m "Update devfile schema based on devfile/api@${lastCommit}"
           git push "https://devfile-ci-robot:${{secrets.DOCS_UPDATE_SECRET}}@github.com/devfile/docs"
           


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

### What does this PR do?
The docs repo changes the file system structure, API repo needs to accommodate that change as API repo is responsible for automatically pushing devfile.json to docs repo.

### What issues does this PR fix or reference?
Fix the issue below:
![Screen Shot 2020-12-07 at 10 32 39 AM](https://user-images.githubusercontent.com/15131537/101370761-e8a01100-3877-11eb-8e49-a3c5d44038a8.png)

