### PR TITLE
add keyset length check

### DIFF
--- a/pkg/utils/overriding/merging.go
+++ b/pkg/utils/overriding/merging.go
@@ -36,6 +36,10 @@ func MergeDevWorkspaceTemplateSpec(
 	if err := ensureNoConflictsWithPlugins(mainContent, pluginFlattenedContents...); err != nil {
 		return nil, err
 	}
+	// also need to ensure no conflict between parent and plugins
+	if err := ensureNoConflictsWithPlugins(parentFlattenedContent, pluginFlattenedContents...); err != nil {
+		return nil, err
+	}
 
 	result := workspaces.DevWorkspaceTemplateSpecContent{}
 

--- a/pkg/utils/overriding/overriding.go
+++ b/pkg/utils/overriding/overriding.go
@@ -116,6 +116,9 @@ func OverrideDevWorkspaceTemplateSpec(original *workspaces.DevWorkspaceTemplateS
 
 func ensureOnlyExistingElementsAreOverridden(spec *workspaces.DevWorkspaceTemplateSpecContent, overrides workspaces.Overrides) error {
 	return checkKeys(func(elementType string, keysSets []sets.String) []error {
+		if len(keysSets) <= 1 {
+			return []error{}
+		}
 		specKeys := keysSets[0]
 		overlayKeys := keysSets[1]
 		newElementsInOverlay := overlayKeys.Difference(specKeys)


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
should not assume the keyset length
add keyset length check before access `keyset[0]` and `keyset[1]`

### What issues does this PR fix or reference?
fixes #276 

### Is your PR tested? Consider putting some instruction how to test your changes
tested with parser unit test

