### PR TITLE
 Fix generating arrays for top level properties

### DIFF
--- a/build/typescript-model/generate-swagger-json.py
+++ b/build/typescript-model/generate-swagger-json.py
@@ -239,6 +239,9 @@ def flatten(consolidated_crds_object: dict) -> None:
         # Add in all the initial properties to the queue
         for prop in original_definitions[root]['properties']:
             new_path = root + '.' + prop
+            if 'items' in original_definitions[root]['properties'][prop]:
+                new_path += '.items'
+
             queue.append({
                 new_path: original_definitions[root]['properties'][prop]
             })


### PR DESCRIPTION
### What does this PR do?:
this PR fixes generating arrays for top level properties, like devfile.projects, devfile.commands.

### Which issue(s) this PR fixes:
fixes https://github.com/devfile/api/issues/557

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
run ./build/typescript-model/generate.sh and that `V220Devfile` has array for projects, commands and so on.