### PR TITLE
Update Attribute Key Not Found Err

### DIFF
--- a/pkg/attributes/attributes.go
+++ b/pkg/attributes/attributes.go
@@ -2,7 +2,6 @@ package attributes
 
 import (
 	"encoding/json"
-	"errors"
 	"strconv"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -65,7 +64,7 @@ func (attributes Attributes) getPrimitive(key string, zeroValue interface{}, res
 			}
 		}
 	} else {
-		err = errors.New("Attribute with key '" + key + "' does not exist")
+		err = &KeyNotFoundError{Key: key}
 	}
 	if errorHolder != nil {
 		*errorHolder = err
@@ -186,7 +185,7 @@ func (attributes Attributes) Get(key string, errorHolder *error) interface{} {
 			return (*container)[0]
 		}
 	} else if !exists && errorHolder != nil {
-		*errorHolder = errors.New("Attribute with key '" + key + "' does not exist")
+		*errorHolder = &KeyNotFoundError{Key: key}
 	}
 	return nil
 }
@@ -202,7 +201,7 @@ func (attributes Attributes) GetInto(key string, into interface{}) error {
 	if attribute, exists := attributes[key]; exists {
 		err = json.Unmarshal(attribute.Raw, into)
 	} else {
-		err = errors.New("Attribute with key '" + key + "' does not exist")
+		err = &KeyNotFoundError{Key: key}
 	}
 	return err
 }

--- a/pkg/attributes/attributes_test.go
+++ b/pkg/attributes/attributes_test.go
@@ -239,6 +239,10 @@ type decodeAttributeTestCase struct {
 	decodeIntoError         string
 }
 
+var invalidKey = "randomKey"
+
+var keyNotFoundErr error = &KeyNotFoundError{Key: invalidKey}
+
 var decodeAttributeTestCases []decodeAttributeTestCase = []decodeAttributeTestCase{
 	{
 		name:                    "DecodeSimpleString",
@@ -504,17 +508,17 @@ var decodeAttributeTestCases []decodeAttributeTestCase = []decodeAttributeTestCa
 	},
 	{
 		name:                    "GetInvalidKey",
-		attributeKey:            "randomKey",
+		attributeKey:            invalidKey,
 		attributeJson:           `9`,
 		expectedInterface:       nil,
 		expectedNumber:          float64(0),
-		expectedInterfaceError:  "Attribute with key 'randomKey' does not exist",
-		expectedBoolError:       "Attribute with key 'randomKey' does not exist",
-		expectedNumberError:     "Attribute with key 'randomKey' does not exist",
-		expectedStringError:     "Attribute with key 'randomKey' does not exist",
+		expectedInterfaceError:  keyNotFoundErr.Error(),
+		expectedBoolError:       keyNotFoundErr.Error(),
+		expectedNumberError:     keyNotFoundErr.Error(),
+		expectedStringError:     keyNotFoundErr.Error(),
 		decodeInto:              &map[string]interface{}{},
 		decodeIntoExpectedValue: map[string]interface{}{},
-		decodeIntoError:         "Attribute with key 'randomKey' does not exist",
+		decodeIntoError:         keyNotFoundErr.Error(),
 	},
 }
 

--- a/pkg/attributes/errors.go
+++ b/pkg/attributes/errors.go
@@ -1,0 +1,12 @@
+package attributes
+
+import "fmt"
+
+// KeyNotFoundError returns an error if no key is found for the attribute
+type KeyNotFoundError struct {
+	Key string
+}
+
+func (e *KeyNotFoundError) Error() string {
+	return fmt.Sprintf("Attribute with key %q does not exist", e.Key)
+}


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?
This is an extension of PR #270 

We define an error for Attribute key not found because this also enables devfile/api consumers like the devfile/library to check for the specific error rather than matching hardcoded error strings. Since devfile/library also uses attributes to allow filtering. So if an attribute key is not present from devfile/library's perspective, it should continue onto the next devfile object rather than error out.

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes
attributes_test.go

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
