### PR TITLE
change endpoint name limit to 63 characters

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -4539,7 +4539,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -4708,7 +4708,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -4817,7 +4817,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -5266,7 +5266,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -5425,7 +5425,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -5545,7 +5545,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -6073,7 +6073,7 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 15
+                                        maxLength: 63
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
@@ -6223,7 +6223,7 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 15
+                                        maxLength: 63
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
@@ -6334,7 +6334,7 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 15
+                                        maxLength: 63
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
@@ -6794,7 +6794,7 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 15
+                                                  maxLength: 63
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
@@ -6962,7 +6962,7 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 15
+                                                  maxLength: 63
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
@@ -7088,7 +7088,7 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 15
+                                                  maxLength: 63
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -4538,7 +4538,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -4710,7 +4710,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -4821,7 +4821,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -5271,7 +5271,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -5430,7 +5430,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -5550,7 +5550,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -6078,7 +6078,7 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 15
+                                        maxLength: 63
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
@@ -6228,7 +6228,7 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 15
+                                        maxLength: 63
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
@@ -6339,7 +6339,7 @@ spec:
                                         - none
                                         type: string
                                       name:
-                                        maxLength: 15
+                                        maxLength: 63
                                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                         type: string
                                       path:
@@ -6799,7 +6799,7 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 15
+                                                  maxLength: 63
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
@@ -6967,7 +6967,7 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 15
+                                                  maxLength: 63
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:
@@ -7093,7 +7093,7 @@ spec:
                                                   - none
                                                   type: string
                                                 name:
-                                                  maxLength: 15
+                                                  maxLength: 63
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 path:

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -4290,7 +4290,7 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 15
+                                maxLength: 63
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
@@ -4454,7 +4454,7 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 15
+                                maxLength: 63
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
@@ -4559,7 +4559,7 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 15
+                                maxLength: 63
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
@@ -4997,7 +4997,7 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 15
+                                          maxLength: 63
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
@@ -5149,7 +5149,7 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 15
+                                          maxLength: 63
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
@@ -5262,7 +5262,7 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 15
+                                          maxLength: 63
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
@@ -5773,7 +5773,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -5917,7 +5917,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -6025,7 +6025,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -6473,7 +6473,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -6632,7 +6632,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -6752,7 +6752,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -4289,7 +4289,7 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 15
+                                maxLength: 63
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
@@ -4456,7 +4456,7 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 15
+                                maxLength: 63
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
@@ -4563,7 +4563,7 @@ spec:
                                 - none
                                 type: string
                               name:
-                                maxLength: 15
+                                maxLength: 63
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               path:
@@ -5002,7 +5002,7 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 15
+                                          maxLength: 63
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
@@ -5154,7 +5154,7 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 15
+                                          maxLength: 63
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
@@ -5267,7 +5267,7 @@ spec:
                                           - none
                                           type: string
                                         name:
-                                          maxLength: 15
+                                          maxLength: 63
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         path:
@@ -5778,7 +5778,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -5922,7 +5922,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -6030,7 +6030,7 @@ spec:
                                     - none
                                     type: string
                                   name:
-                                    maxLength: 15
+                                    maxLength: 63
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   path:
@@ -6478,7 +6478,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -6637,7 +6637,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:
@@ -6757,7 +6757,7 @@ spec:
                                               - none
                                               type: string
                                             name:
-                                              maxLength: 15
+                                              maxLength: 63
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             path:

--- a/pkg/apis/workspaces/v1alpha2/endpoint.go
+++ b/pkg/apis/workspaces/v1alpha2/endpoint.go
@@ -48,7 +48,7 @@ const (
 
 type Endpoint struct {
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	TargetPort int `json:"targetPort"`

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -415,7 +415,7 @@ type ContainerParentOverride struct {
 type EndpointParentOverride struct {
 
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	//  +optional
@@ -968,7 +968,7 @@ type ContainerPluginOverrideParentOverride struct {
 type EndpointPluginOverrideParentOverride struct {
 
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	//  +optional

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -294,7 +294,7 @@ type ContainerPluginOverride struct {
 type EndpointPluginOverride struct {
 
 	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-	// +kubebuilder:validation:MaxLength=15
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	//  +optional

--- a/pkg/validation/validation-rule.md
+++ b/pkg/validation/validation-rule.md
@@ -6,7 +6,7 @@ The restriction is added to allow easy translation to K8s resource names, and al
 The validation will be done as part of schema validation, the rule will be introduced as a regex in schema definition, any objection of the rule in devfile will result in a failure.
 
 - limit to lowercase characters i.e., no uppercase allowed
-- limit within 63 characters, except for endpoint’s name which is limited within 15 characters
+- limit within 63 characters
 - no special characters allowed except dash(-)
 - start with an alphanumeric character
 - end with an alphanumeric character

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -469,7 +469,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -624,7 +624,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -714,7 +714,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -1152,7 +1152,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1282,7 +1282,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1369,7 +1369,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1906,7 +1906,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2036,7 +2036,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2123,7 +2123,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2560,7 +2560,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2690,7 +2690,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2777,7 +2777,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -634,7 +634,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -789,7 +789,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -879,7 +879,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -1317,7 +1317,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -1447,7 +1447,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -1534,7 +1534,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2071,7 +2071,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -2201,7 +2201,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -2288,7 +2288,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -2725,7 +2725,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -2855,7 +2855,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -2942,7 +2942,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -647,7 +647,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -802,7 +802,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -892,7 +892,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -1330,7 +1330,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -1460,7 +1460,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -1547,7 +1547,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -2084,7 +2084,7 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 15,
+                                  "maxLength": 63,
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
@@ -2214,7 +2214,7 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 15,
+                                  "maxLength": 63,
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
@@ -2301,7 +2301,7 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 15,
+                                  "maxLength": 63,
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
@@ -2738,7 +2738,7 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 15,
+                                            "maxLength": 63,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
@@ -2868,7 +2868,7 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 15,
+                                            "maxLength": 63,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
@@ -2955,7 +2955,7 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 15,
+                                            "maxLength": 63,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -414,7 +414,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -549,7 +549,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -639,7 +639,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -1077,7 +1077,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1207,7 +1207,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1294,7 +1294,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1875,7 +1875,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2005,7 +2005,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2092,7 +2092,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2529,7 +2529,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2659,7 +2659,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2746,7 +2746,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -519,7 +519,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -687,7 +687,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -784,7 +784,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -1271,7 +1271,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1414,7 +1414,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1510,7 +1510,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -2112,7 +2112,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2255,7 +2255,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2351,7 +2351,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2838,7 +2838,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2981,7 +2981,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -3077,7 +3077,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -717,7 +717,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -885,7 +885,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -982,7 +982,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -1469,7 +1469,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -1612,7 +1612,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -1708,7 +1708,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2310,7 +2310,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -2453,7 +2453,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -2549,7 +2549,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -3036,7 +3036,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -3179,7 +3179,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -3275,7 +3275,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -730,7 +730,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -898,7 +898,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -995,7 +995,7 @@
                             },
                             "name": {
                               "type": "string",
-                              "maxLength": 15,
+                              "maxLength": 63,
                               "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                             },
                             "path": {
@@ -1482,7 +1482,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -1625,7 +1625,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -1721,7 +1721,7 @@
                                       },
                                       "name": {
                                         "type": "string",
-                                        "maxLength": 15,
+                                        "maxLength": 63,
                                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                       },
                                       "path": {
@@ -2323,7 +2323,7 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 15,
+                                  "maxLength": 63,
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
@@ -2466,7 +2466,7 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 15,
+                                  "maxLength": 63,
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
@@ -2562,7 +2562,7 @@
                                 },
                                 "name": {
                                   "type": "string",
-                                  "maxLength": 15,
+                                  "maxLength": 63,
                                   "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                 },
                                 "path": {
@@ -3049,7 +3049,7 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 15,
+                                            "maxLength": 63,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
@@ -3192,7 +3192,7 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 15,
+                                            "maxLength": 63,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {
@@ -3288,7 +3288,7 @@
                                           },
                                           "name": {
                                             "type": "string",
-                                            "maxLength": 15,
+                                            "maxLength": 63,
                                             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                           },
                                           "path": {

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -457,7 +457,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -602,7 +602,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -699,7 +699,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -1186,7 +1186,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1329,7 +1329,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1425,7 +1425,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -2080,7 +2080,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2223,7 +2223,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2319,7 +2319,7 @@
                         },
                         "name": {
                           "type": "string",
-                          "maxLength": 15,
+                          "maxLength": 63,
                           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                         },
                         "path": {
@@ -2806,7 +2806,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -2949,7 +2949,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {
@@ -3045,7 +3045,7 @@
                                   },
                                   "name": {
                                     "type": "string",
-                                    "maxLength": 15,
+                                    "maxLength": 63,
                                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                                   },
                                   "path": {

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -427,7 +427,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -570,7 +570,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -666,7 +666,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -1153,7 +1153,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1296,7 +1296,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1392,7 +1392,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {

--- a/schemas/latest/ide-targeted/plugin-overrides.json
+++ b/schemas/latest/ide-targeted/plugin-overrides.json
@@ -422,7 +422,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -565,7 +565,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -661,7 +661,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -382,7 +382,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -512,7 +512,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -599,7 +599,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -1036,7 +1036,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1166,7 +1166,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {
@@ -1253,7 +1253,7 @@
                               },
                               "name": {
                                 "type": "string",
-                                "maxLength": 15,
+                                "maxLength": 63,
                                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                               },
                               "path": {

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -377,7 +377,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -507,7 +507,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {
@@ -594,7 +594,7 @@
                     },
                     "name": {
                       "type": "string",
-                      "maxLength": 15,
+                      "maxLength": 63,
                       "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                     },
                     "path": {


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
This PR changes the length limit of Endpoint Name from 15 to 63 to match DNS1123 and be consistent with the other K8s resources defined in devfile.

the length limit was defined to be 15 was because the container port name defined in pod has to be less than 15 characters
since library is not going to use the endpoint name as the port name(https://github.com/devfile/api/issues/287), the length limit should match the other K8s resources

### What issues does this PR fix or reference?
#288 

### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
