### PR TITLE
Update Devfile API Go module to add version to module path

### DIFF
--- a/generator/overrides/gen.go
+++ b/generator/overrides/gen.go
@@ -127,7 +127,7 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		genutils.WriteFormattedSourceFile(fileNamePart, ctx, root, func(buf *bytes.Buffer) {
 			buf.WriteString(`
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 )
 
 `)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/devfile/api
+module github.com/devfile/api/v2
 
 go 1.13
 

--- a/pkg/apis/addtoscheme_workspaces_v1alpha2.go
+++ b/pkg/apis/addtoscheme_workspaces_v1alpha2.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func init() {

--- a/pkg/apis/workspaces/v1alpha1/attributes_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/attributes_conversion.go
@@ -2,7 +2,8 @@ package v1alpha1
 
 import (
 	"fmt"
-	"github.com/devfile/api/pkg/attributes"
+
+	"github.com/devfile/api/v2/pkg/attributes"
 )
 
 func convertAttributesTo_v1alpha2(src map[string]string, dest *attributes.Attributes) {

--- a/pkg/apis/workspaces/v1alpha1/commands_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/commands_conversion.go
@@ -2,9 +2,10 @@ package v1alpha1
 
 import (
 	"encoding/json"
-	"github.com/devfile/api/pkg/attributes"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/attributes"
+
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func convertCommandTo_v1alpha2(src *Command, dest *v1alpha2.Command) error {

--- a/pkg/apis/workspaces/v1alpha1/commands_conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/commands_conversion_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"

--- a/pkg/apis/workspaces/v1alpha1/components_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/components_conversion.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func convertComponentTo_v1alpha2(src *Component, dest *v1alpha2.Component) error {

--- a/pkg/apis/workspaces/v1alpha1/components_conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/components_conversion_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"

--- a/pkg/apis/workspaces/v1alpha1/conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/conversion.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func convertDevWorkspaceTo_v1alpha2(src *DevWorkspace, dest *v1alpha2.DevWorkspace) error {

--- a/pkg/apis/workspaces/v1alpha1/conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/conversion_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"

--- a/pkg/apis/workspaces/v1alpha1/devworkspace_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/devworkspace_conversion.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 

--- a/pkg/apis/workspaces/v1alpha1/devworkspacetemplate_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/devworkspacetemplate_conversion.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
 

--- a/pkg/apis/workspaces/v1alpha1/events_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/events_conversion.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 import (
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func convertEventsTo_v1alpha2(src *Events, dest *v1alpha2.Events) error {

--- a/pkg/apis/workspaces/v1alpha1/events_conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/events_conversion_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/apis/workspaces/v1alpha1/parent_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/parent_conversion.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func convertParentTo_v1alpha2(src *Parent, dest *v1alpha2.Parent) error {

--- a/pkg/apis/workspaces/v1alpha1/parent_conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/parent_conversion_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/google/go-cmp/cmp"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"

--- a/pkg/apis/workspaces/v1alpha1/plugin_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/plugin_conversion.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func convertPluginComponentTo_v1alpha2(srcComponent *Component, destComponent *v1alpha2.Component) error {

--- a/pkg/apis/workspaces/v1alpha1/projects_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/projects_conversion.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"encoding/json"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 func convertProjectTo_v1alpha2(src *Project, dest *v1alpha2.Project) error {

--- a/pkg/apis/workspaces/v1alpha1/projects_conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/projects_conversion_test.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
-	"github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/apis/workspaces/v1alpha2/components.go
+++ b/pkg/apis/workspaces/v1alpha2/components.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/apis/workspaces/v1alpha2/devfile.go
+++ b/pkg/apis/workspaces/v1alpha2/devfile.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 import (
-	"github.com/devfile/api/pkg/devfile"
+	"github.com/devfile/api/v2/pkg/devfile"
 )
 
 // Devfile describes the structure of a cloud-native workspace and development environment.

--- a/pkg/apis/workspaces/v1alpha2/endpoint.go
+++ b/pkg/apis/workspaces/v1alpha2/endpoint.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 )
 
 // EndpointProtocol defines the application and transport protocols of the traffic that will go through this endpoint.

--- a/pkg/apis/workspaces/v1alpha2/projects.go
+++ b/pkg/apis/workspaces/v1alpha2/projects.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.deepcopy.go
@@ -5,7 +5,7 @@
 package v1alpha2
 
 import (
-	"github.com/devfile/api/pkg/attributes"
+	"github.com/devfile/api/v2/pkg/attributes"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 )
 
 // +devfile:jsonschema:generate

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -1,7 +1,7 @@
 package v1alpha2
 
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 )
 
 // +devfile:jsonschema:generate

--- a/pkg/devfile/header.go
+++ b/pkg/devfile/header.go
@@ -1,7 +1,7 @@
 package devfile
 
 import (
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 )
 
 // DevfileHeader describes the structure of the devfile-specific top-level fields

--- a/pkg/devfile/header_test.go
+++ b/pkg/devfile/header_test.go
@@ -3,7 +3,7 @@ package devfile
 import (
 	"testing"
 
-	attributes "github.com/devfile/api/pkg/attributes"
+	attributes "github.com/devfile/api/v2/pkg/attributes"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
 )

--- a/pkg/utils/overriding/keys.go
+++ b/pkg/utils/overriding/keys.go
@@ -1,7 +1,7 @@
 package overriding
 
 import (
-	workspaces "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspaces "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/util/sets"
 )

--- a/pkg/utils/overriding/merging.go
+++ b/pkg/utils/overriding/merging.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	workspaces "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspaces "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"

--- a/pkg/utils/overriding/overriding.go
+++ b/pkg/utils/overriding/overriding.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"strings"
 
-	workspaces "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
-	unions "github.com/devfile/api/pkg/utils/unions"
+	workspaces "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	unions "github.com/devfile/api/v2/pkg/utils/unions"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 	strategicpatch "k8s.io/apimachinery/pkg/util/strategicpatch"

--- a/pkg/utils/overriding/overriding_test.go
+++ b/pkg/utils/overriding/overriding_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	workspaces "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspaces "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/json"
 	yamlMachinery "k8s.io/apimachinery/pkg/util/yaml"

--- a/pkg/utils/unions/normalize.go
+++ b/pkg/utils/unions/normalize.go
@@ -3,7 +3,7 @@ package unions
 import (
 	"reflect"
 
-	workspaces "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspaces "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/mitchellh/reflectwalk"
 )
 

--- a/pkg/utils/unions/normalize_test.go
+++ b/pkg/utils/unions/normalize_test.go
@@ -3,7 +3,7 @@ package unions
 import (
 	"testing"
 
-	workspaces "github.com/devfile/api/pkg/apis/workspaces/v1alpha2"
+	workspaces "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
### What does this PR do?
This PR updates the Go module path of the Devfile API to add the major version to its path, allowing v2 (and higher) versions of the module to be published.

As discussed on yesterday's Devfile cabal, to be able to publish the Devfile API Go module with a version of v2 or higher (and to ensure the module's version matches the Devfile schema version), we decided to update the module path of the Devfile API module to include the major version (`v2` in this case). Some discussion on why this is needed can be found [here](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher).

Once this PR is merged, consumers of the Devfile API Go module will need to update the import paths of the module's packages (`github.com/devfile/api/pkg/...` -> `github.com/devfile/api/v2/pkg/...`) when they update the version of the API module that they pull in that has these changes.

### What issues does this PR fix or reference?
N/A, but related to https://github.com/devfile/api/issues/150 and https://github.com/devfile/api/pull/278 (I can open a dedicated issue if needed).

### Is your PR tested? Consider putting some instruction how to test your changes
N/A

#### Docs PR
N/A

CC  @amisevsk @davidfestal @elsony @kadel @l0rd 