### PR TITLE
Add arch metadata, fix variable desc

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -7306,10 +7306,10 @@ spec:
                       in the devfile. Values can can be referenced via {{variable-key}}
                       to replace the corresponding value in string fields in the devfile.
                       Replacement cannot be used for \n  - schemaVersion, metadata,
-                      parent source  - element identifiers, e.g. command id, component
-                      name, endpoint name, project name  - references to identifiers,
+                      parent source \n  - element identifiers, e.g. command id, component
+                      name, endpoint name, project name \n  - references to identifiers,
                       e.g. in events, a command's component, container's volume mount
-                      name  - string enums, e.g. command group kind, endpoint exposure"
+                      name \n  - string enums, e.g. command group kind, endpoint exposure"
                     type: object
                 type: object
             required:

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -7311,10 +7311,10 @@ spec:
                       in the devfile. Values can can be referenced via {{variable-key}}
                       to replace the corresponding value in string fields in the devfile.
                       Replacement cannot be used for \n  - schemaVersion, metadata,
-                      parent source  - element identifiers, e.g. command id, component
-                      name, endpoint name, project name  - references to identifiers,
+                      parent source \n  - element identifiers, e.g. command id, component
+                      name, endpoint name, project name \n  - references to identifiers,
                       e.g. in events, a command's component, container's volume mount
-                      name  - string enums, e.g. command group kind, endpoint exposure"
+                      name \n  - string enums, e.g. command group kind, endpoint exposure"
                     type: object
                 type: object
             required:

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -6965,10 +6965,10 @@ spec:
                   in the devfile. Values can can be referenced via {{variable-key}}
                   to replace the corresponding value in string fields in the devfile.
                   Replacement cannot be used for \n  - schemaVersion, metadata, parent
-                  source  - element identifiers, e.g. command id, component name,
-                  endpoint name, project name  - references to identifiers, e.g. in
-                  events, a command's component, container's volume mount name  -
-                  string enums, e.g. command group kind, endpoint exposure"
+                  source \n  - element identifiers, e.g. command id, component name,
+                  endpoint name, project name \n  - references to identifiers, e.g.
+                  in events, a command's component, container's volume mount name
+                  \n  - string enums, e.g. command group kind, endpoint exposure"
                 type: object
             type: object
         type: object

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -6970,10 +6970,10 @@ spec:
                   in the devfile. Values can can be referenced via {{variable-key}}
                   to replace the corresponding value in string fields in the devfile.
                   Replacement cannot be used for \n  - schemaVersion, metadata, parent
-                  source  - element identifiers, e.g. command id, component name,
-                  endpoint name, project name  - references to identifiers, e.g. in
-                  events, a command's component, container's volume mount name  -
-                  string enums, e.g. command group kind, endpoint exposure"
+                  source \n  - element identifiers, e.g. command id, component name,
+                  endpoint name, project name \n  - references to identifiers, e.g.
+                  in events, a command's component, container's volume mount name
+                  \n  - string enums, e.g. command group kind, endpoint exposure"
                 type: object
             type: object
         type: object

--- a/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_spec.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_spec.go
@@ -18,8 +18,11 @@ type DevWorkspaceTemplateSpecContent struct {
 	// to replace the corresponding value in string fields in the devfile. Replacement cannot be used for
 	//
 	//  - schemaVersion, metadata, parent source
+	//
 	//  - element identifiers, e.g. command id, component name, endpoint name, project name
+	//
 	//  - references to identifiers, e.g. in events, a command's component, container's volume mount name
+	//
 	//  - string enums, e.g. command group kind, endpoint exposure
 	// +optional
 	// +patchStrategy=merge

--- a/pkg/devfile/header.go
+++ b/pkg/devfile/header.go
@@ -43,6 +43,11 @@ type DevfileMetadata struct {
 	// +optional
 	Tags []string `json:"tags,omitempty"`
 
+	// Optional list of processor architectures that the devfile supports, empty list suggests that the devfile can be used on any architecture.
+	// Architecture values are `amd64`, `arm64`, `ppc64le`, `s390x`
+	// +optional
+	Architectures []string `json:"architectures,omitempty"`
+
 	// Optional devfile icon, can be a URI or a relative path in the project
 	// +optional
 	Icon string `json:"icon,omitempty"`

--- a/pkg/validation/metadata.go
+++ b/pkg/validation/metadata.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 )
 
-var validArchitectures = map[string]bool {
-	"amd64": true,
-	"arm64": true,
+var validArchitectures = map[string]bool{
+	"amd64":   true,
+	"arm64":   true,
 	"ppc64le": true,
-	"s390x": true,
+	"s390x":   true,
 }
 
 // ValidateMetadata validates the devfile metadata

--- a/pkg/validation/metadata.go
+++ b/pkg/validation/metadata.go
@@ -1,0 +1,43 @@
+package validation
+
+import (
+	"fmt"
+	"github.com/devfile/api/v2/pkg/devfile"
+	"strings"
+)
+
+var validArchitectures = map[string]bool {
+	"amd64": true,
+	"arm64": true,
+	"ppc64le": true,
+	"s390x": true,
+}
+
+// ValidateMetadata validates the devfile metadata
+func ValidateMetadata(metadata devfile.DevfileMetadata) (err error) {
+
+	if len(metadata.Architectures) > 0 {
+		err = validateArchitectures(metadata.Architectures)
+	}
+
+	return err
+}
+
+// validateArchitectures validates the architectures property to ensure that the architectures
+// mentioned conform to the architecture convention for container images
+func validateArchitectures(architectures []string) error {
+
+	var err error
+	var invalidArchitectures []string
+	for _, arch := range architectures {
+		if ok := validArchitectures[arch]; !ok {
+			invalidArchitectures = append(invalidArchitectures, arch)
+		}
+	}
+
+	if len(invalidArchitectures) > 0 {
+		err = fmt.Errorf("architecture: %s not valid. Please ensure that the architecture list conforms to specification", strings.Join(invalidArchitectures, ","))
+	}
+
+	return err
+}

--- a/pkg/validation/metadata.go
+++ b/pkg/validation/metadata.go
@@ -36,8 +36,16 @@ func validateArchitectures(architectures []string) error {
 	}
 
 	if len(invalidArchitectures) > 0 {
-		err = fmt.Errorf("architecture: %s not valid. Please ensure that the architecture list conforms to specification", strings.Join(invalidArchitectures, ","))
+		err = fmt.Errorf("architecture: %s not valid. Please ensure that the architecture list conforms to %s", strings.Join(invalidArchitectures, ","), strings.Join(mapKeyList(validArchitectures), ","))
 	}
 
 	return err
+}
+
+func mapKeyList(m map[string]bool) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/pkg/validation/metadata_test.go
+++ b/pkg/validation/metadata_test.go
@@ -1,0 +1,46 @@
+package validation
+
+import (
+	"github.com/devfile/api/v2/pkg/devfile"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidateMetadata(t *testing.T) {
+
+	invalidArchErr := "architecture:.* not valid. Please ensure that the architecture list conforms to specification"
+
+	tests := []struct {
+		name     string
+		metadata devfile.DevfileMetadata
+		wantErr  *string
+	}{
+		{
+			name: "Architecture Present - Valid",
+			metadata: devfile.DevfileMetadata{
+				Architectures: []string{"amd64", "s390x"},
+			},
+		},
+		{
+			name: "Architecture Present - Invalid",
+			metadata: devfile.DevfileMetadata{
+				Architectures: []string{"amd64", "386", "arm", "s390x"},
+			},
+			wantErr: &invalidArchErr,
+		},
+		{
+			name: "Architecture Absent",
+			metadata: devfile.DevfileMetadata{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMetadata(tt.metadata)
+			if tt.wantErr != nil && assert.Error(t, err) {
+				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
+			} else {
+				assert.NoError(t, err, "Expected error to be nil")
+			}
+		})
+	}
+}

--- a/pkg/validation/metadata_test.go
+++ b/pkg/validation/metadata_test.go
@@ -29,7 +29,7 @@ func TestValidateMetadata(t *testing.T) {
 			wantErr: &invalidArchErr,
 		},
 		{
-			name: "Architecture Absent",
+			name:     "Architecture Absent",
 			metadata: devfile.DevfileMetadata{},
 		},
 	}

--- a/pkg/validation/metadata_test.go
+++ b/pkg/validation/metadata_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestValidateMetadata(t *testing.T) {
 
-	invalidArchErr := "architecture:.* not valid. Please ensure that the architecture list conforms to specification"
+	invalidArchErr := "architecture:.* not valid. Please ensure that the architecture list conforms.*"
 
 	tests := []struct {
 		name     string

--- a/pkg/validation/validation-rule.md
+++ b/pkg/validation/validation-rule.md
@@ -60,3 +60,7 @@ Common rules for all components types:
 ### projects
 - if more than one remote is configured, a checkout remote is mandatory
 - if checkout remote is mentioned, validate it against the starter project remote configured map
+
+### Architectures
+
+Architectures list support the following values - `amd64`, `arm64`, `ppc64le`, `s390x`. These values are determined by the .manifests[].platform["architecture"] field from an image's manifests and manually selected.

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -2928,7 +2928,7 @@
       }
     },
     "variables": {
-      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
       "type": "object",
       "additionalProperties": {
         "type": "string"

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -3093,7 +3093,7 @@
           }
         },
         "variables": {
-          "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+          "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
           "type": "object",
           "additionalProperties": {
             "type": "string"

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -3106,7 +3106,7 @@
               }
             },
             "variables": {
-              "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+              "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
               "type": "object",
               "additionalProperties": {
                 "type": "string"

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -636,6 +636,13 @@
       "description": "Optional metadata",
       "type": "object",
       "properties": {
+        "architectures": {
+          "description": "Optional list of processor architectures that the devfile supports, empty list suggests that the devfile can be used on any architecture. Architecture values are `amd64`, `arm64`, `ppc64le`, `s390x`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "attributes": {
           "description": "Map of implementation-dependant free-form YAML attributes. Deprecated, use the top-level attributes field instead.",
           "type": "object",
@@ -1647,7 +1654,7 @@
       }
     },
     "variables": {
-      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
       "type": "object",
       "additionalProperties": {
         "type": "string"

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -3258,12 +3258,12 @@
       "markdownDescription": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects"
     },
     "variables": {
-      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
       "type": "object",
       "additionalProperties": {
         "type": "string"
       },
-      "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure"
+      "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure"
     }
   },
   "additionalProperties": false,

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -3456,12 +3456,12 @@
           "markdownDescription": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects"
         },
         "variables": {
-          "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+          "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
           "type": "object",
           "additionalProperties": {
             "type": "string"
           },
-          "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure"
+          "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure"
         }
       },
       "additionalProperties": false,

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -3469,12 +3469,12 @@
               "markdownDescription": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects"
             },
             "variables": {
-              "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+              "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
               "type": "object",
               "additionalProperties": {
                 "type": "string"
               },
-              "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure"
+              "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure"
             }
           },
           "additionalProperties": false,

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -699,6 +699,14 @@
       "description": "Optional metadata",
       "type": "object",
       "properties": {
+        "architectures": {
+          "description": "Optional list of processor architectures that the devfile supports, empty list suggests that the devfile can be used on any architecture. Architecture values are `amd64`, `arm64`, `ppc64le`, `s390x`",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Optional list of processor architectures that the devfile supports, empty list suggests that the devfile can be used on any architecture. Architecture values are `amd64`, `arm64`, `ppc64le`, `s390x`"
+        },
         "attributes": {
           "description": "Map of implementation-dependant free-form YAML attributes. Deprecated, use the top-level attributes field instead.",
           "type": "object",
@@ -1840,12 +1848,12 @@
       "markdownDescription": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects"
     },
     "variables": {
-      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure",
+      "description": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure",
       "type": "object",
       "additionalProperties": {
         "type": "string"
       },
-      "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source  - element identifiers, e.g. command id, component name, endpoint name, project name  - references to identifiers, e.g. in events, a command's component, container's volume mount name  - string enums, e.g. command group kind, endpoint exposure"
+      "markdownDescription": "Map of key-value variables used for string replacement in the devfile. Values can can be referenced via {{variable-key}} to replace the corresponding value in string fields in the devfile. Replacement cannot be used for\n\n - schemaVersion, metadata, parent source\n\n - element identifiers, e.g. command id, component name, endpoint name, project name\n\n - references to identifiers, e.g. in events, a command's component, container's volume mount name\n\n - string enums, e.g. command group kind, endpoint exposure"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

### What does this PR do?
- Adds in Architecture metadata of type `[]string` (amd64 is considered default unless specified otherwise)
- Fixes the Variable desc, so that the bullet list renders properly on devfile.io

### What issues does this PR fix or reference?
Partially addresses #244 

### Is your PR tested? Consider putting some instruction how to test your changes
Repo's Go tests

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
