### PR TITLE
Fix generation with multi apiversion

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -24,6 +24,8 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
+    shortNames:
+    - dw
     singular: devworkspace
   preserveUnknownFields: false
   scope: Namespaced

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DevWorkspace
     listKind: DevWorkspaceList
     plural: devworkspaces
+    shortNames:
+    - dw
     singular: devworkspace
   scope: Namespaced
   versions:

--- a/devfile.api.code-workspace
+++ b/devfile.api.code-workspace
@@ -65,7 +65,7 @@
                 "mode": "auto",
                 "program": "${workspaceFolder:generator}",
                 "env": { "GOMOD": "${workspaceFolder:generator}/go.mod"},
-                "args": [ "crds", "paths=./pkg/apis/workspaces/v1alpha2", "output:crds:artifacts:config=crds" ],
+                "args": [ "crds", "paths=./pkg/apis/workspaces/v1alpha2;./pkg/apis/workspaces/v1alpha1", "output:crds:artifacts:config=crds" ],
                 "cwd": "${workspaceFolder:api}"
             },
             {
@@ -75,7 +75,7 @@
                 "mode": "auto",
                 "program": "${workspaceFolder:generator}",
                 "env": { "GOMOD": "${workspaceFolder:generator}/go.mod"},
-                "args": [ "deepcopy", "paths=./pkg/apis/workspaces/v1alpha2" ],
+                "args": [ "deepcopy", "paths=./pkg/apis/workspaces/v1alpha2;./pkg/apis/workspaces/v1alpha1" ],
                 "cwd": "${workspaceFolder:api}"
             },
             {
@@ -85,7 +85,7 @@
                 "mode": "auto",
                 "program": "${workspaceFolder:generator}",
                 "env": { "GOMOD": "${workspaceFolder:generator}/go.mod"},
-                "args": [ "schemas", "paths=./pkg/apis/workspaces/v1alpha2", "output:schemas:artifacts:config=schemas" ],
+                "args": [ "schemas", "paths=./pkg/apis/workspaces/v1alpha2;./pkg/apis/workspaces/v1alpha1", "output:schemas:artifacts:config=schemas" ],
                 "cwd": "${workspaceFolder:api}"
             },
             {

--- a/generator/crds/gen.go
+++ b/generator/crds/gen.go
@@ -119,7 +119,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			if typeInfo == nil {
 				continue
 			}
-	
+
 			for _, markerVals := range typeInfo.Markers {
 				for _, val := range markerVals {
 					crdMarker, isCrdResourceMarker := val.(crdmarkers.Resource)
@@ -132,7 +132,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 				}
 			}
 		}
-	
+
 		for i, ver := range crdVersions {
 			copiedCrd := crdRaw.DeepCopy()
 			if crdVersions[i] == "v1beta1" {

--- a/generator/genutils/kube_liike_versions.go
+++ b/generator/genutils/kube_liike_versions.go
@@ -14,10 +14,23 @@ func (a sortByKubeLikeVersion) Len() int           { return len(a) }
 func (a sortByKubeLikeVersion) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a sortByKubeLikeVersion) Less(i, j int) bool { return version.CompareKubeAwareVersionStrings(a[i], a[j]) < 0 }
 
+
+// SortKubeLikeVersion sorts the provided versions according to "kube-like" versioning order.
+// "Kube-like" versions start with a "v", then are followed by a number (the major version),
+// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+// by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing
+// major version, then minor version. An example sorted list of versions:
+// v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 func SortKubeLikeVersion(versions []string) {
 	sort.Sort(sortByKubeLikeVersion(versions))
 }
 
+// LatestKubeLikeVersion retrieves the latest version from the the provided versions, according to "kube-like" versioning order.
+// "Kube-like" versions start with a "v", then are followed by a number (the major version),
+// then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first
+// by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing
+// major version, then minor version. An example sorted list of versions:
+// v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
 func LatestKubeLikeVersion(versions []string) string {
 	if len(versions) == 0 {
 		return ""

--- a/generator/genutils/kube_liike_versions.go
+++ b/generator/genutils/kube_liike_versions.go
@@ -6,14 +6,13 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 )
 
-
-
 type sortByKubeLikeVersion []string
-		
-func (a sortByKubeLikeVersion) Len() int           { return len(a) }
-func (a sortByKubeLikeVersion) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a sortByKubeLikeVersion) Less(i, j int) bool { return version.CompareKubeAwareVersionStrings(a[i], a[j]) < 0 }
 
+func (a sortByKubeLikeVersion) Len() int      { return len(a) }
+func (a sortByKubeLikeVersion) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a sortByKubeLikeVersion) Less(i, j int) bool {
+	return version.CompareKubeAwareVersionStrings(a[i], a[j]) < 0
+}
 
 // SortKubeLikeVersion sorts the provided versions according to "kube-like" versioning order.
 // "Kube-like" versions start with a "v", then are followed by a number (the major version),
@@ -38,5 +37,5 @@ func LatestKubeLikeVersion(versions []string) string {
 	versionsToSort := make([]string, len(versions))
 	copy(versionsToSort, versions)
 	sort.Sort(sortByKubeLikeVersion(versionsToSort))
-	return versionsToSort[len(versionsToSort)-1]	
+	return versionsToSort[len(versionsToSort)-1]
 }

--- a/generator/genutils/kube_liike_versions.go
+++ b/generator/genutils/kube_liike_versions.go
@@ -35,7 +35,8 @@ func LatestKubeLikeVersion(versions []string) string {
 	if len(versions) == 0 {
 		return ""
 	}
-	versionsToSort := versions
+	versionsToSort := make([]string, len(versions))
+	copy(versionsToSort, versions)
 	sort.Sort(sortByKubeLikeVersion(versionsToSort))
 	return versionsToSort[len(versionsToSort)-1]	
 }

--- a/generator/genutils/kube_liike_versions.go
+++ b/generator/genutils/kube_liike_versions.go
@@ -1,0 +1,28 @@
+package genutils
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/version"
+)
+
+
+
+type sortByKubeLikeVersion []string
+		
+func (a sortByKubeLikeVersion) Len() int           { return len(a) }
+func (a sortByKubeLikeVersion) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a sortByKubeLikeVersion) Less(i, j int) bool { return version.CompareKubeAwareVersionStrings(a[i], a[j]) < 0 }
+
+func SortKubeLikeVersion(versions []string) {
+	sort.Sort(sortByKubeLikeVersion(versions))
+}
+
+func LatestKubeLikeVersion(versions []string) string {
+	if len(versions) == 0 {
+		return ""
+	}
+	versionsToSort := versions
+	sort.Sort(sortByKubeLikeVersion(versionsToSort))
+	return versionsToSort[len(versionsToSort)-1]	
+}

--- a/generator/genutils/kube_like_versions.go
+++ b/generator/genutils/kube_like_versions.go
@@ -34,8 +34,11 @@ func LatestKubeLikeVersion(versions []string) string {
 	if len(versions) == 0 {
 		return ""
 	}
-	versionsToSort := make([]string, len(versions))
-	copy(versionsToSort, versions)
-	sort.Sort(sortByKubeLikeVersion(versionsToSort))
-	return versionsToSort[len(versionsToSort)-1]
+	latest := versions[0]
+	for _, ver := range versions {
+		if version.CompareKubeAwareVersionStrings(ver, latest) > 0 {
+			latest = ver
+		}
+	}
+	return latest
 }

--- a/generator/schemas/gen.go
+++ b/generator/schemas/gen.go
@@ -182,9 +182,9 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			if currentSchemaVersion != nil && schemaVersion != nil {
 				if schemaVersion.Compare(*currentSchemaVersion) <= 0 {
 					packageByGV[groupVersion].AddError(fmt.Errorf("The schema versions should be incremented on each increment of the corresponding K8S apiVersion.\n" +
-						"This is not the case in the '" + groupName + "' API group:\n" +
-						"  '" + currentAPIVersion + "' K8S apiVersion => '" + currentSchemaVersion.String() + "' Json schema version\n" +
-						"  '" + apiVersion + "' K8S apiVersion => '" + schemaVersion.String() + "' Json schema version\n"))
+						"This is not the case in the "%s' API group:\n" +
+						"  '%s' K8S apiVersion => '%s' Json schema version\n" +
+						"  '%s' K8S apiVersion => '%s' Json schema version\n", groupName, currentAPIVersion, currentSchemaVersion.String(), apiVersion, schemaVersion.String()))
 					return nil
 				}
 			}

--- a/generator/schemas/gen.go
+++ b/generator/schemas/gen.go
@@ -70,11 +70,11 @@ func (Generator) RegisterMarkers(into *markers.Registry) error {
 }
 
 type toGenerate struct {
-	groupName string
-	version string
+	groupName            string
+	version              string
 	devfileSchemaVersion *semver.Version
-	unionDiscriminators []markers.FieldInfo
-	jsonschemaRequested []*markers.TypeInfo
+	unionDiscriminators  []markers.FieldInfo
+	jsonschemaRequested  []*markers.TypeInfo
 }
 
 // Generate generates the artifacts
@@ -93,16 +93,16 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	}
 
 	toGenerateByPackage := map[*loader.Package]toGenerate{}
-	
+
 	apiVersionsByAPIGroup := map[string][]string{}
 	schemaVersionsByGV := map[schema.GroupVersion]*semver.Version{}
 	packageByGV := map[schema.GroupVersion]*loader.Package{}
 
 	for _, root := range ctx.Roots {
-		forRoot := toGenerate {
+		forRoot := toGenerate{
 			version: root.Name,
 		}
-		
+
 		ctx.Checker.Check(root, func(node ast.Node) bool {
 			// ignore interfaces
 			_, isIface := node.(*ast.InterfaceType)
@@ -161,7 +161,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			return nil
 		}
 		groupVersion := schema.GroupVersion{
-			Group: forRoot.groupName,
+			Group:   forRoot.groupName,
 			Version: forRoot.version,
 		}
 
@@ -173,7 +173,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 
 	for groupName, apiVersions := range apiVersionsByAPIGroup {
 		genutils.SortKubeLikeVersion(apiVersions)
-		
+
 		var currentSchemaVersion *semver.Version
 		var currentAPIVersion string
 		for _, apiVersion := range apiVersions {
@@ -181,10 +181,10 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			schemaVersion := schemaVersionsByGV[groupVersion]
 			if currentSchemaVersion != nil && schemaVersion != nil {
 				if schemaVersion.Compare(*currentSchemaVersion) <= 0 {
-					packageByGV[groupVersion].AddError(fmt.Errorf("The schema versions should be incremented on each increment of the corresponding K8S apiVersion.\n" + 
-					"This is not the case in the '" + groupName + "' API group:\n" +
-					"  '" + currentAPIVersion + "' K8S apiVersion => '" + currentSchemaVersion.String() + "' Json schema version\n" +
-					"  '" + apiVersion + "' K8S apiVersion => '" + schemaVersion.String() + "' Json schema version\n"))
+					packageByGV[groupVersion].AddError(fmt.Errorf("The schema versions should be incremented on each increment of the corresponding K8S apiVersion.\n" +
+						"This is not the case in the '" + groupName + "' API group:\n" +
+						"  '" + currentAPIVersion + "' K8S apiVersion => '" + currentSchemaVersion.String() + "' Json schema version\n" +
+						"  '" + apiVersion + "' K8S apiVersion => '" + schemaVersion.String() + "' Json schema version\n"))
 					return nil
 				}
 			}
@@ -193,7 +193,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		}
 	}
 
-	for root, toDo := range toGenerateByPackage {		
+	for root, toDo := range toGenerateByPackage {
 		for _, typeToProcess := range toDo.jsonschemaRequested {
 			typeIdent := crd.TypeIdent{
 				Package: root,

--- a/generator/schemas/gen.go
+++ b/generator/schemas/gen.go
@@ -181,10 +181,12 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			schemaVersion := schemaVersionsByGV[groupVersion]
 			if currentSchemaVersion != nil && schemaVersion != nil {
 				if schemaVersion.Compare(*currentSchemaVersion) <= 0 {
-					packageByGV[groupVersion].AddError(fmt.Errorf("The schema versions should be incremented on each increment of the corresponding K8S apiVersion.\n" +
-						"This is not the case in the "%s' API group:\n" +
-						"  '%s' K8S apiVersion => '%s' Json schema version\n" +
-						"  '%s' K8S apiVersion => '%s' Json schema version\n", groupName, currentAPIVersion, currentSchemaVersion.String(), apiVersion, schemaVersion.String()))
+					packageByGV[groupVersion].AddError(
+						fmt.Errorf(`The schema versions should be incremented on each increment of the corresponding K8S apiVersion.
+This is not the case in the "%s' API group:
+  '%s' K8S apiVersion => '%s' Json schema version
+  '%s' K8S apiVersion => '%s' Json schema version`,
+							groupName, currentAPIVersion, currentSchemaVersion.String(), apiVersion, schemaVersion.String()))
 					return nil
 				}
 			}

--- a/generator/schemas/gen.go
+++ b/generator/schemas/gen.go
@@ -16,6 +16,7 @@ import (
 	"github.com/devfile/api/generator/genutils"
 	"github.com/iancoleman/strcase"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 
@@ -68,6 +69,14 @@ func (Generator) RegisterMarkers(into *markers.Registry) error {
 	return genutils.RegisterUnionMarkers(into)
 }
 
+type toGenerate struct {
+	groupName string
+	version string
+	devfileSchemaVersion *semver.Version
+	unionDiscriminators []markers.FieldInfo
+	jsonschemaRequested []*markers.TypeInfo
+}
+
 // Generate generates the artifacts
 func (g Generator) Generate(ctx *genall.GenerationContext) error {
 	parser := &crd.Parser{
@@ -83,7 +92,17 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		delete(p.Schemata, crd.TypeIdent{Name: "ObjectMeta", Package: pkg})
 	}
 
+	toGenerateByPackage := map[*loader.Package]toGenerate{}
+	
+	apiVersionsByAPIGroup := map[string][]string{}
+	schemaVersionsByGV := map[schema.GroupVersion]*semver.Version{}
+	packageByGV := map[schema.GroupVersion]*loader.Package{}
+
 	for _, root := range ctx.Roots {
+		forRoot := toGenerate {
+			version: root.Name,
+		}
+		
 		ctx.Checker.Check(root, func(node ast.Node) bool {
 			// ignore interfaces
 			_, isIface := node.(*ast.InterfaceType)
@@ -94,20 +113,17 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 
 		parser.NeedPackage(root)
 
-		unionDiscriminators := []markers.FieldInfo{}
-		jsonschemaRequested := []*markers.TypeInfo{}
-
 		if err := markers.EachType(ctx.Collector, root, func(info *markers.TypeInfo) {
 			if info.Markers.Get(genutils.UnionMarker.Name) != nil {
 				for _, field := range info.Fields {
 					if field.Markers.Get(genutils.UnionDiscriminatorMarker.Name) != nil {
-						unionDiscriminators = append(unionDiscriminators, field)
+						forRoot.unionDiscriminators = append(forRoot.unionDiscriminators, field)
 					}
 				}
 				return
 			}
 			if info.Markers.Get(jsonschemaGenerateMarker.Name) != nil {
-				jsonschemaRequested = append(jsonschemaRequested, info)
+				forRoot.jsonschemaRequested = append(forRoot.jsonschemaRequested, info)
 				return
 			}
 		}); err != nil {
@@ -115,8 +131,8 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			return nil
 		}
 
-		if len(jsonschemaRequested) == 0 {
-			return nil
+		if len(forRoot.jsonschemaRequested) == 0 {
+			continue
 		}
 
 		var devfileSchemaVersion *semver.Version
@@ -131,12 +147,54 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 				root.AddError(fmt.Errorf("In order to generate Json schemas from the K8S API, you should provide a valid semver-compatible devfile version in the +devfile:jsonschema:version comment marker of the K8S API package (in the doc.go file)"))
 				return nil
 			}
+			forRoot.devfileSchemaVersion = devfileSchemaVersion
 		default:
 			root.AddError(fmt.Errorf("In order to generate Json schemas from the K8S API, you should annotate the K8S API package (in the doc.go file) with the +devfile:jsonschema:version comment marker"))
 			return nil
 		}
 
-		for _, typeToProcess := range jsonschemaRequested {
+		switch groupName := packageMarkers.Get("groupName").(type) {
+		case string:
+			forRoot.groupName = groupName
+		default:
+			root.AddError(fmt.Errorf("The package should have a valid 'groupName' annotation"))
+			return nil
+		}
+		groupVersion := schema.GroupVersion{
+			Group: forRoot.groupName,
+			Version: forRoot.version,
+		}
+
+		apiVersionsByAPIGroup[groupVersion.Group] = append(apiVersionsByAPIGroup[groupVersion.Group], groupVersion.Version)
+		schemaVersionsByGV[groupVersion] = forRoot.devfileSchemaVersion
+		packageByGV[groupVersion] = root
+		toGenerateByPackage[root] = forRoot
+	}
+
+	for groupName, apiVersions := range apiVersionsByAPIGroup {
+		genutils.SortKubeLikeVersion(apiVersions)
+		
+		var currentSchemaVersion *semver.Version
+		var currentAPIVersion string
+		for _, apiVersion := range apiVersions {
+			groupVersion := schema.GroupVersion{Group: groupName, Version: apiVersion}
+			schemaVersion := schemaVersionsByGV[groupVersion]
+			if currentSchemaVersion != nil && schemaVersion != nil {
+				if schemaVersion.Compare(*currentSchemaVersion) <= 0 {
+					packageByGV[groupVersion].AddError(fmt.Errorf("The schema versions should be incremented on each increment of the corresponding K8S apiVersion.\n" + 
+					"This is not the case in the '" + groupName + "' API group:\n" +
+					"  '" + currentAPIVersion + "' K8S apiVersion => '" + currentSchemaVersion.String() + "' Json schema version\n" +
+					"  '" + apiVersion + "' K8S apiVersion => '" + schemaVersion.String() + "' Json schema version\n"))
+					return nil
+				}
+			}
+			currentAPIVersion = apiVersion
+			currentSchemaVersion = schemaVersion
+		}
+	}
+
+	for root, toDo := range toGenerateByPackage {		
+		for _, typeToProcess := range toDo.jsonschemaRequested {
 			typeIdent := crd.TypeIdent{
 				Package: root,
 				Name:    typeToProcess.Name,
@@ -154,7 +212,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 				fieldsToSkip = append(fieldsToSkip, "Custom")
 			}
 
-			genutils.AddUnionOneOfConstraints(&currentJSONSchema, unionDiscriminators, true, fieldsToSkip...)
+			genutils.AddUnionOneOfConstraints(&currentJSONSchema, toDo.unionDiscriminators, true, fieldsToSkip...)
 
 			// Fix descriptions to have them Markdown compatible
 			genutils.EditJSONSchema(&currentJSONSchema, func(schema *apiext.JSONSchemaProps) (newVisitor genutils.Visitor, stop bool) {
@@ -197,7 +255,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 			})
 
 			if schemaGenerateMarker.Title == "" {
-				schemaGenerateMarker.Title = typeToProcess.Name + " schema - Version " + devfileSchemaVersion.String()
+				schemaGenerateMarker.Title = typeToProcess.Name + " schema - Version " + toDo.devfileSchemaVersion.String()
 			}
 
 			(&currentJSONSchema).Title = schemaGenerateMarker.Title
@@ -236,6 +294,9 @@ to provide markdown-rendered documentation hovers.
 
 			schemaBaseName := strcase.ToKebab(typeToProcess.Name)
 			schemaFolder := "latest"
+			if toDo.version != genutils.LatestKubeLikeVersion(apiVersionsByAPIGroup[toDo.groupName]) {
+				schemaFolder = toDo.version
+			}
 			folderForIdeTargetedSchemas := filepath.Join(schemaFolder, "ide-targeted")
 			schemaFileName := schemaBaseName + ".json"
 			err = writeFile(ctx, schemaFolder, schemaFileName, jsonSchema)
@@ -253,7 +314,7 @@ to provide markdown-rendered documentation hovers.
 				root.AddError(err)
 				return nil
 			}
-			err = writeFile(ctx, schemaFolder, "jsonSchemaVersion.txt", []byte(devfileSchemaVersion.String()))
+			err = writeFile(ctx, schemaFolder, "jsonSchemaVersion.txt", []byte(toDo.devfileSchemaVersion.String()))
 			if err != nil {
 				root.AddError(err)
 				return nil

--- a/generator/vendor/k8s.io/apimachinery/pkg/version/doc.go
+++ b/generator/vendor/k8s.io/apimachinery/pkg/version/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +k8s:openapi-gen=true
+
+// Package version supplies the type for version information collected at build time.
+package version // import "k8s.io/apimachinery/pkg/version"

--- a/generator/vendor/k8s.io/apimachinery/pkg/version/helpers.go
+++ b/generator/vendor/k8s.io/apimachinery/pkg/version/helpers.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type versionType int
+
+const (
+	// Bigger the version type number, higher priority it is
+	versionTypeAlpha versionType = iota
+	versionTypeBeta
+	versionTypeGA
+)
+
+var kubeVersionRegex = regexp.MustCompile("^v([\\d]+)(?:(alpha|beta)([\\d]+))?$")
+
+func parseKubeVersion(v string) (majorVersion int, vType versionType, minorVersion int, ok bool) {
+	var err error
+	submatches := kubeVersionRegex.FindStringSubmatch(v)
+	if len(submatches) != 4 {
+		return 0, 0, 0, false
+	}
+	switch submatches[2] {
+	case "alpha":
+		vType = versionTypeAlpha
+	case "beta":
+		vType = versionTypeBeta
+	case "":
+		vType = versionTypeGA
+	default:
+		return 0, 0, 0, false
+	}
+	if majorVersion, err = strconv.Atoi(submatches[1]); err != nil {
+		return 0, 0, 0, false
+	}
+	if vType != versionTypeGA {
+		if minorVersion, err = strconv.Atoi(submatches[3]); err != nil {
+			return 0, 0, 0, false
+		}
+	}
+	return majorVersion, vType, minorVersion, true
+}
+
+// CompareKubeAwareVersionStrings compares two kube-like version strings.
+// Kube-like version strings are starting with a v, followed by a major version, optional "alpha" or "beta" strings
+// followed by a minor version (e.g. v1, v2beta1). Versions will be sorted based on GA/alpha/beta first and then major
+// and minor versions. e.g. v2, v1, v1beta2, v1beta1, v1alpha1.
+func CompareKubeAwareVersionStrings(v1, v2 string) int {
+	if v1 == v2 {
+		return 0
+	}
+	v1major, v1type, v1minor, ok1 := parseKubeVersion(v1)
+	v2major, v2type, v2minor, ok2 := parseKubeVersion(v2)
+	switch {
+	case !ok1 && !ok2:
+		return strings.Compare(v2, v1)
+	case !ok1 && ok2:
+		return -1
+	case ok1 && !ok2:
+		return 1
+	}
+	if v1type != v2type {
+		return int(v1type) - int(v2type)
+	}
+	if v1major != v2major {
+		return v1major - v2major
+	}
+	return v1minor - v2minor
+}

--- a/generator/vendor/k8s.io/apimachinery/pkg/version/types.go
+++ b/generator/vendor/k8s.io/apimachinery/pkg/version/types.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Info contains versioning information.
+// TODO: Add []string of api versions supported? It's still unclear
+// how we'll want to distribute that information.
+type Info struct {
+	Major        string `json:"major"`
+	Minor        string `json:"minor"`
+	GitVersion   string `json:"gitVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	BuildDate    string `json:"buildDate"`
+	GoVersion    string `json:"goVersion"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+}
+
+// String returns info as a human-friendly version string.
+func (info Info) String() string {
+	return info.GitVersion
+}

--- a/generator/vendor/modules.txt
+++ b/generator/vendor/modules.txt
@@ -92,6 +92,7 @@ k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/validation/field
+k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/klog v1.0.0


### PR DESCRIPTION
### What does this PR do?

This PR fixes the code / CRD and schema generation process to make it compatible with the support of several K8S API versions of the `workspace.devfile.io` api group. 

### What issues does this PR fix or reference?

This will fix issue https://github.com/devfile/api/issues/247 and is somehow a prerequisite to issue https://github.com/devfile/api/issues/150

### Is your PR tested? Consider putting some instruction how to test your changes

Yes, it was tested.

To test it, just change (temporarily) some source files of the `v1alpha1` package and run the generation:

- Add the following line just above the `package v1alpha1` line in file `pkg/apis/workspaces/v1alpha1/doc.go` file:
```go
// +devfile:jsonschema:version=2.0.0-alpha1
```
- Add the following line just above the `type DevWorkspaceTemplateSpec struct {` line in file `pkg/apis/workspaces/v1alpha1/devworkspaceTemplateSpec.go` file:
```go
// +devfile:jsonschema:generate
```
- Generate the Json Schemas with the `./build.sh` command

- Observe the new schemas created in the `v1alpha1` schema sub-folder.

If you update your previous change from: 
```go
// +devfile:jsonschema:version=2.0.0-alpha1
```
to
```go
// +devfile:jsonschema:version=2.0.0-beta1
```
And run the generation again, you will get the following expected error:
```
Generating JsonSchemas
github.com/devfile/api/pkg/apis/workspaces/v1alpha2:-: The schema versions should be incremented on each increment of the corresponding K8S apiVersion.
This is not the case in the 'workspace.devfile.io' API group:
  'v1alpha1' K8S apiVersion => '2.0.0-beta1' Json schema version
  'v1alpha2' K8S apiVersion => '2.0.0-alpha2' Json schema version

Error: not all generators ran successfully
```
