### PR TITLE
Ephemeral volumes

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -1657,6 +1657,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -1707,6 +1712,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -3420,6 +3429,11 @@ spec:
                                         description: Configuration overriding for
                                           a Volume component in a plugin
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           name:
                                             description: Mandatory name that allows
                                               referencing the Volume component in
@@ -3473,6 +3487,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 name:
                                   description: Mandatory name that allows referencing
                                     the Volume component in Container volume mounts
@@ -5626,6 +5644,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -5666,6 +5689,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -7185,6 +7212,11 @@ spec:
                                         description: Allows specifying the definition
                                           of a volume shared by several other components
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           size:
                                             description: Size of the volume
                                             type: string
@@ -7224,6 +7256,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 size:
                                   description: Size of the volume
                                   type: string

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -1653,6 +1653,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -1703,6 +1708,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -3416,6 +3425,11 @@ spec:
                                         description: Configuration overriding for
                                           a Volume component in a plugin
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           name:
                                             description: Mandatory name that allows
                                               referencing the Volume component in
@@ -3469,6 +3483,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 name:
                                   description: Mandatory name that allows referencing
                                     the Volume component in Container volume mounts
@@ -5631,6 +5649,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -5671,6 +5694,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string
@@ -7190,6 +7217,11 @@ spec:
                                         description: Allows specifying the definition
                                           of a volume shared by several other components
                                         properties:
+                                          ephemeral:
+                                            description: Ephemeral volumes are not
+                                              stored persistently across restarts.
+                                              Defaults to false
+                                            type: boolean
                                           size:
                                             description: Size of the volume
                                             type: string
@@ -7229,6 +7261,10 @@ spec:
                               description: Allows specifying the definition of a volume
                                 shared by several other components
                               properties:
+                                ephemeral:
+                                  description: Ephemeral volumes are not stored persistently
+                                    across restarts. Defaults to false
+                                  type: boolean
                                 size:
                                   description: Size of the volume
                                   type: string

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -1584,6 +1584,10 @@ spec:
                                 description: Configuration overriding for a Volume
                                   component in a plugin
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   name:
                                     description: Mandatory name that allows referencing
                                       the Volume component in Container volume mounts
@@ -1634,6 +1638,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         name:
                           description: Mandatory name that allows referencing the
                             Volume component in Container volume mounts or inside
@@ -3288,6 +3296,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -3338,6 +3351,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -5340,6 +5357,10 @@ spec:
                                 description: Allows specifying the definition of a
                                   volume shared by several other components
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   size:
                                     description: Size of the volume
                                     type: string
@@ -5380,6 +5401,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         size:
                           description: Size of the volume
                           type: string
@@ -6845,6 +6870,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -6883,6 +6913,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -1582,6 +1582,10 @@ spec:
                                 description: Configuration overriding for a Volume
                                   component in a plugin
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   name:
                                     description: Mandatory name that allows referencing
                                       the Volume component in Container volume mounts
@@ -1632,6 +1636,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         name:
                           description: Mandatory name that allows referencing the
                             Volume component in Container volume mounts or inside
@@ -3286,6 +3294,11 @@ spec:
                                     description: Configuration overriding for a Volume
                                       component in a plugin
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       name:
                                         description: Mandatory name that allows referencing
                                           the Volume component in Container volume
@@ -3336,6 +3349,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             name:
                               description: Mandatory name that allows referencing
                                 the Volume component in Container volume mounts or
@@ -5345,6 +5362,10 @@ spec:
                                 description: Allows specifying the definition of a
                                   volume shared by several other components
                                 properties:
+                                  ephemeral:
+                                    description: Ephemeral volumes are not stored
+                                      persistently across restarts. Defaults to false
+                                    type: boolean
                                   size:
                                     description: Size of the volume
                                     type: string
@@ -5385,6 +5406,10 @@ spec:
                       description: Allows specifying the definition of a volume shared
                         by several other components
                       properties:
+                        ephemeral:
+                          description: Ephemeral volumes are not stored persistently
+                            across restarts. Defaults to false
+                          type: boolean
                         size:
                           description: Size of the volume
                           type: string
@@ -6850,6 +6875,11 @@ spec:
                                     description: Allows specifying the definition
                                       of a volume shared by several other components
                                     properties:
+                                      ephemeral:
+                                        description: Ephemeral volumes are not stored
+                                          persistently across restarts. Defaults to
+                                          false
+                                        type: boolean
                                       size:
                                         description: Size of the volume
                                         type: string
@@ -6888,6 +6918,10 @@ spec:
                           description: Allows specifying the definition of a volume
                             shared by several other components
                           properties:
+                            ephemeral:
+                              description: Ephemeral volumes are not stored persistently
+                                across restarts. Defaults to false
+                              type: boolean
                             size:
                               description: Size of the volume
                               type: string

--- a/pkg/apis/workspaces/v1alpha1/volumeComponent.go
+++ b/pkg/apis/workspaces/v1alpha1/volumeComponent.go
@@ -15,4 +15,9 @@ type Volume struct {
 	// +optional
 	// Size of the volume
 	Size string `json:"size,omitempty"`
+
+	// +optional
+	// Ephemeral volumes are not stored persistently across restarts. Defaults
+	// to false
+	Ephemeral bool `json:"ephemeral,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/volumeComponent.go
+++ b/pkg/apis/workspaces/v1alpha2/volumeComponent.go
@@ -11,4 +11,9 @@ type Volume struct {
 	// +optional
 	// Size of the volume
 	Size string `json:"size,omitempty"`
+
+	// +optional
+	// Ephemeral volumes are not stored persistently across restarts. Defaults
+	// to false
+	Ephemeral bool `json:"ephemeral,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -498,6 +498,11 @@ type VolumeParentOverride struct {
 	// +optional
 	// Size of the volume
 	Size string `json:"size,omitempty"`
+
+	// +optional
+	// Ephemeral volumes are not stored persistently across restarts. Defaults
+	// to false
+	Ephemeral bool `json:"ephemeral,omitempty"`
 }
 
 type ImportReferenceParentOverride struct {
@@ -1060,6 +1065,11 @@ type VolumePluginOverrideParentOverride struct {
 	// +optional
 	// Size of the volume
 	Size string `json:"size,omitempty"`
+
+	// +optional
+	// Ephemeral volumes are not stored persistently across restarts. Defaults
+	// to false
+	Ephemeral bool `json:"ephemeral,omitempty"`
 }
 
 type LabeledCommandPluginOverrideParentOverride struct {

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -377,6 +377,11 @@ type VolumePluginOverride struct {
 	// +optional
 	// Size of the volume
 	Size string `json:"size,omitempty"`
+
+	// +optional
+	// Ephemeral volumes are not stored persistently across restarts. Defaults
+	// to false
+	Ephemeral bool `json:"ephemeral,omitempty"`
 }
 
 type LabeledCommandPluginOverride struct {

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -1432,6 +1432,10 @@
                       "description": "Allows specifying the definition of a volume shared by several other components",
                       "type": "object",
                       "properties": {
+                        "ephemeral": {
+                          "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                          "type": "boolean"
+                        },
                         "size": {
                           "description": "Size of the volume",
                           "type": "string"
@@ -1477,6 +1481,10 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string"
@@ -2858,6 +2866,10 @@
                           "description": "Allows specifying the definition of a volume shared by several other components",
                           "type": "object",
                           "properties": {
+                            "ephemeral": {
+                              "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                              "type": "boolean"
+                            },
                             "size": {
                               "description": "Size of the volume",
                               "type": "string"
@@ -2900,6 +2912,10 @@
                 "description": "Allows specifying the definition of a volume shared by several other components",
                 "type": "object",
                 "properties": {
+                  "ephemeral": {
+                    "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                    "type": "boolean"
+                  },
                   "size": {
                     "description": "Size of the volume",
                     "type": "string"

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -1597,6 +1597,10 @@
                           "description": "Allows specifying the definition of a volume shared by several other components",
                           "type": "object",
                           "properties": {
+                            "ephemeral": {
+                              "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                              "type": "boolean"
+                            },
                             "size": {
                               "description": "Size of the volume",
                               "type": "string"
@@ -1642,6 +1646,10 @@
                 "description": "Allows specifying the definition of a volume shared by several other components",
                 "type": "object",
                 "properties": {
+                  "ephemeral": {
+                    "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                    "type": "boolean"
+                  },
                   "size": {
                     "description": "Size of the volume",
                     "type": "string"
@@ -3023,6 +3031,10 @@
                               "description": "Allows specifying the definition of a volume shared by several other components",
                               "type": "object",
                               "properties": {
+                                "ephemeral": {
+                                  "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                                  "type": "boolean"
+                                },
                                 "size": {
                                   "description": "Size of the volume",
                                   "type": "string"
@@ -3065,6 +3077,10 @@
                     "description": "Allows specifying the definition of a volume shared by several other components",
                     "type": "object",
                     "properties": {
+                      "ephemeral": {
+                        "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                        "type": "boolean"
+                      },
                       "size": {
                         "description": "Size of the volume",
                         "type": "string"

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -1610,6 +1610,10 @@
                               "description": "Allows specifying the definition of a volume shared by several other components",
                               "type": "object",
                               "properties": {
+                                "ephemeral": {
+                                  "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                                  "type": "boolean"
+                                },
                                 "size": {
                                   "description": "Size of the volume",
                                   "type": "string"
@@ -1655,6 +1659,10 @@
                     "description": "Allows specifying the definition of a volume shared by several other components",
                     "type": "object",
                     "properties": {
+                      "ephemeral": {
+                        "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                        "type": "boolean"
+                      },
                       "size": {
                         "description": "Size of the volume",
                         "type": "string"
@@ -3036,6 +3044,10 @@
                                   "description": "Allows specifying the definition of a volume shared by several other components",
                                   "type": "object",
                                   "properties": {
+                                    "ephemeral": {
+                                      "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                                      "type": "boolean"
+                                    },
                                     "size": {
                                       "description": "Size of the volume",
                                       "type": "string"
@@ -3078,6 +3090,10 @@
                         "description": "Allows specifying the definition of a volume shared by several other components",
                         "type": "object",
                         "properties": {
+                          "ephemeral": {
+                            "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                            "type": "boolean"
+                          },
                           "size": {
                             "description": "Size of the volume",
                             "type": "string"

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -1357,6 +1357,10 @@
                       "description": "Allows specifying the definition of a volume shared by several other components",
                       "type": "object",
                       "properties": {
+                        "ephemeral": {
+                          "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                          "type": "boolean"
+                        },
                         "size": {
                           "description": "Size of the volume",
                           "type": "string"
@@ -1402,6 +1406,10 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string"
@@ -2827,6 +2835,10 @@
                           "description": "Allows specifying the definition of a volume shared by several other components",
                           "type": "object",
                           "properties": {
+                            "ephemeral": {
+                              "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                              "type": "boolean"
+                            },
                             "size": {
                               "description": "Size of the volume",
                               "type": "string"
@@ -2869,6 +2881,10 @@
                 "description": "Allows specifying the definition of a volume shared by several other components",
                 "type": "object",
                 "properties": {
+                  "ephemeral": {
+                    "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                    "type": "boolean"
+                  },
                   "size": {
                     "description": "Size of the volume",
                     "type": "string"

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -1579,6 +1579,11 @@
                       "description": "Allows specifying the definition of a volume shared by several other components",
                       "type": "object",
                       "properties": {
+                        "ephemeral": {
+                          "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                          "type": "boolean",
+                          "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                        },
                         "size": {
                           "description": "Size of the volume",
                           "type": "string",
@@ -1631,6 +1636,11 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean",
+                "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string",
@@ -3164,6 +3174,11 @@
                           "description": "Allows specifying the definition of a volume shared by several other components",
                           "type": "object",
                           "properties": {
+                            "ephemeral": {
+                              "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                              "type": "boolean",
+                              "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                            },
                             "size": {
                               "description": "Size of the volume",
                               "type": "string",
@@ -3213,6 +3228,11 @@
                 "description": "Allows specifying the definition of a volume shared by several other components",
                 "type": "object",
                 "properties": {
+                  "ephemeral": {
+                    "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                    "type": "boolean",
+                    "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                  },
                   "size": {
                     "description": "Size of the volume",
                     "type": "string",

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -1777,6 +1777,11 @@
                           "description": "Allows specifying the definition of a volume shared by several other components",
                           "type": "object",
                           "properties": {
+                            "ephemeral": {
+                              "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                              "type": "boolean",
+                              "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                            },
                             "size": {
                               "description": "Size of the volume",
                               "type": "string",
@@ -1829,6 +1834,11 @@
                 "description": "Allows specifying the definition of a volume shared by several other components",
                 "type": "object",
                 "properties": {
+                  "ephemeral": {
+                    "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                    "type": "boolean",
+                    "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                  },
                   "size": {
                     "description": "Size of the volume",
                     "type": "string",
@@ -3362,6 +3372,11 @@
                               "description": "Allows specifying the definition of a volume shared by several other components",
                               "type": "object",
                               "properties": {
+                                "ephemeral": {
+                                  "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                                  "type": "boolean",
+                                  "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                                },
                                 "size": {
                                   "description": "Size of the volume",
                                   "type": "string",
@@ -3411,6 +3426,11 @@
                     "description": "Allows specifying the definition of a volume shared by several other components",
                     "type": "object",
                     "properties": {
+                      "ephemeral": {
+                        "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                        "type": "boolean",
+                        "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                      },
                       "size": {
                         "description": "Size of the volume",
                         "type": "string",

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -1790,6 +1790,11 @@
                               "description": "Allows specifying the definition of a volume shared by several other components",
                               "type": "object",
                               "properties": {
+                                "ephemeral": {
+                                  "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                                  "type": "boolean",
+                                  "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                                },
                                 "size": {
                                   "description": "Size of the volume",
                                   "type": "string",
@@ -1842,6 +1847,11 @@
                     "description": "Allows specifying the definition of a volume shared by several other components",
                     "type": "object",
                     "properties": {
+                      "ephemeral": {
+                        "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                        "type": "boolean",
+                        "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                      },
                       "size": {
                         "description": "Size of the volume",
                         "type": "string",
@@ -3375,6 +3385,11 @@
                                   "description": "Allows specifying the definition of a volume shared by several other components",
                                   "type": "object",
                                   "properties": {
+                                    "ephemeral": {
+                                      "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                                      "type": "boolean",
+                                      "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                                    },
                                     "size": {
                                       "description": "Size of the volume",
                                       "type": "string",
@@ -3424,6 +3439,11 @@
                         "description": "Allows specifying the definition of a volume shared by several other components",
                         "type": "object",
                         "properties": {
+                          "ephemeral": {
+                            "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                            "type": "boolean",
+                            "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                          },
                           "size": {
                             "description": "Size of the volume",
                             "type": "string",

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -1494,6 +1494,11 @@
                       "description": "Allows specifying the definition of a volume shared by several other components",
                       "type": "object",
                       "properties": {
+                        "ephemeral": {
+                          "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                          "type": "boolean",
+                          "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                        },
                         "size": {
                           "description": "Size of the volume",
                           "type": "string",
@@ -1546,6 +1551,11 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean",
+                "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string",
@@ -3132,6 +3142,11 @@
                           "description": "Allows specifying the definition of a volume shared by several other components",
                           "type": "object",
                           "properties": {
+                            "ephemeral": {
+                              "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                              "type": "boolean",
+                              "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                            },
                             "size": {
                               "description": "Size of the volume",
                               "type": "string",
@@ -3181,6 +3196,11 @@
                 "description": "Allows specifying the definition of a volume shared by several other components",
                 "type": "object",
                 "properties": {
+                  "ephemeral": {
+                    "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                    "type": "boolean",
+                    "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                  },
                   "size": {
                     "description": "Size of the volume",
                     "type": "string",

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -1461,6 +1461,11 @@
                       "description": "Allows specifying the definition of a volume shared by several other components",
                       "type": "object",
                       "properties": {
+                        "ephemeral": {
+                          "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                          "type": "boolean",
+                          "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+                        },
                         "size": {
                           "description": "Size of the volume",
                           "type": "string",
@@ -1510,6 +1515,11 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean",
+                "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string",

--- a/schemas/latest/ide-targeted/plugin-overrides.json
+++ b/schemas/latest/ide-targeted/plugin-overrides.json
@@ -721,6 +721,11 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean",
+                "markdownDescription": "Ephemeral volumes are not stored persistently across restarts. Defaults to false"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string",

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -1316,6 +1316,10 @@
                       "description": "Allows specifying the definition of a volume shared by several other components",
                       "type": "object",
                       "properties": {
+                        "ephemeral": {
+                          "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                          "type": "boolean"
+                        },
                         "size": {
                           "description": "Size of the volume",
                           "type": "string"
@@ -1358,6 +1362,10 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string"

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -648,6 +648,10 @@
             "description": "Allows specifying the definition of a volume shared by several other components",
             "type": "object",
             "properties": {
+              "ephemeral": {
+                "description": "Ephemeral volumes are not stored persistently across restarts. Defaults to false",
+                "type": "boolean"
+              },
               "size": {
                 "description": "Size of the volume",
                 "type": "string"


### PR DESCRIPTION
### What does this PR do?
This PR is half of https://github.com/devfile/api/pull/319 (support for ephemeral/emptyDir volume components). These components provide a way to share storage between components -- e.g. sharing a `.m2` volume between a builder container and a Java language server sidecar. 

Compared to https://github.com/devfile/api/pull/319, I've renamed the field from `persistent` to `ephemeral` (following @davidfestal's suggestion) to support having `false` as the default value; otherwise, we're generally required to use a boolean pointer, which is a hassle to work with. 

### What issues does this PR fix or reference?
Fixes 1/2 of #310 

### Is your PR tested? Consider putting some instruction how to test your changes
N/A, spec change.

