### PR TITLE
Add error DevWorkspace Phase and ConditionType

### DIFF
--- a/pkg/apis/workspaces/v1alpha1/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha1/devworkspace_types.go
@@ -37,6 +37,7 @@ const (
 	WorkspaceStatusStopped  WorkspacePhase = "Stopped"
 	WorkspaceStatusStopping WorkspacePhase = "Stopping"
 	WorkspaceStatusFailed   WorkspacePhase = "Failed"
+	WorkspaceStatusError    WorkspacePhase = "Error"
 )
 
 // WorkspaceCondition contains details for the current condition of this workspace.
@@ -63,6 +64,7 @@ const (
 	WorkspaceServiceAccountReady WorkspaceConditionType = "ServiceAccountReady"
 	WorkspaceReady               WorkspaceConditionType = "Ready"
 	WorkspaceFailedStart         WorkspaceConditionType = "FailedStart"
+	WorkspaceError               WorkspaceConditionType = "Error"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -35,6 +35,7 @@ const (
 	WorkspaceStatusStopped  WorkspacePhase = "Stopped"
 	WorkspaceStatusStopping WorkspacePhase = "Stopping"
 	WorkspaceStatusFailed   WorkspacePhase = "Failed"
+	WorkspaceStatusError    WorkspacePhase = "Error"
 )
 
 // WorkspaceCondition contains details for the current condition of this workspace.
@@ -61,6 +62,7 @@ const (
 	WorkspaceServiceAccountReady WorkspaceConditionType = "ServiceAccountReady"
 	WorkspaceReady               WorkspaceConditionType = "Ready"
 	WorkspaceFailedStart         WorkspaceConditionType = "FailedStart"
+	WorkspaceError               WorkspaceConditionType = "Error"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
### What does this PR do?
Add an error Phase to DevWorkspace status and a corresponding ConditionType. The error phase is used to represent server-side errors than impact the DevWorkspace (e.g. failed to clean up storage when deleting a workspace).

### What issues does this PR fix or reference?
Closes #286 

### Is your PR tested? Consider putting some instruction how to test your changes
N/A - Changes need to be incorporated into DevWorkspace Operator.

#### Docs PR
No API changes.
