### PR TITLE
validator uses multierror.append to construct the returned error

### DIFF
--- a/pkg/validation/commands.go
+++ b/pkg/validation/commands.go
@@ -76,7 +76,7 @@ func validateGroup(commands []v1alpha2.Command, groupKind v1alpha2.CommandGroupK
 	}
 
 	if defaultCommandCount == 0 {
-		return &MisingDefaultCmdWarning{groupKind: groupKind}
+		return &MissingDefaultCmdWarning{groupKind: groupKind}
 	} else if defaultCommandCount > 1 {
 		var commandsReferenceList []string
 		for _, command := range defaultCommands {
@@ -84,7 +84,7 @@ func validateGroup(commands []v1alpha2.Command, groupKind v1alpha2.CommandGroupK
 				resolveErrorMessageWithImportAttributes(fmt.Errorf("command: %s", command.Id), command.Attributes).Error())
 		}
 		commandsReference := strings.Join(commandsReferenceList, "; ")
-		// example: there should be exactly one default command, currently there is more than one default command;
+		// example: there should be exactly one default command, currently there are multiple commands;
 		// command: <id1>; command: <id2>, imported from uri: http://127.0.0.1:8080, in parent overrides from main devfile"
 		return &MultipleDefaultCmdError{
 			groupKind:         groupKind,

--- a/pkg/validation/commands.go
+++ b/pkg/validation/commands.go
@@ -87,7 +87,7 @@ func validateGroup(commands []v1alpha2.Command, groupKind v1alpha2.CommandGroupK
 		// example: there should be exactly one default command, currently there is more than one default command;
 		// command: <id1>; command: <id2>, imported from uri: http://127.0.0.1:8080, in parent overrides from main devfile"
 		return &MultipleDefaultCmdError{
-			groupKind: groupKind,
+			groupKind:         groupKind,
 			commandsReference: commandsReference,
 		}
 	}

--- a/pkg/validation/commands_test.go
+++ b/pkg/validation/commands_test.go
@@ -75,8 +75,9 @@ func TestValidateCommands(t *testing.T) {
 
 	duplicateKeyErr := "duplicate key: somecommand1"
 	noDefaultCmdErr := ".*there should be exactly one default command, currently there is no default command"
-	multipleDefaultCmdErr := ".*there should be exactly one default command, currently there is more than one default command"
+	multipleDefaultCmdErr := ".*there should be exactly one default command, currently there are more than one default commands"
 	invalidCmdErr := ".*command does not map to a container component"
+	nonExistCmdInComposite := "the command .* mentioned in the composite command does not exist in the devfile"
 
 	parentOverridesFromMainDevfile := attributes.Attributes{}.PutString(ImportSourceAttribute,
 		"uri: http://127.0.0.1:8080").PutString(ParentOverrideAttribute, "main devfile")
@@ -85,7 +86,7 @@ func TestValidateCommands(t *testing.T) {
 	tests := []struct {
 		name     string
 		commands []v1alpha2.Command
-		wantErr  *string
+		wantErr  []string
 	}{
 		{
 			name: "Valid Exec Command",
@@ -107,15 +108,15 @@ func TestValidateCommands(t *testing.T) {
 				generateDummyExecCommand("somecommand1", component, nil),
 				generateDummyExecCommand("somecommand1", component, nil),
 			},
-			wantErr: &duplicateKeyErr,
+			wantErr: []string{duplicateKeyErr},
 		},
 		{
-			name: "Duplicate commands, different types",
+			name: "Multiple errors: Duplicate commands, non-exist command in composite command",
 			commands: []v1alpha2.Command{
 				generateDummyExecCommand("somecommand1", component, nil),
 				generateDummyCompositeCommand("somecommand1", []string{"fakecommand"}, &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: true}),
 			},
-			wantErr: &duplicateKeyErr,
+			wantErr: []string{duplicateKeyErr, nonExistCmdInComposite},
 		},
 		{
 			name: "Different command types belonging to the same group but no default",
@@ -123,7 +124,7 @@ func TestValidateCommands(t *testing.T) {
 				generateDummyExecCommand("somecommand1", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 				generateDummyCompositeCommand("somecommand2", []string{"somecommand1"}, &v1alpha2.CommandGroup{Kind: buildGroup}),
 			},
-			wantErr: &noDefaultCmdErr,
+			wantErr: []string{noDefaultCmdErr},
 		},
 		{
 			name: "Different command types belonging to the same group with more than one default",
@@ -132,14 +133,14 @@ func TestValidateCommands(t *testing.T) {
 				generateDummyExecCommand("somecommand3", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 				generateDummyCompositeCommand("somecommand2", []string{"somecommand1"}, &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: true}),
 			},
-			wantErr: &multipleDefaultCmdErr,
+			wantErr: []string{multipleDefaultCmdErr},
 		},
 		{
 			name: "Invalid Apply command with wrong component",
 			commands: []v1alpha2.Command{
 				generateDummyApplyCommand("command", "invalidComponent", nil, attributes.Attributes{}),
 			},
-			wantErr: &invalidCmdErr,
+			wantErr: []string{invalidCmdErr},
 		},
 		{
 			name: "Valid Composite command with one subcommand referencing the other",
@@ -155,16 +156,19 @@ func TestValidateCommands(t *testing.T) {
 			commands: []v1alpha2.Command{
 				generateDummyApplyCommand("command", "invalidComponent", nil, parentOverridesFromMainDevfile),
 			},
-			wantErr: &invalidCmdErrWithImportAttributes,
+			wantErr: []string{invalidCmdErrWithImportAttributes},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateCommands(tt.commands, components)
-			if tt.wantErr != nil && assert.Error(t, err) {
-				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
+			if tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
+				for i:= 0; i < len(err); i++ {
+					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+				}
 			} else {
-				assert.NoError(t, err, "Expected error to be nil")
+				assert.Equal(t, 0, len(err), "Error list should be empty")
 			}
 		})
 	}
@@ -320,7 +324,7 @@ func TestValidateGroup(t *testing.T) {
 	component := "alias1"
 
 	noDefaultCmdErr := ".*there should be exactly one default command, currently there is no default command"
-	multipleDefaultError := ".*there should be exactly one default command, currently there is more than one default command"
+	multipleDefaultError := ".*there should be exactly one default command, currently there are more than one default commands"
 	multipleDefaultCmdErr := multipleDefaultError + "; command: run command; command: customcommand"
 
 	parentOverridesFromMainDevfile := attributes.Attributes{}.PutString(ImportSourceAttribute,
@@ -331,6 +335,7 @@ func TestValidateGroup(t *testing.T) {
 	tests := []struct {
 		name     string
 		commands []v1alpha2.Command
+		group v1alpha2.CommandGroupKind
 		wantErr  *string
 	}{
 		{
@@ -339,6 +344,7 @@ func TestValidateGroup(t *testing.T) {
 				generateDummyExecCommand("run command", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}),
 				generateDummyExecCommand("customcommand", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}),
 			},
+			group: runGroup,
 			wantErr: &multipleDefaultCmdErr,
 		},
 		{
@@ -347,6 +353,7 @@ func TestValidateGroup(t *testing.T) {
 				generateDummyExecCommand("run command", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}),
 				generateDummyApplyCommand("customcommand", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}, parentOverridesFromMainDevfile),
 			},
+			group: runGroup,
 			wantErr: &multipleDefaultCmdErrWithImportAttributes,
 		},
 		{
@@ -355,6 +362,7 @@ func TestValidateGroup(t *testing.T) {
 				generateDummyExecCommand("build command", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 				generateDummyExecCommand("build command 2", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 			},
+			group: buildGroup,
 			wantErr: &noDefaultCmdErr,
 		},
 		{
@@ -362,12 +370,14 @@ func TestValidateGroup(t *testing.T) {
 			commands: []v1alpha2.Command{
 				generateDummyExecCommand("test command", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 			},
+			group: buildGroup,
 		},
 		{
 			name: "One command can have default",
 			commands: []v1alpha2.Command{
 				generateDummyExecCommand("test command", component, &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: true}),
 			},
+			group: buildGroup,
 		},
 		{
 			name: "Composite commands in group",
@@ -376,11 +386,12 @@ func TestValidateGroup(t *testing.T) {
 				generateDummyExecCommand("build command 2", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 				generateDummyCompositeCommand("composite1", []string{"build command", "build command 2"}, &v1alpha2.CommandGroup{Kind: buildGroup, IsDefault: true}),
 			},
+			group: buildGroup,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateGroup(tt.commands)
+			err := validateGroup(tt.commands, tt.group)
 			if tt.wantErr != nil && assert.Error(t, err) {
 				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
 			} else {

--- a/pkg/validation/commands_test.go
+++ b/pkg/validation/commands_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -162,13 +163,14 @@ func TestValidateCommands(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateCommands(tt.commands, components)
-			if tt.wantErr != nil {
-				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i := 0; i < len(err); i++ {
-					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+
+			if merr, ok := err.(*multierror.Error); ok && tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match")
+				for i := 0; i < len(merr.Errors); i++ {
+					assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
 				}
 			} else {
-				assert.Equal(t, 0, len(err), "Error list should be empty")
+				assert.Equal(t, nil, err, "Error should be nil")
 			}
 		})
 	}

--- a/pkg/validation/commands_test.go
+++ b/pkg/validation/commands_test.go
@@ -164,7 +164,7 @@ func TestValidateCommands(t *testing.T) {
 			err := ValidateCommands(tt.commands, components)
 			if tt.wantErr != nil {
 				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i:= 0; i < len(err); i++ {
+				for i := 0; i < len(err); i++ {
 					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
 				}
 			} else {
@@ -335,7 +335,7 @@ func TestValidateGroup(t *testing.T) {
 	tests := []struct {
 		name     string
 		commands []v1alpha2.Command
-		group v1alpha2.CommandGroupKind
+		group    v1alpha2.CommandGroupKind
 		wantErr  *string
 	}{
 		{
@@ -344,7 +344,7 @@ func TestValidateGroup(t *testing.T) {
 				generateDummyExecCommand("run command", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}),
 				generateDummyExecCommand("customcommand", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}),
 			},
-			group: runGroup,
+			group:   runGroup,
 			wantErr: &multipleDefaultCmdErr,
 		},
 		{
@@ -353,7 +353,7 @@ func TestValidateGroup(t *testing.T) {
 				generateDummyExecCommand("run command", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}),
 				generateDummyApplyCommand("customcommand", component, &v1alpha2.CommandGroup{Kind: runGroup, IsDefault: true}, parentOverridesFromMainDevfile),
 			},
-			group: runGroup,
+			group:   runGroup,
 			wantErr: &multipleDefaultCmdErrWithImportAttributes,
 		},
 		{
@@ -362,7 +362,7 @@ func TestValidateGroup(t *testing.T) {
 				generateDummyExecCommand("build command", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 				generateDummyExecCommand("build command 2", component, &v1alpha2.CommandGroup{Kind: buildGroup}),
 			},
-			group: buildGroup,
+			group:   buildGroup,
 			wantErr: &noDefaultCmdErr,
 		},
 		{

--- a/pkg/validation/commands_test.go
+++ b/pkg/validation/commands_test.go
@@ -75,7 +75,7 @@ func TestValidateCommands(t *testing.T) {
 
 	duplicateKeyErr := "duplicate key: somecommand1"
 	noDefaultCmdErr := ".*there should be exactly one default command, currently there is no default command"
-	multipleDefaultCmdErr := ".*there should be exactly one default command, currently there are more than one default commands"
+	multipleDefaultCmdErr := ".*there should be exactly one default command, currently there are multiple default commands"
 	invalidCmdErr := ".*command does not map to a container component"
 	nonExistCmdInComposite := "the command .* mentioned in the composite command does not exist in the devfile"
 
@@ -324,7 +324,7 @@ func TestValidateGroup(t *testing.T) {
 	component := "alias1"
 
 	noDefaultCmdErr := ".*there should be exactly one default command, currently there is no default command"
-	multipleDefaultError := ".*there should be exactly one default command, currently there are more than one default commands"
+	multipleDefaultError := ".*there should be exactly one default command, currently there are multiple default commands"
 	multipleDefaultCmdErr := multipleDefaultError + "; command: run command; command: customcommand"
 
 	parentOverridesFromMainDevfile := attributes.Attributes{}.PutString(ImportSourceAttribute,

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -146,15 +146,15 @@ func TestValidateComponents(t *testing.T) {
 	tests := []struct {
 		name       string
 		components []v1alpha2.Component
-		wantErr    *string
+		wantErr    []string
 	}{
 		{
 			name: "Duplicate components present",
 			components: []v1alpha2.Component{
 				generateDummyVolumeComponent("component1", "1Gi"),
-				generateDummyContainerComponent("component1", volMounts, nil, nil),
+				generateDummyContainerComponent("component1", nil, nil, nil),
 			},
-			wantErr: &duplicateComponentErr,
+			wantErr: []string{duplicateComponentErr},
 		},
 		{
 			name: "Valid container and volume component",
@@ -169,14 +169,14 @@ func TestValidateComponents(t *testing.T) {
 			components: []v1alpha2.Component{
 				generateDummyContainerComponent("container1", nil, nil, projectSourceEnv),
 			},
-			wantErr: &reservedEnvErr,
+			wantErr: []string{reservedEnvErr},
 		},
 		{
 			name: "Invalid container using reserved env PROJECTS_ROOT",
 			components: []v1alpha2.Component{
 				generateDummyContainerComponent("container", nil, nil, projectsRootEnv),
 			},
-			wantErr: &reservedEnvErr,
+			wantErr: []string{reservedEnvErr},
 		},
 		{
 			name: "Invalid volume component size",
@@ -184,7 +184,7 @@ func TestValidateComponents(t *testing.T) {
 				generateDummyVolumeComponent("myvol", "invalid"),
 				generateDummyContainerComponent("container", nil, nil, nil),
 			},
-			wantErr: &invalidSizeErr,
+			wantErr: []string{invalidSizeErr},
 		},
 		{
 			name: "Invalid volume mount referencing a wrong volume component",
@@ -192,7 +192,7 @@ func TestValidateComponents(t *testing.T) {
 				generateDummyVolumeComponent("myvol", "1Gi"),
 				generateDummyContainerComponent("container1", invalidVolMounts, nil, nil),
 			},
-			wantErr: &invalidVolMountErr,
+			wantErr: []string{invalidVolMountErr},
 		},
 		{
 			name: "Invalid containers with the same endpoint names",
@@ -200,7 +200,7 @@ func TestValidateComponents(t *testing.T) {
 				generateDummyContainerComponent("name1", nil, []v1alpha2.Endpoint{endpointUrl18080}, nil),
 				generateDummyContainerComponent("name2", nil, []v1alpha2.Endpoint{endpointUrl18081}, nil),
 			},
-			wantErr: &sameEndpointNameErr,
+			wantErr: []string{sameEndpointNameErr},
 		},
 		{
 			name: "Invalid containers with the same endpoint target ports",
@@ -208,7 +208,7 @@ func TestValidateComponents(t *testing.T) {
 				generateDummyContainerComponent("name1", nil, []v1alpha2.Endpoint{endpointUrl18080}, nil),
 				generateDummyContainerComponent("name2", nil, []v1alpha2.Endpoint{endpointUrl28080}, nil),
 			},
-			wantErr: &sameTargetPortErr,
+			wantErr: []string{sameTargetPortErr},
 		},
 		{
 			name: "Valid container with same target ports but different endpoint name",
@@ -221,7 +221,7 @@ func TestValidateComponents(t *testing.T) {
 			components: []v1alpha2.Component{
 				generateDummyOpenshiftComponent("name1", []v1alpha2.Endpoint{endpointUrl18080, endpointUrl28080}, "http//wronguri"),
 			},
-			wantErr: &invalidURIErr,
+			wantErr: []string{invalidURIErr},
 		},
 		{
 			name: "Valid Kubernetes Component",
@@ -234,31 +234,29 @@ func TestValidateComponents(t *testing.T) {
 			components: []v1alpha2.Component{
 				generateDummyOpenshiftComponent("name1", []v1alpha2.Endpoint{endpointUrl18080, endpointUrl18081}, "http://uri"),
 			},
-			wantErr: &sameEndpointNameErr,
+			wantErr: []string{sameEndpointNameErr},
 		},
 		{
-			name: "Invalid plugin registry url",
+			name: "Multiple errors: Duplicate component name, invalid plugin registry url, bad URI with import source attributes",
 			components: []v1alpha2.Component{
-				generateDummyPluginComponent("abc", "http//invalidregistryurl", attributes.Attributes{}),
-			},
-			wantErr: &invalidURIErr,
-		},
-		{
-			name: "Invalid component due to bad URI with import source attributes",
-			components: []v1alpha2.Component{
+				generateDummyVolumeComponent("component1", "1Gi"),
+				generateDummyPluginComponent("component1", "http//invalidregistryurl", attributes.Attributes{}),
 				generateDummyPluginComponent("abc", "http//invalidregistryurl", pluginOverridesFromMainDevfile),
 			},
-			wantErr: &invalidURIErrWithImportAttributes,
+			wantErr: []string{duplicateComponentErr, invalidURIErr, invalidURIErrWithImportAttributes},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateComponents(tt.components)
 
-			if tt.wantErr != nil && assert.Error(t, err) {
-				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
+			if tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
+				for i:= 0; i < len(err); i++ {
+					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+				}
 			} else {
-				assert.NoError(t, err, "Expected error to be nil")
+				assert.Equal(t, 0, len(err), "Error list should be empty")
 			}
 		})
 	}

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -252,7 +252,7 @@ func TestValidateComponents(t *testing.T) {
 
 			if tt.wantErr != nil {
 				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i:= 0; i < len(err); i++ {
+				for i := 0; i < len(err); i++ {
 					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
 				}
 			} else {

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -250,13 +251,13 @@ func TestValidateComponents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateComponents(tt.components)
 
-			if tt.wantErr != nil {
-				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i := 0; i < len(err); i++ {
-					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+			if merr, ok := err.(*multierror.Error); ok && tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match")
+				for i := 0; i < len(merr.Errors); i++ {
+					assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
 				}
 			} else {
-				assert.Equal(t, 0, len(err), "Error list should be empty")
+				assert.Equal(t, nil, err, "Error should be nil")
 			}
 		})
 	}

--- a/pkg/validation/endpoints.go
+++ b/pkg/validation/endpoints.go
@@ -7,12 +7,12 @@ import "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 // 2. endpoint port are unique across component containers
 // ie; two component containers cannot have the same target port but two endpoints
 // in a single component container can have the same target port
-func validateEndpoints(endpoints []v1alpha2.Endpoint, processedEndPointPort map[int]bool, processedEndPointName map[string]bool) error {
+func validateEndpoints(endpoints []v1alpha2.Endpoint, processedEndPointPort map[int]bool, processedEndPointName map[string]bool) (errList []error) {
 	currentComponentEndPointPort := make(map[int]bool)
 
 	for _, endPoint := range endpoints {
 		if _, ok := processedEndPointName[endPoint.Name]; ok {
-			return &InvalidEndpointError{name: endPoint.Name}
+			errList = append(errList, &InvalidEndpointError{name: endPoint.Name})
 		}
 		processedEndPointName[endPoint.Name] = true
 		currentComponentEndPointPort[endPoint.TargetPort] = true
@@ -20,9 +20,9 @@ func validateEndpoints(endpoints []v1alpha2.Endpoint, processedEndPointPort map[
 
 	for targetPort := range currentComponentEndPointPort {
 		if _, ok := processedEndPointPort[targetPort]; ok {
-			return &InvalidEndpointError{port: targetPort}
+			errList = append(errList, &InvalidEndpointError{port: targetPort})
 		}
 		processedEndPointPort[targetPort] = true
 	}
-	return nil
+	return errList
 }

--- a/pkg/validation/endpoints_test.go
+++ b/pkg/validation/endpoints_test.go
@@ -74,7 +74,7 @@ func TestValidateEndpoints(t *testing.T) {
 				8080: true,
 				8081: true,
 			},
-			wantErr:               []string{duplicateNameErr, duplicatePortErr,duplicatePortErr},
+			wantErr: []string{duplicateNameErr, duplicatePortErr, duplicatePortErr},
 		},
 	}
 	for _, tt := range tests {
@@ -83,7 +83,7 @@ func TestValidateEndpoints(t *testing.T) {
 
 			if tt.wantErr != nil {
 				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i:= 0; i < len(err); i++ {
+				for i := 0; i < len(err); i++ {
 					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
 				}
 			} else {

--- a/pkg/validation/endpoints_test.go
+++ b/pkg/validation/endpoints_test.go
@@ -17,7 +17,7 @@ func TestValidateEndpoints(t *testing.T) {
 		endpoints             []v1alpha2.Endpoint
 		processedEndpointName map[string]bool
 		processedEndpointPort map[int]bool
-		wantErr               *string
+		wantErr               []string
 	}{
 		{
 			name: "Duplicate endpoint name",
@@ -27,7 +27,7 @@ func TestValidateEndpoints(t *testing.T) {
 			},
 			processedEndpointName: map[string]bool{},
 			processedEndpointPort: map[int]bool{},
-			wantErr:               &duplicateNameErr,
+			wantErr:               []string{duplicateNameErr},
 		},
 		{
 			name: "Duplicate endpoint name across components",
@@ -38,7 +38,7 @@ func TestValidateEndpoints(t *testing.T) {
 				"url1": true,
 			},
 			processedEndpointPort: map[int]bool{},
-			wantErr:               &duplicateNameErr,
+			wantErr:               []string{duplicateNameErr},
 		},
 		{
 			name: "Duplicate endpoint port within same component",
@@ -59,17 +59,35 @@ func TestValidateEndpoints(t *testing.T) {
 			processedEndpointPort: map[int]bool{
 				8080: true,
 			},
-			wantErr: &duplicatePortErr,
+			wantErr: []string{duplicatePortErr},
+		},
+		{
+			name: "Multiple errors: Duplicate endpoint name, duplicate endpoint port",
+			endpoints: []v1alpha2.Endpoint{
+				generateDummyEndpoint("url1", 8080),
+				generateDummyEndpoint("url2", 8081),
+			},
+			processedEndpointName: map[string]bool{
+				"url1": true,
+			},
+			processedEndpointPort: map[int]bool{
+				8080: true,
+				8081: true,
+			},
+			wantErr:               []string{duplicateNameErr, duplicatePortErr,duplicatePortErr},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateEndpoints(tt.endpoints, tt.processedEndpointPort, tt.processedEndpointName)
 
-			if tt.wantErr != nil && assert.Error(t, err) {
-				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
+			if tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
+				for i:= 0; i < len(err); i++ {
+					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+				}
 			} else {
-				assert.NoError(t, err, "Expected error to be nil")
+				assert.Equal(t, 0, len(err), "Error list should be empty")
 			}
 		})
 	}

--- a/pkg/validation/errors.go
+++ b/pkg/validation/errors.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	attributesAPI "github.com/devfile/api/v2/pkg/attributes"
 )
 
@@ -32,6 +33,26 @@ type InvalidCommandTypeError struct {
 
 func (e *InvalidCommandTypeError) Error() string {
 	return fmt.Sprintf("command %s has invalid type", e.commandId)
+}
+
+// MultipleDefaultCmdError returns an error if there are multiple default commands for a single group kind
+type MultipleDefaultCmdError struct {
+	groupKind v1alpha2.CommandGroupKind
+	commandsReference string
+}
+
+func (e *MultipleDefaultCmdError) Error() string {
+	return fmt.Sprintf("command group %s error - there should be exactly one default command, currently there are more than one default commands; %s",
+		e.groupKind, e.commandsReference)
+}
+
+// MisingDefaultCmdWarning returns an error if there is no default command for a single group kind
+type MisingDefaultCmdWarning struct {
+	groupKind v1alpha2.CommandGroupKind
+}
+
+func (e *MisingDefaultCmdWarning) Error() string {
+	return fmt.Sprintf("command group %s warning - there should be exactly one default command, currently there is no default command", e.groupKind)
 }
 
 // ReservedEnvError returns an error if the user attempts to customize a reserved ENV in a container

--- a/pkg/validation/errors.go
+++ b/pkg/validation/errors.go
@@ -42,16 +42,16 @@ type MultipleDefaultCmdError struct {
 }
 
 func (e *MultipleDefaultCmdError) Error() string {
-	return fmt.Sprintf("command group %s error - there should be exactly one default command, currently there are more than one default commands; %s",
+	return fmt.Sprintf("command group %s error - there should be exactly one default command, currently there are multiple default commands; %s",
 		e.groupKind, e.commandsReference)
 }
 
-// MisingDefaultCmdWarning returns an error if there is no default command for a single group kind
-type MisingDefaultCmdWarning struct {
+// MissingDefaultCmdWarning returns an error if there is no default command for a single group kind
+type MissingDefaultCmdWarning struct {
 	groupKind v1alpha2.CommandGroupKind
 }
 
-func (e *MisingDefaultCmdWarning) Error() string {
+func (e *MissingDefaultCmdWarning) Error() string {
 	return fmt.Sprintf("command group %s warning - there should be exactly one default command, currently there is no default command", e.groupKind)
 }
 

--- a/pkg/validation/errors.go
+++ b/pkg/validation/errors.go
@@ -37,7 +37,7 @@ func (e *InvalidCommandTypeError) Error() string {
 
 // MultipleDefaultCmdError returns an error if there are multiple default commands for a single group kind
 type MultipleDefaultCmdError struct {
-	groupKind v1alpha2.CommandGroupKind
+	groupKind         v1alpha2.CommandGroupKind
 	commandsReference string
 }
 

--- a/pkg/validation/events.go
+++ b/pkg/validation/events.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"strings"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
@@ -15,33 +16,33 @@ const (
 )
 
 // ValidateEvents validates all the devfile events
-func ValidateEvents(events v1alpha2.Events, commands []v1alpha2.Command) (errList []error) {
+func ValidateEvents(events v1alpha2.Events, commands []v1alpha2.Command) (err error) {
 
 	commandMap := getCommandsMap(commands)
 
 	switch {
 	case len(events.PreStart) > 0:
 		if preStartErr := isEventValid(events.PreStart, preStart, commandMap); preStartErr != nil {
-			errList = append(errList, preStartErr)
+			err = multierror.Append(err, preStartErr)
 		}
 		fallthrough
 	case len(events.PostStart) > 0:
 		if postStartErr := isEventValid(events.PostStart, postStart, commandMap); postStartErr != nil {
-			errList = append(errList, postStartErr)
+			err = multierror.Append(err, postStartErr)
 		}
 		fallthrough
 	case len(events.PreStop) > 0:
 		if preStopErr := isEventValid(events.PreStop, preStop, commandMap); preStopErr != nil {
-			errList = append(errList, preStopErr)
+			err = multierror.Append(err, preStopErr)
 		}
 		fallthrough
 	case len(events.PostStop) > 0:
 		if postStopErr := isEventValid(events.PostStop, postStop, commandMap); postStopErr != nil {
-			errList = append(errList, postStopErr)
+			err = multierror.Append(err, postStopErr)
 		}
 	}
 
-	return errList
+	return err
 }
 
 // isEventValid checks if events belonging to a specific event type are valid ie;

--- a/pkg/validation/events.go
+++ b/pkg/validation/events.go
@@ -15,40 +15,33 @@ const (
 )
 
 // ValidateEvents validates all the devfile events
-func ValidateEvents(events v1alpha2.Events, commands []v1alpha2.Command) error {
+func ValidateEvents(events v1alpha2.Events, commands []v1alpha2.Command) (errList []error) {
 
 	commandMap := getCommandsMap(commands)
-	var eventErrorsList []string
 
 	switch {
 	case len(events.PreStart) > 0:
 		if preStartErr := isEventValid(events.PreStart, preStart, commandMap); preStartErr != nil {
-			eventErrorsList = append(eventErrorsList, preStartErr.Error())
+			errList = append(errList, preStartErr)
 		}
 		fallthrough
 	case len(events.PostStart) > 0:
 		if postStartErr := isEventValid(events.PostStart, postStart, commandMap); postStartErr != nil {
-			eventErrorsList = append(eventErrorsList, postStartErr.Error())
+			errList = append(errList, postStartErr)
 		}
 		fallthrough
 	case len(events.PreStop) > 0:
 		if preStopErr := isEventValid(events.PreStop, preStop, commandMap); preStopErr != nil {
-			eventErrorsList = append(eventErrorsList, preStopErr.Error())
+			errList = append(errList, preStopErr)
 		}
 		fallthrough
 	case len(events.PostStop) > 0:
 		if postStopErr := isEventValid(events.PostStop, postStop, commandMap); postStopErr != nil {
-			eventErrorsList = append(eventErrorsList, postStopErr.Error())
+			errList = append(errList, postStopErr)
 		}
 	}
 
-	// if there is any validation error, return it
-	if len(eventErrorsList) > 0 {
-		eventErrors := fmt.Sprintf("\n%s", strings.Join(eventErrorsList, "\n"))
-		return fmt.Errorf("devfile events validation error: %s", eventErrors)
-	}
-
-	return nil
+	return errList
 }
 
 // isEventValid checks if events belonging to a specific event type are valid ie;

--- a/pkg/validation/events_test.go
+++ b/pkg/validation/events_test.go
@@ -119,7 +119,7 @@ func TestValidateEvents(t *testing.T) {
 
 			if tt.wantErr != nil {
 				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i:= 0; i < len(err); i++ {
+				for i := 0; i < len(err); i++ {
 					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
 				}
 			} else {

--- a/pkg/validation/events_test.go
+++ b/pkg/validation/events_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 	"github.com/devfile/api/v2/pkg/attributes"
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -117,13 +118,13 @@ func TestValidateEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateEvents(tt.events, commands)
 
-			if tt.wantErr != nil {
-				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i := 0; i < len(err); i++ {
-					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+			if merr, ok := err.(*multierror.Error); ok && tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match")
+				for i := 0; i < len(merr.Errors); i++ {
+					assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
 				}
 			} else {
-				assert.Equal(t, 0, len(err), "Error list should be empty")
+				assert.Equal(t, nil, err, "Error should be nil")
 			}
 		})
 	}

--- a/pkg/validation/events_test.go
+++ b/pkg/validation/events_test.go
@@ -28,7 +28,7 @@ func TestValidateEvents(t *testing.T) {
 	tests := []struct {
 		name    string
 		events  v1alpha2.Events
-		wantErr *string
+		wantErr []string
 	}{
 		{
 			name: "Valid preStart events - Apply and Composite Apply Commands",
@@ -53,7 +53,7 @@ func TestValidateEvents(t *testing.T) {
 					},
 				},
 			},
-			wantErr: &preStartPostStopErr,
+			wantErr: []string{preStartPostStopErr},
 		},
 		{
 			name: "Invalid exec commands in postStop",
@@ -66,7 +66,7 @@ func TestValidateEvents(t *testing.T) {
 					},
 				},
 			},
-			wantErr: &preStartPostStopErr,
+			wantErr: []string{preStartPostStopErr},
 		},
 		{
 			name: "Invalid apply commands in postStart",
@@ -79,7 +79,7 @@ func TestValidateEvents(t *testing.T) {
 					},
 				},
 			},
-			wantErr: &postStartPreStopErr,
+			wantErr: []string{postStartPreStopErr},
 		},
 		{
 			name: "Invalid apply commands in preStop",
@@ -92,17 +92,38 @@ func TestValidateEvents(t *testing.T) {
 					},
 				},
 			},
-			wantErr: &postStartPreStopErr,
+			wantErr: []string{postStartPreStopErr},
+		},
+		{
+			name: "Multiple errors: Invalid exec commands in postStop, Invalid apply commands in preStop",
+			events: v1alpha2.Events{
+				DevWorkspaceEvents: v1alpha2.DevWorkspaceEvents{
+					PreStop: []string{
+						"apply12",
+						"exec2",
+						"compositeExecApply",
+					},
+					PostStop: []string{
+						"apply12",
+						"exec2",
+						"compositeExecApply",
+					},
+				},
+			},
+			wantErr: []string{postStartPreStopErr, preStartPostStopErr},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateEvents(tt.events, commands)
 
-			if tt.wantErr != nil && assert.Error(t, err) {
-				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
+			if tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
+				for i:= 0; i < len(err); i++ {
+					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+				}
 			} else {
-				assert.NoError(t, err, "Expected error to be nil")
+				assert.Equal(t, 0, len(err), "Error list should be empty")
 			}
 		})
 	}

--- a/pkg/validation/projects.go
+++ b/pkg/validation/projects.go
@@ -3,11 +3,12 @@ package validation
 import (
 	"fmt"
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/hashicorp/go-multierror"
 )
 
 // ValidateStarterProjects checks if starter project has only one remote configured
 // and if the checkout remote matches the renote configured
-func ValidateStarterProjects(starterProjects []v1alpha2.StarterProject) (errList []error) {
+func ValidateStarterProjects(starterProjects []v1alpha2.StarterProject) (returnedErr error) {
 
 	for _, starterProject := range starterProjects {
 		var gitSource v1alpha2.GitLikeProjectSource
@@ -21,28 +22,28 @@ func ValidateStarterProjects(starterProjects []v1alpha2.StarterProject) (errList
 		case 0:
 			starterProjectErr := fmt.Errorf("starterProject %s should have at least one remote", starterProject.Name)
 			newErr := resolveErrorMessageWithImportAttributes(starterProjectErr, starterProject.Attributes)
-			errList = append(errList, newErr)
+			returnedErr = multierror.Append(returnedErr, newErr)
 		case 1:
 			if gitSource.CheckoutFrom != nil && gitSource.CheckoutFrom.Remote != "" {
 				err := validateRemoteMap(gitSource.Remotes, gitSource.CheckoutFrom.Remote, starterProject.Name)
 				if err != nil {
 					newErr := resolveErrorMessageWithImportAttributes(err, starterProject.Attributes)
-					errList = append(errList, newErr)
+					returnedErr = multierror.Append(returnedErr, newErr)
 				}
 			}
 		default: // len(gitSource.Remotes) >= 2
 			starterProjectErr := fmt.Errorf("starterProject %s should have one remote only", starterProject.Name)
 			newErr := resolveErrorMessageWithImportAttributes(starterProjectErr, starterProject.Attributes)
-			errList = append(errList, newErr)
+			returnedErr = multierror.Append(returnedErr, newErr)
 		}
 	}
 
-	return errList
+	return returnedErr
 }
 
 // ValidateProjects checks if the project has more than one remote configured then a checkout
 // remote is mandatory and if the checkout remote matches the renote configured
-func ValidateProjects(projects []v1alpha2.Project) (errList []error) {
+func ValidateProjects(projects []v1alpha2.Project) (returnedErr error) {
 
 	for _, project := range projects {
 		var gitSource v1alpha2.GitLikeProjectSource
@@ -55,29 +56,29 @@ func ValidateProjects(projects []v1alpha2.Project) (errList []error) {
 		case 0:
 			projectErr := fmt.Errorf("projects %s should have at least one remote", project.Name)
 			newErr := resolveErrorMessageWithImportAttributes(projectErr, project.Attributes)
-			errList = append(errList, newErr)
+			returnedErr = multierror.Append(returnedErr, newErr)
 		case 1:
 			if gitSource.CheckoutFrom != nil && gitSource.CheckoutFrom.Remote != "" {
 				if err := validateRemoteMap(gitSource.Remotes, gitSource.CheckoutFrom.Remote, project.Name); err != nil {
 					newErr := resolveErrorMessageWithImportAttributes(err, project.Attributes)
-					errList = append(errList, newErr)
+					returnedErr = multierror.Append(returnedErr, newErr)
 				}
 			}
 		default: // len(gitSource.Remotes) >= 2
 			if gitSource.CheckoutFrom == nil || gitSource.CheckoutFrom.Remote == "" {
 				projectErr := fmt.Errorf("project %s has more than one remote defined, but has no checkoutfrom remote defined", project.Name)
 				newErr := resolveErrorMessageWithImportAttributes(projectErr, project.Attributes)
-				errList = append(errList, newErr)
+				returnedErr = multierror.Append(returnedErr, newErr)
 				continue
 			}
 			if err := validateRemoteMap(gitSource.Remotes, gitSource.CheckoutFrom.Remote, project.Name); err != nil {
 				newErr := resolveErrorMessageWithImportAttributes(err, project.Attributes)
-				errList = append(errList, newErr)
+				returnedErr = multierror.Append(returnedErr, newErr)
 			}
 		}
 	}
 
-	return errList
+	return returnedErr
 }
 
 // validateRemoteMap checks if the checkout remote is present in the project remote map

--- a/pkg/validation/projects.go
+++ b/pkg/validation/projects.go
@@ -42,7 +42,7 @@ func ValidateStarterProjects(starterProjects []v1alpha2.StarterProject) (errList
 
 // ValidateProjects checks if the project has more than one remote configured then a checkout
 // remote is mandatory and if the checkout remote matches the renote configured
-func ValidateProjects(projects []v1alpha2.Project) (errList []error)  {
+func ValidateProjects(projects []v1alpha2.Project) (errList []error) {
 
 	for _, project := range projects {
 		var gitSource v1alpha2.GitLikeProjectSource

--- a/pkg/validation/projects.go
+++ b/pkg/validation/projects.go
@@ -2,16 +2,13 @@ package validation
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 )
 
 // ValidateStarterProjects checks if starter project has only one remote configured
 // and if the checkout remote matches the renote configured
-func ValidateStarterProjects(starterProjects []v1alpha2.StarterProject) error {
+func ValidateStarterProjects(starterProjects []v1alpha2.StarterProject) (errList []error) {
 
-	var projectErrorsList []string
 	for _, starterProject := range starterProjects {
 		var gitSource v1alpha2.GitLikeProjectSource
 		if starterProject.Git != nil {
@@ -24,36 +21,29 @@ func ValidateStarterProjects(starterProjects []v1alpha2.StarterProject) error {
 		case 0:
 			starterProjectErr := fmt.Errorf("starterProject %s should have at least one remote", starterProject.Name)
 			newErr := resolveErrorMessageWithImportAttributes(starterProjectErr, starterProject.Attributes)
-			projectErrorsList = append(projectErrorsList, newErr.Error())
+			errList = append(errList, newErr)
 		case 1:
 			if gitSource.CheckoutFrom != nil && gitSource.CheckoutFrom.Remote != "" {
 				err := validateRemoteMap(gitSource.Remotes, gitSource.CheckoutFrom.Remote, starterProject.Name)
 				if err != nil {
 					newErr := resolveErrorMessageWithImportAttributes(err, starterProject.Attributes)
-					projectErrorsList = append(projectErrorsList, newErr.Error())
+					errList = append(errList, newErr)
 				}
 			}
 		default: // len(gitSource.Remotes) >= 2
 			starterProjectErr := fmt.Errorf("starterProject %s should have one remote only", starterProject.Name)
 			newErr := resolveErrorMessageWithImportAttributes(starterProjectErr, starterProject.Attributes)
-			projectErrorsList = append(projectErrorsList, newErr.Error())
+			errList = append(errList, newErr)
 		}
 	}
 
-	var err error
-	if len(projectErrorsList) > 0 {
-		projectErrors := fmt.Sprintf("\n%s", strings.Join(projectErrorsList, "\n"))
-		err = fmt.Errorf("error validating starter projects:%s", projectErrors)
-	}
-
-	return err
+	return errList
 }
 
 // ValidateProjects checks if the project has more than one remote configured then a checkout
 // remote is mandatory and if the checkout remote matches the renote configured
-func ValidateProjects(projects []v1alpha2.Project) error {
+func ValidateProjects(projects []v1alpha2.Project) (errList []error)  {
 
-	var projectErrorsList []string
 	for _, project := range projects {
 		var gitSource v1alpha2.GitLikeProjectSource
 		if project.Git != nil {
@@ -65,35 +55,29 @@ func ValidateProjects(projects []v1alpha2.Project) error {
 		case 0:
 			projectErr := fmt.Errorf("projects %s should have at least one remote", project.Name)
 			newErr := resolveErrorMessageWithImportAttributes(projectErr, project.Attributes)
-			projectErrorsList = append(projectErrorsList, newErr.Error())
+			errList = append(errList, newErr)
 		case 1:
 			if gitSource.CheckoutFrom != nil && gitSource.CheckoutFrom.Remote != "" {
 				if err := validateRemoteMap(gitSource.Remotes, gitSource.CheckoutFrom.Remote, project.Name); err != nil {
 					newErr := resolveErrorMessageWithImportAttributes(err, project.Attributes)
-					projectErrorsList = append(projectErrorsList, newErr.Error())
+					errList = append(errList, newErr)
 				}
 			}
 		default: // len(gitSource.Remotes) >= 2
 			if gitSource.CheckoutFrom == nil || gitSource.CheckoutFrom.Remote == "" {
 				projectErr := fmt.Errorf("project %s has more than one remote defined, but has no checkoutfrom remote defined", project.Name)
 				newErr := resolveErrorMessageWithImportAttributes(projectErr, project.Attributes)
-				projectErrorsList = append(projectErrorsList, newErr.Error())
+				errList = append(errList, newErr)
 				continue
 			}
 			if err := validateRemoteMap(gitSource.Remotes, gitSource.CheckoutFrom.Remote, project.Name); err != nil {
 				newErr := resolveErrorMessageWithImportAttributes(err, project.Attributes)
-				projectErrorsList = append(projectErrorsList, newErr.Error())
+				errList = append(errList, newErr)
 			}
 		}
 	}
 
-	var err error
-	if len(projectErrorsList) > 0 {
-		projectErrors := fmt.Sprintf("\n%s", strings.Join(projectErrorsList, "\n"))
-		err = fmt.Errorf("error validating projects:%s", projectErrors)
-	}
-
-	return err
+	return errList
 }
 
 // validateRemoteMap checks if the checkout remote is present in the project remote map

--- a/pkg/validation/projects_test.go
+++ b/pkg/validation/projects_test.go
@@ -109,7 +109,7 @@ func TestValidateStarterProjects(t *testing.T) {
 
 			if tt.wantErr != nil {
 				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i:= 0; i < len(err); i++ {
+				for i := 0; i < len(err); i++ {
 					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
 				}
 			} else {
@@ -191,7 +191,7 @@ func TestValidateProjects(t *testing.T) {
 
 			if tt.wantErr != nil {
 				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i:= 0; i < len(err); i++ {
+				for i := 0; i < len(err); i++ {
 					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
 				}
 			} else {

--- a/pkg/validation/projects_test.go
+++ b/pkg/validation/projects_test.go
@@ -52,7 +52,7 @@ func TestValidateStarterProjects(t *testing.T) {
 	tests := []struct {
 		name            string
 		starterProjects []v1alpha2.StarterProject
-		wantErr         *string
+		wantErr         []string
 	}{
 		{
 			name: "Valid Starter Project",
@@ -66,14 +66,14 @@ func TestValidateStarterProjects(t *testing.T) {
 			starterProjects: []v1alpha2.StarterProject{
 				generateDummyGitStarterProject("project1", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{"origin": "originremote", "test": "testremote"}, attributes.Attributes{}),
 			},
-			wantErr: &oneRemoteErr,
+			wantErr: []string{oneRemoteErr},
 		},
 		{
 			name: "Invalid Starter Project with wrong checkout",
 			starterProjects: []v1alpha2.StarterProject{
 				generateDummyGitStarterProject("project1", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{"test": "testremote"}, attributes.Attributes{}),
 			},
-			wantErr: &wrongCheckoutErr,
+			wantErr: []string{wrongCheckoutErr},
 		},
 		{
 			name: "Valid Starter Project with empty checkout remote",
@@ -88,29 +88,32 @@ func TestValidateStarterProjects(t *testing.T) {
 			},
 		},
 		{
-			name: "Invalid Starter Project with empty remotes",
+			name: "Multiple errors: Starter Project with empty remotes, Starter Project with multiple remotes",
 			starterProjects: []v1alpha2.StarterProject{
 				generateDummyGitStarterProject("project1", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{}, attributes.Attributes{}),
 				generateDummyGitStarterProject("project3", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{"origin": "originremote", "test": "testremote"}, attributes.Attributes{}),
 			},
-			wantErr: &atleastOneRemoteErr,
+			wantErr: []string{atleastOneRemoteErr, oneRemoteErr},
 		},
 		{
 			name: "Invalid Starter Project due to wrong checkout with import source attributes",
 			starterProjects: []v1alpha2.StarterProject{
 				generateDummyGitStarterProject("project1", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{"test": "testremote"}, parentOverridesFromMainDevfile),
 			},
-			wantErr: &wrongCheckoutErrWithImportAttributes,
+			wantErr: []string{wrongCheckoutErrWithImportAttributes},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateStarterProjects(tt.starterProjects)
 
-			if tt.wantErr != nil && assert.Error(t, err) {
-				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
+			if tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
+				for i:= 0; i < len(err); i++ {
+					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+				}
 			} else {
-				assert.NoError(t, err, "Expected error to be nil")
+				assert.Equal(t, 0, len(err), "Error list should be empty")
 			}
 		})
 	}
@@ -129,7 +132,7 @@ func TestValidateProjects(t *testing.T) {
 	tests := []struct {
 		name     string
 		projects []v1alpha2.Project
-		wantErr  *string
+		wantErr  []string
 	}{
 		{
 			name: "Valid Project",
@@ -143,7 +146,7 @@ func TestValidateProjects(t *testing.T) {
 			projects: []v1alpha2.Project{
 				generateDummyGitProject("project2", nil, map[string]string{"origin": "originremote", "test": "testremote"}, attributes.Attributes{}),
 			},
-			wantErr: &missingCheckOutFromRemoteErr,
+			wantErr: []string{missingCheckOutFromRemoteErr},
 		},
 		{
 			name: "Invalid Project with multiple remote and empty checkout remote",
@@ -151,15 +154,14 @@ func TestValidateProjects(t *testing.T) {
 				generateDummyGitProject("project2", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{"origin": "originremote"}, attributes.Attributes{}),
 				generateDummyGitProject("project1", &v1alpha2.CheckoutFrom{Remote: ""}, map[string]string{"origin": "originremote", "test": "testremote"}, attributes.Attributes{}),
 			},
-			wantErr: &missingCheckOutFromRemoteErr,
+			wantErr: []string{missingCheckOutFromRemoteErr},
 		},
 		{
 			name: "Invalid Project with wrong checkout",
 			projects: []v1alpha2.Project{
 				generateDummyGitProject("project1", &v1alpha2.CheckoutFrom{Remote: "origin1"}, map[string]string{"origin": "originremote", "test": "testremote"}, attributes.Attributes{}),
-				generateDummyGitProject("project2", &v1alpha2.CheckoutFrom{Remote: "origin1"}, map[string]string{"origin2": "originremote2"}, attributes.Attributes{}),
 			},
-			wantErr: &wrongCheckoutErr,
+			wantErr: []string{wrongCheckoutErr},
 		},
 		{
 			name: "Valid Project with empty checkout remote",
@@ -168,29 +170,32 @@ func TestValidateProjects(t *testing.T) {
 			},
 		},
 		{
-			name: "Invalid Project with empty remotes",
+			name: "Multiple errors: invalid Project with empty remotes, invalid Project with wrong checkout",
 			projects: []v1alpha2.Project{
 				generateDummyGitProject("project1", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{}, attributes.Attributes{}),
 				generateDummyGitProject("project2", &v1alpha2.CheckoutFrom{Remote: "origins"}, map[string]string{"origin": "originremote", "test": "testremote"}, attributes.Attributes{}),
 			},
-			wantErr: &atleastOneRemoteErr,
+			wantErr: []string{atleastOneRemoteErr, wrongCheckoutErr},
 		},
 		{
 			name: "Invalid Project due to wrong checkout with import source attributes",
 			projects: []v1alpha2.Project{
 				generateDummyGitProject("project1", &v1alpha2.CheckoutFrom{Remote: "origin"}, map[string]string{"test": "testremote"}, parentOverridesFromMainDevfile),
 			},
-			wantErr: &wrongCheckoutErrWithImportAttributes,
+			wantErr: []string{wrongCheckoutErrWithImportAttributes},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateProjects(tt.projects)
 
-			if tt.wantErr != nil && assert.Error(t, err) {
-				assert.Regexp(t, *tt.wantErr, err.Error(), "Error message should match")
+			if tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
+				for i:= 0; i < len(err); i++ {
+					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+				}
 			} else {
-				assert.NoError(t, err, "Expected error to be nil")
+				assert.Equal(t, 0, len(err), "Error list should be empty")
 			}
 		})
 	}

--- a/pkg/validation/projects_test.go
+++ b/pkg/validation/projects_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/devfile/api/v2/pkg/attributes"
 
 	"github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
+	"github.com/hashicorp/go-multierror"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,13 +108,13 @@ func TestValidateStarterProjects(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateStarterProjects(tt.starterProjects)
 
-			if tt.wantErr != nil {
-				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i := 0; i < len(err); i++ {
-					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+			if merr, ok := err.(*multierror.Error); ok && tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match")
+				for i := 0; i < len(merr.Errors); i++ {
+					assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
 				}
 			} else {
-				assert.Equal(t, 0, len(err), "Error list should be empty")
+				assert.Equal(t, nil, err, "Error should be nil")
 			}
 		})
 	}
@@ -189,13 +190,13 @@ func TestValidateProjects(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateProjects(tt.projects)
 
-			if tt.wantErr != nil {
-				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i := 0; i < len(err); i++ {
-					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+			if merr, ok := err.(*multierror.Error); ok && tt.wantErr != nil {
+				assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match")
+				for i := 0; i < len(merr.Errors); i++ {
+					assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
 				}
 			} else {
-				assert.Equal(t, 0, len(err), "Error list should be empty")
+				assert.Equal(t, nil, err, "Error should be nil")
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR changes validator to use `multierror.append` to construct the returned error. 
This PR adds `MultipleDefaultCmdError` and `MisingDefaultCmdWarning` error types, to help identify the error. 
This PR updates the unit tests to test the new change

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
#577 

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
can run unit test in validation package
