### PR TITLE
Add 'dwt' shortname for DevWorkspaceTemplates

### DIFF
--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DevWorkspaceTemplate
     listKind: DevWorkspaceTemplateList
     plural: devworkspacetemplates
+    shortNames:
+    - dwt
     singular: devworkspacetemplate
   preserveUnknownFields: false
   scope: Namespaced

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -11,6 +11,8 @@ spec:
     kind: DevWorkspaceTemplate
     listKind: DevWorkspaceTemplateList
     plural: devworkspacetemplates
+    shortNames:
+    - dwt
     singular: devworkspacetemplate
   scope: Namespaced
   versions:

--- a/pkg/apis/workspaces/v1alpha1/devworkspacetemplate_types.go
+++ b/pkg/apis/workspaces/v1alpha1/devworkspacetemplate_types.go
@@ -8,7 +8,7 @@ import (
 
 // DevWorkspaceTemplate is the Schema for the devworkspacetemplates API
 // +k8s:openapi-gen=true
-// +kubebuilder:resource:path=devworkspacetemplates,scope=Namespaced
+// +kubebuilder:resource:path=devworkspacetemplates,scope=Namespaced,shortName=dwt
 type DevWorkspaceTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_types.go
@@ -7,7 +7,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DevWorkspaceTemplate is the Schema for the devworkspacetemplates API
-// +kubebuilder:resource:path=devworkspacetemplates,scope=Namespaced
+// +kubebuilder:resource:path=devworkspacetemplates,scope=Namespaced,shortName=dwt
 // +devfile:jsonschema:generate
 // +kubebuilder:storageversion
 type DevWorkspaceTemplate struct {


### PR DESCRIPTION
### What does this PR do?
Add the `dwt` shortname for DevWorkspaceTemplates, to match the `dw` shortname for DevWorkspaces

### What issues does this PR fix or reference?
`kubectl get devworkspacetemplates` is long to type out.
