### PR TITLE
Cleanup printcolumns

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -4088,12 +4088,8 @@ spec:
       name: Phase
       type: string
     - JSONPath: .status.message
-      description: Additional information about workspace state
+      description: Additional information about the workspace
       name: Info
-      type: string
-    - JSONPath: .status.ideUrl
-      description: Url endpoint for accessing workspace
-      name: URL
       type: string
     name: v1alpha2
     schema:

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -4085,13 +4085,9 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: Additional information about workspace state
+    - description: Additional information about the workspace
       jsonPath: .status.message
       name: Info
-      type: string
-    - description: Url endpoint for accessing workspace
-      jsonPath: .status.ideUrl
-      name: URL
       type: string
     name: v1alpha2
     schema:

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -72,8 +72,7 @@ const (
 // +kubebuilder:resource:path=devworkspaces,scope=Namespaced,shortName=dw
 // +kubebuilder:printcolumn:name="Workspace ID",type="string",JSONPath=".status.workspaceId",description="The workspace's unique id"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current workspace startup phase"
-// +kubebuilder:printcolumn:name="Info",type="string",JSONPath=".status.message",description="Additional information about workspace state"
-// +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"
+// +kubebuilder:printcolumn:name="Info",type="string",JSONPath=".status.message",description="Additional information about the workspace"
 // +devfile:jsonschema:generate
 // +kubebuilder:storageversion
 type DevWorkspace struct {


### PR DESCRIPTION
### What does this PR do?
Removes `.status.ideUrl` from the DevWorkspace printcolumns. Since the [addition](https://github.com/devfile/api/pull/221) of the `Info` field (`.status.message`), the output from `kubectl get devworkspaces` has become long and unweildy:
```
$ kubectl get dw

NAME           WORKSPACE ID                PHASE     INFO                                                          URL
theia          workspace8af91dfdf1f1417f   Running                                                                 http://workspace8af91dfdf1f1417f-theia-3100.192.168.49.2.nip.io
web-terminal   workspace32d4b43e65e64e64   Failed    Failed to install network objects required for devworkspace   
```
Since `INFO` and `URL` are generally mutually exclusive, it makes sense to combine the two, so that 
- If a workspace has no issues, `INFO` contains a message like `Workspace is accessible at <url>`
- If a workspace has an issue, information about the problem is propagated to `INFO`.

Proposed output (example):
```
$ kubectl get dw

NAME           WORKSPACE ID                PHASE     INFO
theia          workspace8af91dfdf1f1417f   Running   Workspace is accessible at http://workspace8af91dfdf1f1417f-theia-3100.192.168.49.2.nip.io
web-terminal   workspace32d4b43e65e64e64   Failed    Failed to install network objects required for devworkspace   
```