### PR TITLE
Append v to devfile type version to avoid model word appearing

### DIFF
--- a/.github/actions/generate_types/generate.py
+++ b/.github/actions/generate_types/generate.py
@@ -40,7 +40,7 @@ def consolidate_schemas() -> object:
 
     with open(os.path.join(schemas_dir, 'jsonSchemaVersion.txt')) as f:
         devfileVersion = f.readline()
-        devfileVersion = devfileVersion.replace('-alpha', '')
+        devfileVersion = 'v' + devfileVersion.replace('-alpha', '')
 
     definitionName = devfileVersion + '.Devfile'
     devfile_json_schema_path = os.path.join(schemas_dir, 'devfile.json')


### PR DESCRIPTION
### What does this PR do?:
Append v to devfile type version to avoid model word appearing.

### Which issue(s) this PR fixes:
No issue is created

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
I've tested so, currently, we have types like model220Devfile, model220DevfileMetadataComponent.
With my changes they will be v220Devfile and v220DevfileMetadataComponent.
So, it's a bit nicer but I don't have a strong opinion