### PR TITLE
Add tools for releasing the Devfile schema

### DIFF
--- a/.github/workflows/release-schema.yaml
+++ b/.github/workflows/release-schema.yaml
@@ -1,0 +1,48 @@
+name: Release Devfile Schema
+
+# Triggers the workflow when a release is published on GitHub.
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-json-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout devfile docs
+        uses: actions/checkout@v2
+        with:
+          repository: devfile/docs
+          persist-credentials: false
+          path: docs-repo
+      - name: Checkout devfile api
+        uses: actions/checkout@v2
+        with:
+          path: api-repo
+      - name: Get the version being released
+        id: get_version
+        run: echo ::set-output name=version::$(cat api-repo/schemas/latest/jsonSchemaVersion.txt)
+      - name: Overwrite Stable Json Schema in Docs
+        run: mkdir -p docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable && cp -f api-repo/schemas/latest/devfile.json docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable/devfile.json
+      - name: Copy released Json Schema to Docs
+        run: mkdir -p docs-repo/docs/modules/user-guide/attachments/jsonschemas/${{ steps.get_version.outputs.VERSION }} && cp -f api-repo/schemas/latest/devfile.json docs-repo/docs/modules/user-guide/attachments/jsonschemas/${{ steps.get_version.outputs.VERSION }}/devfile.json
+      - name: Push to the devfile/docs repo
+        working-directory: docs-repo/
+        run: |
+          if [ "$(git status -s)" == "" ]
+          then
+            echo "Nothing to commit, Json schema didn't change"
+            exit 0
+          fi
+          
+          lastCommit="$(cd ../api-repo; git log -1 --format=%H)"
+          lastCommitterName="$(cd ../api-repo; git log -1 --format=%an)"
+          lastCommitterEmail="$(cd ../api-repo; git log -1 --format=%ae)"
+          
+          git config --global user.email "${lastCommitterEmail}"
+          git config --global user.name "${lastCommitterName}"
+          
+          git add docs/modules/user-guide/attachments/jsonschemas/stable/devfile.json docs/modules/user-guide/attachments/jsonschemas/${{ steps.get_version.outputs.VERSION }}/devfile.json 
+          git commit -m "Update devfile schema based on devfile/api@${lastCommit}"
+          git push "https://devfile-ci-robot:${{secrets.DOCS_UPDATE_SECRET}}@github.com/devfile/docs"
+          

--- a/.github/workflows/release-schema.yaml
+++ b/.github/workflows/release-schema.yaml
@@ -22,11 +22,36 @@ jobs:
       - name: Get the version being released
         id: get_version
         run: echo ::set-output name=version::$(cat api-repo/schemas/latest/jsonSchemaVersion.txt)
-      - name: Overwrite Stable Json Schema in Docs
+      - name: Overwrite Stable Json Schema in Docs if needed
         run: |
-          mkdir -p docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable && \
-          cp -f api-repo/schemas/latest/devfile.json \
-            docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable/devfile.json
+          if [ ! -f docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable/jsonSchemaVersion.txt ]; then
+            # Stable version doesn't currently exist, so just copy over the schema we're releasing
+            mkdir -p docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable
+            cp -f api-repo/schemas/latest/{devfile.json,jsonSchemaVersion.txt} \
+              docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable/
+            exit 0
+          fi
+
+          # Parse the schema version that's being released
+          IFS='.' read -a semver <<< "${{ steps.get_version.outputs.VERSION }}"
+          MAJOR=${semver[0]}
+          MINOR=${semver[1]}
+          BUGFIX=${semver[2]}
+          
+          # Parse the version currently set to stable
+          stableVersion=`cat docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable/jsonSchemaVersion.txt`
+          IFS='.' read -a stableSemVer <<< "$stableVersion"
+          stableMajor=${stableSemVer[0]}
+          stableMinor=${stableSemVer[1]}
+          stableBugfix=$(echo ${stableSemVer[2]} | awk -F '-' '{print $1}')
+
+          # Compare the two versions, only update stable if needed
+          if ((stableMajor <= MAJOR)) && ((stableMinor <= MINOR)) && ((stableBugfix <= BUGFIX)); then
+            cp -f api-repo/schemas/latest/{devfile.json,jsonSchemaVersion.txt} \
+              docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable/
+          else
+            echo "::warning::Current stable schema version is newer than the schema version being released, so the stable version will not be updated."
+          fi
       - name: Copy released Json Schema to Docs
         run: |
           mkdir -p docs-repo/docs/modules/user-guide/attachments/jsonschemas/${{ steps.get_version.outputs.VERSION }} && \
@@ -48,7 +73,7 @@ jobs:
           git config --global user.email "${lastCommitterEmail}"
           git config --global user.name "${lastCommitterName}"
           
-          git add docs/modules/user-guide/attachments/jsonschemas/stable/devfile.json docs/modules/user-guide/attachments/jsonschemas/${{ steps.get_version.outputs.VERSION }}/devfile.json 
+          git add --all
           git commit -m "Update devfile schema based on devfile/api@${lastCommit}"
           git push "https://devfile-ci-robot:${{secrets.DOCS_UPDATE_SECRET}}@github.com/devfile/docs"
           

--- a/.github/workflows/release-schema.yaml
+++ b/.github/workflows/release-schema.yaml
@@ -50,7 +50,7 @@ jobs:
             cp -f api-repo/schemas/latest/{devfile.json,jsonSchemaVersion.txt} \
               docs-repo/docs/modules/user-guide/attachments/jsonschemas/stable/
           else
-            echo "::warning::Current stable schema version is newer than the schema version being released, so the stable version will not be updated."
+            echo "::warning::Current stable schema version is newer than the schema version being released, so the stable schema will not be updated."
           fi
       - name: Copy released Json Schema to Docs
         run: |

--- a/docs/proposals/versioning-and-release.md
+++ b/docs/proposals/versioning-and-release.md
@@ -58,7 +58,11 @@ The following steps outline the steps done to release a new version of the Devfi
 
    1) The release engineer tasked with creating the release clones the repository (and checks out the release branch if one already exists)
 
-   2) `make-release.sh <schema-version> <k8s-api-version>` is run:
+   2) The release engineer installs the `hub` CLI from https://github.com/github/hub if it is not already installed on their machine.
+
+   3) `export GITHUB_TOKEN=<token>` is run, where `<token>` is a GitHub personal access token with `repo` permissions created from https://github.com/settings/tokens.
+
+   4) `./make-release.sh <schema-version> <k8s-api-version>` is run:
 
       i) A release branch (the name corresponding to the schema version) is created, if one does not already exist.
 
@@ -68,14 +72,16 @@ The following steps outline the steps done to release a new version of the Devfi
       
       iv) A new commit including the changes
 
-      v) Finally, a PR is opened to merge these changes into the release branch
+      v) A PR is opened to merge these changes into the release branch
 
-   3) Once the release PR is approved and merged, the release engineer creates a new release on GitHub based off the release branch that was just created and includes the generated `devfile.json` as a release artifact. 
+      vi) The schema version on the master branch is bumped and a PR is opened, provided the schema version passed in is **not** older than the master branch schema version. 
+
+   5) Once the release PR is approved and merged, the release engineer creates a new release on GitHub based off the release branch that was just created and includes the generated `devfile.json` as a release artifact. 
        - The tag `v{major}.{minor}.{bugfix}`, where the `{major}.{minor}.{bugfix}` corresponds to the devfile schema version, is used to enable the new version of the API to be pulled in as a Go module.
 
-   4) Once the release is published, GitHub actions run to publish the new schema to devfile.io. The “stable” schema is also updated to point to the new schema.
+   6) Once the release is published, GitHub actions run to publish the new schema to devfile.io. The “stable” schema is also updated to point to the new schema.
 
-   5) Make a release announcement on the devfile mailing list and slack channel
+   7) Make a release announcement on the devfile mailing list and slack channel
 
 An example pull request, `make-release.sh` script and GitHub action can be found here:
 - [Release Pull Request](https://github.com/johnmcollier/api/pull/7)

--- a/make-release.sh
+++ b/make-release.sh
@@ -107,12 +107,10 @@ bumpVersion() {
 }
 
 updateVersionOnMaster() {
-  # Switch back to the master branch
-  BRANCH=master
-  resetChanges $BRANCH
+  # Checkout to a PR branch based on master to make our changes in
   git checkout -b $SCHEMA_VERSION
-
-  # Set the schema version on master to the new version (with -alpha appended) and build the schemas
+  
+  # Set the schema version to the new version (with -alpha appended) and build the schemas
   setVersionAndBuild
   
   commitChanges "chore(post-release): bump schema version to ${SCHEMA_VERSION}"
@@ -124,14 +122,14 @@ compareMasterVersion() {
   MAJOR=${semver[0]}
   MINOR=${semver[1]}
   BUGFIX=${semver[2]}
-
+  
   # Parse the version currently set in the schema
   latestVersion=`cat schemas/latest/jsonSchemaVersion.txt`
   IFS='.' read -a latestSemVer <<< "$latestVersion"
   local latestMajor=${latestSemVer[0]}
   local latestMinor=${latestSemVer[1]}
   local latestBugfix=$(echo ${latestSemVer[2]} | awk -F '-' '{print $1}')
-
+  
   # Compare the new vers
   if ((latestMajor <= MAJOR)) && ((latestMinor <= MINOR)) && ((latestBugfix <= BUGFIX)); then
     return 0
@@ -150,6 +148,9 @@ run() {
   createPR "Release version ${SCHEMA_VERSION}"
 
   # If needed, bump the schema version in master and open a PR against master
+  # Switch back to the master branch
+  BRANCH=master
+  resetChanges $BRANCH
   if compareMasterVersion; then
     echo "[INFO] Updating schema version on master to ${SCHEMA_VERSION}"
     bumpVersion

--- a/make-release.sh
+++ b/make-release.sh
@@ -89,7 +89,7 @@ commitChanges() {
 
 createReleaseBranch() {
   echo "[INFO] Create the release branch based on $VERSION"
-  git push origin $VERSION:release -f
+  git push origin $VERSION -f
 }
 
 createPR() {

--- a/make-release.sh
+++ b/make-release.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
+# Based on https://github.com/che-incubator/chectl/blob/master/make-release.sh
+
+set -e
+set -u
+
+usage ()
+{   echo "Usage: ./make-release.sh <schema-version> <k8s-api-version>"
+    exit
+}
+
+if [[ $# -lt 2 ]]; then usage; fi
+
+if ! command -v hub > /dev/null; then
+  echo "[ERROR] The hub CLI needs to be installed. See https://github.com/github/hub/releases"
+  exit
+fi
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo "[ERROR] The GITHUB_TOKEN environment variable must be set."
+  exit
+fi
+
+VERSION=$1
+API_VERSION=$2
+
+init() {
+  BRANCH=$(echo $VERSION | sed 's/.$/x/')
+  echo $BRANCH
+}
+
+apply_sed() {
+    SHORT_UNAME=$(uname -s)
+  if [ "$(uname)" == "Darwin" ]; then
+    sed -i '' "$1" "$2"
+  elif [ "${SHORT_UNAME:0:5}" == "Linux" ]; then
+    sed -i "$1" "$2"
+  fi
+}
+
+resetChanges() {
+  echo "[INFO] Reset changes in $1 branch"
+  git reset --hard
+  git checkout $1
+  git fetch origin --prune
+  git pull origin $1
+}
+
+checkoutToReleaseBranch() {
+  echo "[INFO] Checking out to $BRANCH branch."
+  local branchExist=$(git ls-remote -q --heads | grep $BRANCH | wc -l)
+  if [[ $branchExist == 1 ]]; then
+    echo "[INFO] $BRANCH exists."
+    resetChanges $BRANCH
+  else
+    echo "[INFO] $BRANCH does not exist. Will be created a new one from master."
+    resetChanges master
+    git push origin master:$BRANCH
+  fi
+  git checkout -B $VERSION
+}
+
+release() {
+  echo "[INFO] Releasing a new $VERSION version"
+
+  # replace nightly versions by release version
+  apply_sed "s#jsonschema:version=.*#jsonschema:version=${VERSION}#g" pkg/apis/workspaces/$API_VERSION/doc.go #src/constants.ts
+
+  # Generate the schema
+  ./build.sh
+}
+
+commitChanges() {
+  echo "[INFO] Pushing changes to $VERSION branch"
+  git add -A
+  git commit -s -m "chore(release): release version ${VERSION}"
+  git push origin $VERSION
+}
+
+createReleaseBranch() {
+  echo "[INFO] Create the release branch based on $VERSION"
+  git push origin $VERSION:release -f
+}
+
+createPR() {
+  echo "[INFO] Creating a PR"
+  hub pull-request --base ${BRANCH} --head ${VERSION} -m "Release version ${VERSION}"
+}
+
+run() {
+  checkoutToReleaseBranch
+  release
+  commitChanges
+  createReleaseBranch
+  createPR
+}
+
+init
+run


### PR DESCRIPTION
### What does this PR do?
This PR adds tools for releasing and publishing the Devfile schema, as outlined [here](https://github.com/devfile/api/blob/master/docs/proposals/versioning-and-release.md):
- Adds a script to run that generates the schemas for the version being released (e.g. 2.0.0, 2.1.0, etc), and opens a pull request to merge them to the release branch.
    - Script is based on the `make-release.sh` from https://github.com/che-incubator/chectl/blob/master/make-release.sh
- Adds a GitHub workflow action that publishes the released schemas to the Devfile website when a release is created on GitHub.
    - For the time being, the GitHub release still needs to be manually created at first after merging the release PR to trigger the workflow.
    
### What issues does this PR fix or reference?
Resolves https://github.com/devfile/api/issues/150

### Is your PR tested? Consider putting some instruction how to test your changes
Yes.

For the `make-release.sh` script:
1) Ensure the `hub` CLI is installed and the `GITHUB_TOKEN` environment variable is set in your shell
2) Copy the script over from this PR to your fork of the repo
3) Run `./make-release.sh <some-schema-version> v1alpha2`

For the GitHub action, see https://github.com/johnmcollier/api/runs/1558896668?check_suite_focus=true for what a sample run looks like.

#### Docs PR
N/A
