### PR TITLE
Rename ide url

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -7444,8 +7444,8 @@ spec:
               devworkspaceId:
                 description: Id of the DevWorkspace
                 type: string
-              ideUrl:
-                description: URL at which the DevWorkspace Editor can be joined
+              mainUrl:
+                description: Main URL for this DevWorkspace
                 type: string
               message:
                 description: Message is a short user-readable message giving additional

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -7449,8 +7449,8 @@ spec:
               devworkspaceId:
                 description: Id of the DevWorkspace
                 type: string
-              ideUrl:
-                description: URL at which the DevWorkspace Editor can be joined
+              mainUrl:
+                description: Main URL for this DevWorkspace
                 type: string
               message:
                 description: Message is a short user-readable message giving additional

--- a/pkg/apis/workspaces/v1alpha1/conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/conversion.go
@@ -7,7 +7,7 @@ import (
 func convertDevWorkspaceTo_v1alpha2(src *DevWorkspace, dest *v1alpha2.DevWorkspace) error {
 	dest.ObjectMeta = src.ObjectMeta
 	dest.Status.DevWorkspaceId = src.Status.WorkspaceId
-	dest.Status.IdeUrl = src.Status.IdeUrl
+	dest.Status.MainUrl = src.Status.IdeUrl
 	dest.Status.Phase = v1alpha2.DevWorkspacePhase(src.Status.Phase)
 	dest.Status.Message = src.Status.Message
 	convertConditionsTo_v1alpha2(src, dest)
@@ -20,7 +20,7 @@ func convertDevWorkspaceTo_v1alpha2(src *DevWorkspace, dest *v1alpha2.DevWorkspa
 func convertDevWorkspaceFrom_v1alpha2(src *v1alpha2.DevWorkspace, dest *DevWorkspace) error {
 	dest.ObjectMeta = src.ObjectMeta
 	dest.Status.WorkspaceId = src.Status.DevWorkspaceId
-	dest.Status.IdeUrl = src.Status.IdeUrl
+	dest.Status.IdeUrl = src.Status.MainUrl
 	dest.Status.Phase = WorkspacePhase(src.Status.Phase)
 	dest.Status.Message = src.Status.Message
 	convertConditionsFrom_v1alpha2(src, dest)

--- a/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspace_types.go
@@ -16,9 +16,9 @@ type DevWorkspaceSpec struct {
 type DevWorkspaceStatus struct {
 	// Id of the DevWorkspace
 	DevWorkspaceId string `json:"devworkspaceId"`
-	// URL at which the DevWorkspace Editor can be joined
-	IdeUrl string            `json:"ideUrl,omitempty"`
-	Phase  DevWorkspacePhase `json:"phase,omitempty"`
+	// Main URL for this DevWorkspace
+	MainUrl string            `json:"mainUrl,omitempty"`
+	Phase   DevWorkspacePhase `json:"phase,omitempty"`
 	// Conditions represent the latest available observations of an object's state
 	Conditions []DevWorkspaceCondition `json:"conditions,omitempty"`
 	// Message is a short user-readable message giving additional information

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -3294,8 +3294,8 @@
           "description": "Id of the DevWorkspace",
           "type": "string"
         },
-        "ideUrl": {
-          "description": "URL at which the DevWorkspace Editor can be joined",
+        "mainUrl": {
+          "description": "Main URL for this DevWorkspace",
           "type": "string"
         },
         "message": {

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -3683,10 +3683,10 @@
           "type": "string",
           "markdownDescription": "Id of the DevWorkspace"
         },
-        "ideUrl": {
-          "description": "URL at which the DevWorkspace Editor can be joined",
+        "mainUrl": {
+          "description": "Main URL for this DevWorkspace",
           "type": "string",
-          "markdownDescription": "URL at which the DevWorkspace Editor can be joined"
+          "markdownDescription": "Main URL for this DevWorkspace"
         },
         "message": {
           "description": "Message is a short user-readable message giving additional information about an object's state",


### PR DESCRIPTION
### What does this PR do?
Renames `.status.ideUrl` to `.status.mainUrl` in DevWorkspaces.

### What issues does this PR fix or reference?
Closes https://github.com/devfile/api/issues/370 (note we're focusing on the breaking change at the moment; adding additional info will still be possible down the line).

### Is your PR tested? Consider putting some instruction how to test your changes
N/A

#### Docs PR
N/A