### PR TITLE
hardcode @types/bluebird version before building the typescript models

### DIFF
--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -64,6 +64,7 @@ jobs:
           sed -i 's/\"description\": \".*\"/"description": "Typescript types for devfile api"/g' /tmp/typescript-models/package.json
           sed -i 's/\"repository\": \".*\"/"repository": "devfile\/api"/g' /tmp/typescript-models/package.json
           sed -i 's/\"license\": \".*\"/"license": "EPL-2.0"/g' /tmp/typescript-models/package.json
+          sed -i 's/\"@types\/bluebird\": \".*\"/"@types\/bluebird": "3.5.21"/g' /tmp/typescript-models/package.json
           echo "" > /tmp/typescript-models/.npmignore
 
       - name: Setup node


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR hardcodes `@types/bluebird` to be the latest version working with typescript 2.4.2. The reason why this is needed is the package.json of the generated typescript model specifies installing the latest `@types/bluebird` by default, which ends up failing the build.

### What issues does this PR fix or reference?


### Is your PR tested? Consider putting some instruction how to test your changes


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
