### PR TITLE
Create empty .npmignore file so that everything in the typescript models are published

### DIFF
--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -64,6 +64,7 @@ jobs:
           sed -i 's/\"description\": \".*\"/"description": "Typescript types for devfile api"/g' /tmp/typescript-models/package.json
           sed -i 's/\"repository\": \".*\"/"repository": "devfile\/api"/g' /tmp/typescript-models/package.json
           sed -i 's/\"license\": \".*\"/"license": "EPL-2.0"/g' /tmp/typescript-models/package.json
+          echo "" > /tmp/typescript-models/.npmignore
 
       - name: Setup node
         uses: actions/setup-node@v1


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR creates an empty .npmignore file so that nothing is ignored when creating the npm package. Apparently [if an .npmignore file isn't available then .gitignore is used](https://docs.npmjs.com/cli/v7/using-npm/developers#keeping-files-out-of-your-package) and that's why some of the dist files are missing

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
