### PR TITLE
Fix the strange schema generation for `Attributes` 

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -4142,8 +4142,6 @@ spec:
                   of a devworkspace template.
                 properties:
                   attributes:
-                    additionalProperties:
-                      x-kubernetes-preserve-unknown-fields: true
                     description: Map of implementation-dependant free-form YAML attributes.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -4201,8 +4199,6 @@ spec:
                           - component
                           type: object
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -4402,8 +4398,6 @@ spec:
                         - custom
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -4454,8 +4448,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -4627,8 +4619,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -4738,8 +4728,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -4895,8 +4883,6 @@ spec:
                                         type: string
                                     type: object
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -5048,8 +5034,6 @@ spec:
                                   - volume
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -5099,8 +5083,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -5262,8 +5244,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -5384,8 +5364,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -5596,8 +5574,6 @@ spec:
                       - kubernetes
                     properties:
                       attributes:
-                        additionalProperties:
-                          x-kubernetes-preserve-unknown-fields: true
                         description: Overrides of attributes encapsulated in a parent
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
@@ -5656,8 +5632,6 @@ spec:
                                   type: string
                               type: object
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -5808,8 +5782,6 @@ spec:
                             - plugin
                           properties:
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -5859,8 +5831,6 @@ spec:
                                   items:
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
                                           of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -6013,8 +5983,6 @@ spec:
                                   items:
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
                                           of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -6126,8 +6094,6 @@ spec:
                                   items:
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
                                           of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -6287,8 +6253,6 @@ spec:
                                             type: string
                                         type: object
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: Map of implementation-dependant
                                           free-form YAML attributes.
                                         type: object
@@ -6445,8 +6409,6 @@ spec:
                                       - volume
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: Map of implementation-dependant
                                           free-form YAML attributes.
                                         type: object
@@ -6498,8 +6460,6 @@ spec:
                                             items:
                                               properties:
                                                 attributes:
-                                                  additionalProperties:
-                                                    x-kubernetes-preserve-unknown-fields: true
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
                                                     \n Examples of Che-specific attributes:
@@ -6671,8 +6631,6 @@ spec:
                                             items:
                                               properties:
                                                 attributes:
-                                                  additionalProperties:
-                                                    x-kubernetes-preserve-unknown-fields: true
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
                                                     \n Examples of Che-specific attributes:
@@ -6800,8 +6758,6 @@ spec:
                                             items:
                                               properties:
                                                 attributes:
-                                                  additionalProperties:
-                                                    x-kubernetes-preserve-unknown-fields: true
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
                                                     \n Examples of Che-specific attributes:
@@ -7006,8 +6962,6 @@ spec:
                             - zip
                           properties:
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -7090,8 +7044,6 @@ spec:
                             - zip
                           properties:
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -7180,8 +7132,6 @@ spec:
                         - custom
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -7273,8 +7223,6 @@ spec:
                         - custom
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -4140,8 +4140,6 @@ spec:
                   of a devworkspace template.
                 properties:
                   attributes:
-                    additionalProperties:
-                      x-kubernetes-preserve-unknown-fields: true
                     description: Map of implementation-dependant free-form YAML attributes.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -4199,8 +4197,6 @@ spec:
                           - component
                           type: object
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -4400,8 +4396,6 @@ spec:
                         - custom
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -4452,8 +4446,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -4628,8 +4620,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -4741,8 +4731,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -4900,8 +4888,6 @@ spec:
                                         type: string
                                     type: object
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -5053,8 +5039,6 @@ spec:
                                   - volume
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -5104,8 +5088,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -5267,8 +5249,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -5389,8 +5369,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -5601,8 +5579,6 @@ spec:
                       - kubernetes
                     properties:
                       attributes:
-                        additionalProperties:
-                          x-kubernetes-preserve-unknown-fields: true
                         description: Overrides of attributes encapsulated in a parent
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
@@ -5661,8 +5637,6 @@ spec:
                                   type: string
                               type: object
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -5813,8 +5787,6 @@ spec:
                             - plugin
                           properties:
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -5864,8 +5836,6 @@ spec:
                                   items:
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
                                           of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -6018,8 +5988,6 @@ spec:
                                   items:
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
                                           of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -6131,8 +6099,6 @@ spec:
                                   items:
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: "Map of implementation-dependant
                                           string-based free-form attributes. \n Examples
                                           of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -6292,8 +6258,6 @@ spec:
                                             type: string
                                         type: object
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: Map of implementation-dependant
                                           free-form YAML attributes.
                                         type: object
@@ -6450,8 +6414,6 @@ spec:
                                       - volume
                                     properties:
                                       attributes:
-                                        additionalProperties:
-                                          x-kubernetes-preserve-unknown-fields: true
                                         description: Map of implementation-dependant
                                           free-form YAML attributes.
                                         type: object
@@ -6503,8 +6465,6 @@ spec:
                                             items:
                                               properties:
                                                 attributes:
-                                                  additionalProperties:
-                                                    x-kubernetes-preserve-unknown-fields: true
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
                                                     \n Examples of Che-specific attributes:
@@ -6676,8 +6636,6 @@ spec:
                                             items:
                                               properties:
                                                 attributes:
-                                                  additionalProperties:
-                                                    x-kubernetes-preserve-unknown-fields: true
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
                                                     \n Examples of Che-specific attributes:
@@ -6805,8 +6763,6 @@ spec:
                                             items:
                                               properties:
                                                 attributes:
-                                                  additionalProperties:
-                                                    x-kubernetes-preserve-unknown-fields: true
                                                   description: "Map of implementation-dependant
                                                     string-based free-form attributes.
                                                     \n Examples of Che-specific attributes:
@@ -7011,8 +6967,6 @@ spec:
                             - zip
                           properties:
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -7095,8 +7049,6 @@ spec:
                             - zip
                           properties:
                             attributes:
-                              additionalProperties:
-                                x-kubernetes-preserve-unknown-fields: true
                               description: Map of implementation-dependant free-form
                                 YAML attributes.
                               type: object
@@ -7185,8 +7137,6 @@ spec:
                         - custom
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -7278,8 +7228,6 @@ spec:
                         - custom
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -3916,8 +3916,6 @@ spec:
               of a devworkspace template.
             properties:
               attributes:
-                additionalProperties:
-                  x-kubernetes-preserve-unknown-fields: true
                 description: Map of implementation-dependant free-form YAML attributes.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -3974,8 +3972,6 @@ spec:
                       - component
                       type: object
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object
@@ -4166,8 +4162,6 @@ spec:
                     - custom
                   properties:
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object
@@ -4216,8 +4210,6 @@ spec:
                           items:
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
                                   attributes: \n - cookiesAuthEnabled: \"true\" /
@@ -4384,8 +4376,6 @@ spec:
                           items:
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
                                   attributes: \n - cookiesAuthEnabled: \"true\" /
@@ -4491,8 +4481,6 @@ spec:
                           items:
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
                                   attributes: \n - cookiesAuthEnabled: \"true\" /
@@ -4643,8 +4631,6 @@ spec:
                                     type: string
                                 type: object
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: Map of implementation-dependant free-form
                                   YAML attributes.
                                 type: object
@@ -4794,8 +4780,6 @@ spec:
                               - volume
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: Map of implementation-dependant free-form
                                   YAML attributes.
                                 type: object
@@ -4844,8 +4828,6 @@ spec:
                                     items:
                                       properties:
                                         attributes:
-                                          additionalProperties:
-                                            x-kubernetes-preserve-unknown-fields: true
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
                                             Examples of Che-specific attributes: \n
@@ -5000,8 +4982,6 @@ spec:
                                     items:
                                       properties:
                                         attributes:
-                                          additionalProperties:
-                                            x-kubernetes-preserve-unknown-fields: true
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
                                             Examples of Che-specific attributes: \n
@@ -5115,8 +5095,6 @@ spec:
                                     items:
                                       properties:
                                         attributes:
-                                          additionalProperties:
-                                            x-kubernetes-preserve-unknown-fields: true
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
                                             Examples of Che-specific attributes: \n
@@ -5319,8 +5297,6 @@ spec:
                   - kubernetes
                 properties:
                   attributes:
-                    additionalProperties:
-                      x-kubernetes-preserve-unknown-fields: true
                     description: Overrides of attributes encapsulated in a parent
                       devfile. Overriding is done according to K8S strategic merge
                       patch standard rules.
@@ -5376,8 +5352,6 @@ spec:
                               type: string
                           type: object
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -5523,8 +5497,6 @@ spec:
                         - plugin
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -5574,8 +5546,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -5722,8 +5692,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -5832,8 +5800,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -5988,8 +5954,6 @@ spec:
                                         type: string
                                     type: object
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -6141,8 +6105,6 @@ spec:
                                   - volume
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -6192,8 +6154,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -6355,8 +6315,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -6477,8 +6435,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -6674,8 +6630,6 @@ spec:
                         - zip
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -6757,8 +6711,6 @@ spec:
                         - zip
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -6846,8 +6798,6 @@ spec:
                     - custom
                   properties:
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object
@@ -6935,8 +6885,6 @@ spec:
                     - custom
                   properties:
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -3914,8 +3914,6 @@ spec:
               of a devworkspace template.
             properties:
               attributes:
-                additionalProperties:
-                  x-kubernetes-preserve-unknown-fields: true
                 description: Map of implementation-dependant free-form YAML attributes.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -3972,8 +3970,6 @@ spec:
                       - component
                       type: object
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object
@@ -4164,8 +4160,6 @@ spec:
                     - custom
                   properties:
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object
@@ -4214,8 +4208,6 @@ spec:
                           items:
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
                                   attributes: \n - cookiesAuthEnabled: \"true\" /
@@ -4385,8 +4377,6 @@ spec:
                           items:
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
                                   attributes: \n - cookiesAuthEnabled: \"true\" /
@@ -4494,8 +4484,6 @@ spec:
                           items:
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: "Map of implementation-dependant string-based
                                   free-form attributes. \n Examples of Che-specific
                                   attributes: \n - cookiesAuthEnabled: \"true\" /
@@ -4648,8 +4636,6 @@ spec:
                                     type: string
                                 type: object
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: Map of implementation-dependant free-form
                                   YAML attributes.
                                 type: object
@@ -4799,8 +4785,6 @@ spec:
                               - volume
                             properties:
                               attributes:
-                                additionalProperties:
-                                  x-kubernetes-preserve-unknown-fields: true
                                 description: Map of implementation-dependant free-form
                                   YAML attributes.
                                 type: object
@@ -4849,8 +4833,6 @@ spec:
                                     items:
                                       properties:
                                         attributes:
-                                          additionalProperties:
-                                            x-kubernetes-preserve-unknown-fields: true
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
                                             Examples of Che-specific attributes: \n
@@ -5005,8 +4987,6 @@ spec:
                                     items:
                                       properties:
                                         attributes:
-                                          additionalProperties:
-                                            x-kubernetes-preserve-unknown-fields: true
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
                                             Examples of Che-specific attributes: \n
@@ -5120,8 +5100,6 @@ spec:
                                     items:
                                       properties:
                                         attributes:
-                                          additionalProperties:
-                                            x-kubernetes-preserve-unknown-fields: true
                                           description: "Map of implementation-dependant
                                             string-based free-form attributes. \n
                                             Examples of Che-specific attributes: \n
@@ -5324,8 +5302,6 @@ spec:
                   - kubernetes
                 properties:
                   attributes:
-                    additionalProperties:
-                      x-kubernetes-preserve-unknown-fields: true
                     description: Overrides of attributes encapsulated in a parent
                       devfile. Overriding is done according to K8S strategic merge
                       patch standard rules.
@@ -5381,8 +5357,6 @@ spec:
                               type: string
                           type: object
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -5528,8 +5502,6 @@ spec:
                         - plugin
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -5579,8 +5551,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -5727,8 +5697,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -5837,8 +5805,6 @@ spec:
                               items:
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: "Map of implementation-dependant
                                       string-based free-form attributes. \n Examples
                                       of Che-specific attributes: \n - cookiesAuthEnabled:
@@ -5993,8 +5959,6 @@ spec:
                                         type: string
                                     type: object
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -6146,8 +6110,6 @@ spec:
                                   - volume
                                 properties:
                                   attributes:
-                                    additionalProperties:
-                                      x-kubernetes-preserve-unknown-fields: true
                                     description: Map of implementation-dependant free-form
                                       YAML attributes.
                                     type: object
@@ -6197,8 +6159,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -6360,8 +6320,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -6482,8 +6440,6 @@ spec:
                                         items:
                                           properties:
                                             attributes:
-                                              additionalProperties:
-                                                x-kubernetes-preserve-unknown-fields: true
                                               description: "Map of implementation-dependant
                                                 string-based free-form attributes.
                                                 \n Examples of Che-specific attributes:
@@ -6679,8 +6635,6 @@ spec:
                         - zip
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -6762,8 +6716,6 @@ spec:
                         - zip
                       properties:
                         attributes:
-                          additionalProperties:
-                            x-kubernetes-preserve-unknown-fields: true
                           description: Map of implementation-dependant free-form YAML
                             attributes.
                           type: object
@@ -6851,8 +6803,6 @@ spec:
                     - custom
                   properties:
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object
@@ -6940,8 +6890,6 @@ spec:
                     - custom
                   properties:
                     attributes:
-                      additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
                       description: Map of implementation-dependant free-form YAML
                         attributes.
                       type: object

--- a/pkg/apis/workspaces/v1alpha2/commands.go
+++ b/pkg/apis/workspaces/v1alpha2/commands.go
@@ -61,6 +61,9 @@ type Command struct {
 	Id string `json:"id"`
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes   attributes.Attributes `json:"attributes,omitempty"`
 	CommandUnion `json:",inline"`
 }

--- a/pkg/apis/workspaces/v1alpha2/components.go
+++ b/pkg/apis/workspaces/v1alpha2/components.go
@@ -34,6 +34,9 @@ type Component struct {
 	Name string `json:"name"`
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes     attributes.Attributes `json:"attributes,omitempty"`
 	ComponentUnion `json:",inline"`
 }

--- a/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_spec.go
+++ b/pkg/apis/workspaces/v1alpha2/devworkspacetemplate_spec.go
@@ -33,6 +33,9 @@ type DevWorkspaceTemplateSpecContent struct {
 	// +optional
 	// +patchStrategy=merge
 	// +devfile:overrides:include:omitInPlugin=true,description=Overrides of attributes encapsulated in a parent devfile.
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty" patchStrategy:"merge"`
 
 	// List of the devworkspace components, such as editor and plugins,

--- a/pkg/apis/workspaces/v1alpha2/endpoint.go
+++ b/pkg/apis/workspaces/v1alpha2/endpoint.go
@@ -108,5 +108,8 @@ type Endpoint struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/projects.go
+++ b/pkg/apis/workspaces/v1alpha2/projects.go
@@ -13,6 +13,9 @@ type Project struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 
 	// Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
@@ -30,6 +33,9 @@ type StarterProject struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 
 	// Description of a starter project

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -18,6 +18,9 @@ type ParentOverrides struct {
 	// Overriding is done according to K8S strategic merge patch standard rules.
 	// +optional
 	// +patchStrategy=merge
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty" patchStrategy:"merge"`
 
 	// Overrides of components encapsulated in a parent devfile or a plugin.
@@ -65,6 +68,9 @@ type ComponentParentOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes                   attributes.Attributes `json:"attributes,omitempty"`
 	ComponentUnionParentOverride `json:",inline"`
 }
@@ -78,6 +84,9 @@ type ProjectParentOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 
 	// Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.
@@ -96,6 +105,9 @@ type StarterProjectParentOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 
 	// Description of a starter project
@@ -120,6 +132,9 @@ type CommandParentOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes                 attributes.Attributes `json:"attributes,omitempty"`
 	CommandUnionParentOverride `json:",inline"`
 }
@@ -470,6 +485,9 @@ type EndpointParentOverride struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 }
 
@@ -638,6 +656,9 @@ type ComponentPluginOverrideParentOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes                                 attributes.Attributes `json:"attributes,omitempty"`
 	ComponentUnionPluginOverrideParentOverride `json:",inline"`
 }
@@ -653,6 +674,9 @@ type CommandPluginOverrideParentOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes                               attributes.Attributes `json:"attributes,omitempty"`
 	CommandUnionPluginOverrideParentOverride `json:",inline"`
 }
@@ -1003,6 +1027,9 @@ type EndpointPluginOverrideParentOverride struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 }
 

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -37,6 +37,9 @@ type ComponentPluginOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes                   attributes.Attributes `json:"attributes,omitempty"`
 	ComponentUnionPluginOverride `json:",inline"`
 }
@@ -52,6 +55,9 @@ type CommandPluginOverride struct {
 
 	// Map of implementation-dependant free-form YAML attributes.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes                 attributes.Attributes `json:"attributes,omitempty"`
 	CommandUnionPluginOverride `json:",inline"`
 }
@@ -349,6 +355,9 @@ type EndpointPluginOverride struct {
 	//
 	// - type: "terminal" / "ide" / "ide-dev",
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 }
 

--- a/pkg/devfile/header.go
+++ b/pkg/devfile/header.go
@@ -40,6 +40,9 @@ type DevfileMetadata struct {
 
 	// Map of implementation-dependant free-form YAML attributes. Deprecated, use the top-level attributes field instead.
 	// +optional
+	// +kubebuilder:validation:Type=object
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
 	Attributes attributes.Attributes `json:"attributes,omitempty"`
 
 	// Optional devfile display name


### PR DESCRIPTION
The existing way `Attributes` were defined used to rely on a feature that was only available in `0.4.0` (The condition here: https://github.com/kubernetes-sigs/controller-tools/blob/v0.4.0/pkg/crd/schema.go#L112).

Hopefully, with the latest version of `operator-sdk`, there is a cleaner way to do this: the `Schemaless` annotation that can be applied to a field. In such a case, the other annotations used for `Attributes` (`type` and `PreserveUnknownFields`) should also be added on the field that have the `Attributes` type.

So this PR adds the following annotations to each field that is of the `Attributes` type:
```golang
	// +kubebuilder:validation:Type=object
	// +kubebuilder:pruning:PreserveUnknownFields
	// +kubebuilder:validation:Schemaless
```

In an ideal world, we should add some code in the devfile-api `validate` generator, to check that every field with the `Attributes` type would have those 3 annotations set.