### PR TITLE
remove project.sparseCheckoutDir

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -7012,12 +7012,6 @@ spec:
                               - Git
                               - Zip
                               type: string
-                            sparseCheckoutDirs:
-                              description: Populate the project sparsely with selected
-                                directories.
-                              items:
-                                type: string
-                              type: array
                             zip:
                               description: Project's Zip source
                               properties:
@@ -7203,12 +7197,6 @@ spec:
                           - Zip
                           - Custom
                           type: string
-                        sparseCheckoutDirs:
-                          description: Populate the project sparsely with selected
-                            directories.
-                          items:
-                            type: string
-                          type: array
                         zip:
                           description: Project's Zip source
                           properties:

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -7017,12 +7017,6 @@ spec:
                               - Git
                               - Zip
                               type: string
-                            sparseCheckoutDirs:
-                              description: Populate the project sparsely with selected
-                                directories.
-                              items:
-                                type: string
-                              type: array
                             zip:
                               description: Project's Zip source
                               properties:
@@ -7208,12 +7202,6 @@ spec:
                           - Zip
                           - Custom
                           type: string
-                        sparseCheckoutDirs:
-                          description: Populate the project sparsely with selected
-                            directories.
-                          items:
-                            type: string
-                          type: array
                         zip:
                           description: Project's Zip source
                           properties:

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -6679,12 +6679,6 @@ spec:
                           - Git
                           - Zip
                           type: string
-                        sparseCheckoutDirs:
-                          description: Populate the project sparsely with selected
-                            directories.
-                          items:
-                            type: string
-                          type: array
                         zip:
                           description: Project's Zip source
                           properties:
@@ -6865,11 +6859,6 @@ spec:
                       - Zip
                       - Custom
                       type: string
-                    sparseCheckoutDirs:
-                      description: Populate the project sparsely with selected directories.
-                      items:
-                        type: string
-                      type: array
                     zip:
                       description: Project's Zip source
                       properties:

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -6684,12 +6684,6 @@ spec:
                           - Git
                           - Zip
                           type: string
-                        sparseCheckoutDirs:
-                          description: Populate the project sparsely with selected
-                            directories.
-                          items:
-                            type: string
-                          type: array
                         zip:
                           description: Project's Zip source
                           properties:
@@ -6870,11 +6864,6 @@ spec:
                       - Zip
                       - Custom
                       type: string
-                    sparseCheckoutDirs:
-                      description: Populate the project sparsely with selected directories.
-                      items:
-                        type: string
-                      type: array
                     zip:
                       description: Project's Zip source
                       properties:

--- a/pkg/apis/workspaces/v1alpha1/conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/conversion_test.go
@@ -151,10 +151,19 @@ var parentProjectFuzzFunc = func(project *Project, c fuzz.Continue) {
 	switch c.Intn(3) {
 	case 0:
 		c.Fuzz(&project.Git)
+		if project.Git != nil {
+			project.Git.CommonProjectSource = CommonProjectSource{}
+		}
 	case 1:
 		c.Fuzz(&project.Github)
+		if project.Github != nil {
+			project.Github.CommonProjectSource = CommonProjectSource{}
+		}
 	case 2:
 		c.Fuzz(&project.Zip)
+		if project.Zip != nil {
+			project.Zip.CommonProjectSource = CommonProjectSource{}
+		}
 	}
 }
 
@@ -162,10 +171,19 @@ var projectFuzzFunc = func(project *Project, c fuzz.Continue) {
 	switch c.Intn(4) {
 	case 0:
 		c.Fuzz(&project.Git)
+		if project.Git != nil {
+			project.Git.CommonProjectSource = CommonProjectSource{}
+		}
 	case 1:
 		c.Fuzz(&project.Github)
+		if project.Github != nil {
+			project.Github.CommonProjectSource = CommonProjectSource{}
+		}
 	case 2:
 		c.Fuzz(&project.Zip)
+		if project.Zip != nil {
+			project.Zip.CommonProjectSource = CommonProjectSource{}
+		}
 	case 3:
 		c.Fuzz(&project.Custom)
 	}

--- a/pkg/apis/workspaces/v1alpha1/conversion_test.go
+++ b/pkg/apis/workspaces/v1alpha1/conversion_test.go
@@ -152,17 +152,17 @@ var parentProjectFuzzFunc = func(project *Project, c fuzz.Continue) {
 	case 0:
 		c.Fuzz(&project.Git)
 		if project.Git != nil {
-			project.Git.CommonProjectSource = CommonProjectSource{}
+			project.Git.SparseCheckoutDir = ""
 		}
 	case 1:
 		c.Fuzz(&project.Github)
 		if project.Github != nil {
-			project.Github.CommonProjectSource = CommonProjectSource{}
+			project.Github.SparseCheckoutDir = ""
 		}
 	case 2:
 		c.Fuzz(&project.Zip)
 		if project.Zip != nil {
-			project.Zip.CommonProjectSource = CommonProjectSource{}
+			project.Zip.SparseCheckoutDir = ""
 		}
 	}
 }
@@ -172,17 +172,17 @@ var projectFuzzFunc = func(project *Project, c fuzz.Continue) {
 	case 0:
 		c.Fuzz(&project.Git)
 		if project.Git != nil {
-			project.Git.CommonProjectSource = CommonProjectSource{}
+			project.Git.SparseCheckoutDir = ""
 		}
 	case 1:
 		c.Fuzz(&project.Github)
 		if project.Github != nil {
-			project.Github.CommonProjectSource = CommonProjectSource{}
+			project.Github.SparseCheckoutDir = ""
 		}
 	case 2:
 		c.Fuzz(&project.Zip)
 		if project.Zip != nil {
-			project.Zip.CommonProjectSource = CommonProjectSource{}
+			project.Zip.SparseCheckoutDir = ""
 		}
 	case 3:
 		c.Fuzz(&project.Custom)

--- a/pkg/apis/workspaces/v1alpha1/projects_conversion.go
+++ b/pkg/apis/workspaces/v1alpha1/projects_conversion.go
@@ -32,17 +32,6 @@ func convertProjectTo_v1alpha2(src *Project, dest *v1alpha2.Project) error {
 		return err
 	}
 
-	var sparseCheckoutDir string
-	switch {
-	case src.Git != nil:
-		sparseCheckoutDir = src.Git.SparseCheckoutDir
-	case src.Zip != nil:
-		sparseCheckoutDir = src.Zip.SparseCheckoutDir
-	}
-	if sparseCheckoutDir != "" {
-		dest.SparseCheckoutDirs = []string{sparseCheckoutDir}
-	}
-
 	// Make sure we didn't modify underlying src struct
 	if src.Github != nil {
 		src.Git = nil
@@ -59,20 +48,6 @@ func convertProjectFrom_v1alpha2(src *v1alpha2.Project, dest *Project) error {
 	err = json.Unmarshal(jsonProject, dest)
 	if err != nil {
 		return err
-	}
-	// **Note**: These aren't technically compatible:
-	// - v1alpha2 allows us to specify multiple sparse checkout dirs; v1alpha1 only supports one
-	//   -> we ignore all but the first sparseCheckoutDir
-	// - v1alpha2 doesn't forbid sparse checkout dir for a custom project source
-	//   -> we ignore all sparseCheckoutDirs when project source is Custom
-	if len(src.SparseCheckoutDirs) > 0 {
-		sparseCheckoutDir := src.SparseCheckoutDirs[0]
-		switch {
-		case src.Git != nil:
-			dest.Git.SparseCheckoutDir = sparseCheckoutDir
-		case src.Zip != nil:
-			dest.Zip.SparseCheckoutDir = sparseCheckoutDir
-		}
 	}
 
 	// Check if a Git-type project was originally a Github-type project in v1alpha1

--- a/pkg/apis/workspaces/v1alpha2/projects.go
+++ b/pkg/apis/workspaces/v1alpha2/projects.go
@@ -19,10 +19,6 @@ type Project struct {
 	// +optional
 	ClonePath string `json:"clonePath,omitempty"`
 
-	// Populate the project sparsely with selected directories.
-	// +optional
-	SparseCheckoutDirs []string `json:"sparseCheckoutDirs,omitempty"`
-
 	ProjectSource `json:",inline"`
 }
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.deepcopy.go
@@ -2497,11 +2497,6 @@ func (in *Project) DeepCopyInto(out *Project) {
 			(*out)[key] = *val.DeepCopy()
 		}
 	}
-	if in.SparseCheckoutDirs != nil {
-		in, out := &in.SparseCheckoutDirs, &out.SparseCheckoutDirs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	in.ProjectSource.DeepCopyInto(&out.ProjectSource)
 }
 
@@ -2524,11 +2519,6 @@ func (in *ProjectParentOverride) DeepCopyInto(out *ProjectParentOverride) {
 		for key, val := range *in {
 			(*out)[key] = *val.DeepCopy()
 		}
-	}
-	if in.SparseCheckoutDirs != nil {
-		in, out := &in.SparseCheckoutDirs, &out.SparseCheckoutDirs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
 	}
 	in.ProjectSourceParentOverride.DeepCopyInto(&out.ProjectSourceParentOverride)
 }

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -84,10 +84,6 @@ type ProjectParentOverride struct {
 	// +optional
 	ClonePath string `json:"clonePath,omitempty"`
 
-	// Populate the project sparsely with selected directories.
-	// +optional
-	SparseCheckoutDirs []string `json:"sparseCheckoutDirs,omitempty"`
-
 	ProjectSourceParentOverride `json:",inline"`
 }
 

--- a/pkg/validation/variables/test-fixtures/all/devfile-bad-output.yaml
+++ b/pkg/validation/variables/test-fixtures/all/devfile-bad-output.yaml
@@ -3,9 +3,6 @@ variables:
 projects:
 - name: project1
   clonePath: "{{path}}"
-  sparseCheckoutDirs:
-    - xyz
-    - "{{dir}}"
   git:
     checkoutFrom:
       revision: "{{tag}}"

--- a/pkg/validation/variables/test-fixtures/all/devfile-bad.yaml
+++ b/pkg/validation/variables/test-fixtures/all/devfile-bad.yaml
@@ -3,9 +3,6 @@ variables:
 projects:
 - name: project1
   clonePath: "{{path}}"
-  sparseCheckoutDirs:
-    - xyz
-    - "{{dir}}"
   git:
     checkoutFrom:
       revision: "{{tag}}"

--- a/pkg/validation/variables/test-fixtures/projects/project-output.yaml
+++ b/pkg/validation/variables/test-fixtures/projects/project-output.yaml
@@ -1,8 +1,5 @@
 name: project1
 clonePath: "/FOO"
-sparseCheckoutDirs:
-  - /FOO
-  - "/BAR"
 git:
   checkoutFrom:
     revision: "FOO"

--- a/pkg/validation/variables/test-fixtures/projects/project.yaml
+++ b/pkg/validation/variables/test-fixtures/projects/project.yaml
@@ -1,9 +1,6 @@
 # Variables are defined in test-fixtures/variables/variables-referenced.yaml
 name: project1
 clonePath: "/{{foo}}"
-sparseCheckoutDirs:
-  - /FOO
-  - "/{{bar}}"
 git:
   checkoutFrom:
     revision: "{{foo}}"

--- a/pkg/validation/variables/variables_project.go
+++ b/pkg/validation/variables/variables_project.go
@@ -20,13 +20,6 @@ func ValidateAndReplaceForProjects(variables map[string]string, projects []v1alp
 			checkForInvalidError(invalidKeys, err)
 		}
 
-		// Validate project sparse checkout dir
-		for j := range projects[i].SparseCheckoutDirs {
-			if projects[i].SparseCheckoutDirs[j], err = validateAndReplaceDataWithVariable(projects[i].SparseCheckoutDirs[j], variables); err != nil {
-				checkForInvalidError(invalidKeys, err)
-			}
-		}
-
 		// Validate project source
 		if err = validateandReplaceForProjectSource(variables, &projects[i].ProjectSource); err != nil {
 			checkForInvalidError(invalidKeys, err)

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -2594,13 +2594,6 @@
                 "maxLength": 63,
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
-              "sparseCheckoutDirs": {
-                "description": "Populate the project sparsely with selected directories.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "zip": {
                 "description": "Project's Zip source",
                 "type": "object",
@@ -2808,13 +2801,6 @@
             "type": "string",
             "maxLength": 63,
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-          },
-          "sparseCheckoutDirs": {
-            "description": "Populate the project sparsely with selected directories.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           },
           "zip": {
             "description": "Project's Zip source",

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -2759,13 +2759,6 @@
                     "maxLength": 63,
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
-                  "sparseCheckoutDirs": {
-                    "description": "Populate the project sparsely with selected directories.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
                   "zip": {
                     "description": "Project's Zip source",
                     "type": "object",
@@ -2973,13 +2966,6 @@
                 "type": "string",
                 "maxLength": 63,
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-              },
-              "sparseCheckoutDirs": {
-                "description": "Populate the project sparsely with selected directories.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
               },
               "zip": {
                 "description": "Project's Zip source",

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -2772,13 +2772,6 @@
                         "maxLength": 63,
                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                       },
-                      "sparseCheckoutDirs": {
-                        "description": "Populate the project sparsely with selected directories.",
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
                       "zip": {
                         "description": "Project's Zip source",
                         "type": "object",
@@ -2986,13 +2979,6 @@
                     "type": "string",
                     "maxLength": 63,
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-                  },
-                  "sparseCheckoutDirs": {
-                    "description": "Populate the project sparsely with selected directories.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
                   },
                   "zip": {
                     "description": "Project's Zip source",

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -1354,13 +1354,6 @@
                 "maxLength": 63,
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
-              "sparseCheckoutDirs": {
-                "description": "Populate the project sparsely with selected directories.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
               "zip": {
                 "description": "Project's Zip source",
                 "type": "object",
@@ -1545,13 +1538,6 @@
             "type": "string",
             "maxLength": 63,
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-          },
-          "sparseCheckoutDirs": {
-            "description": "Populate the project sparsely with selected directories.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           },
           "zip": {
             "description": "Project's Zip source",

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -2880,14 +2880,6 @@
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
-              "sparseCheckoutDirs": {
-                "description": "Populate the project sparsely with selected directories.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "markdownDescription": "Populate the project sparsely with selected directories."
-              },
               "zip": {
                 "description": "Project's Zip source",
                 "type": "object",
@@ -3123,14 +3115,6 @@
             "maxLength": 63,
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
-          },
-          "sparseCheckoutDirs": {
-            "description": "Populate the project sparsely with selected directories.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "markdownDescription": "Populate the project sparsely with selected directories."
           },
           "zip": {
             "description": "Project's Zip source",

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -3078,14 +3078,6 @@
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
                   },
-                  "sparseCheckoutDirs": {
-                    "description": "Populate the project sparsely with selected directories.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "markdownDescription": "Populate the project sparsely with selected directories."
-                  },
                   "zip": {
                     "description": "Project's Zip source",
                     "type": "object",
@@ -3321,14 +3313,6 @@
                 "maxLength": 63,
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
-              },
-              "sparseCheckoutDirs": {
-                "description": "Populate the project sparsely with selected directories.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "markdownDescription": "Populate the project sparsely with selected directories."
               },
               "zip": {
                 "description": "Project's Zip source",

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -3091,14 +3091,6 @@
                         "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                         "markdownDescription": "Project name"
                       },
-                      "sparseCheckoutDirs": {
-                        "description": "Populate the project sparsely with selected directories.",
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        },
-                        "markdownDescription": "Populate the project sparsely with selected directories."
-                      },
                       "zip": {
                         "description": "Project's Zip source",
                         "type": "object",
@@ -3334,14 +3326,6 @@
                     "maxLength": 63,
                     "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                     "markdownDescription": "Project name"
-                  },
-                  "sparseCheckoutDirs": {
-                    "description": "Populate the project sparsely with selected directories.",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "markdownDescription": "Populate the project sparsely with selected directories."
                   },
                   "zip": {
                     "description": "Project's Zip source",

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -1504,14 +1504,6 @@
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
                 "markdownDescription": "Project name"
               },
-              "sparseCheckoutDirs": {
-                "description": "Populate the project sparsely with selected directories.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "markdownDescription": "Populate the project sparsely with selected directories."
-              },
               "zip": {
                 "description": "Project's Zip source",
                 "type": "object",
@@ -1723,14 +1715,6 @@
             "maxLength": 63,
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
-          },
-          "sparseCheckoutDirs": {
-            "description": "Populate the project sparsely with selected directories.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "markdownDescription": "Populate the project sparsely with selected directories."
           },
           "zip": {
             "description": "Project's Zip source",

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -1379,14 +1379,6 @@
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
             "markdownDescription": "Project name"
           },
-          "sparseCheckoutDirs": {
-            "description": "Populate the project sparsely with selected directories.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "markdownDescription": "Populate the project sparsely with selected directories."
-          },
           "zip": {
             "description": "Project's Zip source",
             "type": "object",

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -1236,13 +1236,6 @@
             "maxLength": 63,
             "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
           },
-          "sparseCheckoutDirs": {
-            "description": "Populate the project sparsely with selected directories.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "zip": {
             "description": "Project's Zip source",
             "type": "object",

--- a/test/v200/devfiles/projects/projectsAll.yaml
+++ b/test/v200/devfiles/projects/projectsAll.yaml
@@ -5,9 +5,7 @@
       remotes: 
         origin: test-origin
     clonePath: /Users/test/projects
-    sparseCheckoutDirs: [thisDir, thatDir]
   - name: testproject3
     zip: 
       location: git-repo.zip
     clonePath: /Users/test/projects
-    sparseCheckoutDirs: [thisDir, thatDir]    

--- a/test/v200/devfiles/projects/projectsGitNoRemotes.yaml
+++ b/test/v200/devfiles/projects/projectsGitNoRemotes.yaml
@@ -3,4 +3,3 @@
       checkoutFrom: 
         remote: test-branch
     clonePath: /Users/test/projects
-    sparseCheckoutDirs: [thisDir, thatDir]

--- a/test/v200/devfiles/projects/projectsNoGitOrZip.yaml
+++ b/test/v200/devfiles/projects/projectsNoGitOrZip.yaml
@@ -1,3 +1,2 @@
   - name: testproject1
     clonePath: /Users/test/projects
-    sparseCheckoutDirs: [thisDir, thatDir]

--- a/test/v200/devfiles/projects/projectsNoName.yaml
+++ b/test/v200/devfiles/projects/projectsNoName.yaml
@@ -1,3 +1,2 @@
   - git: git-repo
     clonePath: /Users/test/projects
-    sparseCheckoutDirs: [thisDir, thatDir]

--- a/test/v200/devfiles/projects/projectsZipNoLocation.yaml
+++ b/test/v200/devfiles/projects/projectsZipNoLocation.yaml
@@ -1,4 +1,3 @@
   - name: testproject1
     zip: 
     clonePath: /Users/test/projects
-    sparseCheckoutDirs: [thisDir, thatDir]

--- a/test/v200/utils/common/project_test_utils.go
+++ b/test/v200/utils/common/project_test_utils.go
@@ -138,16 +138,6 @@ func (testDevfile *TestDevfile) SetProjectValues(project *schema.Project) {
 		LogInfoMessage(fmt.Sprintf("Set ClonePath : %s", project.ClonePath))
 	}
 
-	if GetBinaryDecision() {
-		var sparseCheckoutDirs []string
-		numDirs := GetRandomNumber(1, 6)
-		for i := 0; i < numDirs; i++ {
-			sparseCheckoutDirs = append(sparseCheckoutDirs, GetRandomString(8, false))
-			LogInfoMessage(fmt.Sprintf("Set sparseCheckoutDir : %s", sparseCheckoutDirs[i]))
-		}
-		project.SparseCheckoutDirs = sparseCheckoutDirs
-	}
-
 	if project.Git != nil {
 		setGitProjectValues(project.Git)
 	} else if project.Zip != nil {


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?
This PR removes `project.sparseCheckoutDir` as has no current usage, and no good use case for it. 

### What issues does this PR fix or reference?
Fixes #385 

### Is your PR tested? Consider putting some instruction how to test your changes
updated tests

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
