### PR TITLE
fix command validator bug

### DIFF
--- a/pkg/validation/commands.go
+++ b/pkg/validation/commands.go
@@ -18,7 +18,7 @@ func ValidateCommands(commands []v1alpha2.Command, components []v1alpha2.Compone
 
 	err := v1alpha2.CheckDuplicateKeys(commands)
 	if err != nil {
-		multierror.Append(returnedErr, err)
+		returnedErr = multierror.Append(returnedErr, err)
 	}
 
 	for _, command := range commands {
@@ -26,7 +26,7 @@ func ValidateCommands(commands []v1alpha2.Command, components []v1alpha2.Compone
 		parentCommands := make(map[string]string)
 		err := validateCommand(command, parentCommands, commandMap, components)
 		if err != nil {
-			multierror.Append(returnedErr, resolveErrorMessageWithImportAttributes(err, command.Attributes))
+			returnedErr = multierror.Append(returnedErr, resolveErrorMessageWithImportAttributes(err, command.Attributes))
 		}
 
 		commandGroup := getGroup(command)
@@ -37,7 +37,7 @@ func ValidateCommands(commands []v1alpha2.Command, components []v1alpha2.Compone
 
 	for groupKind, commands := range groupKindCommandMap {
 		if err := validateGroup(commands, groupKind); err != nil {
-			multierror.Append(returnedErr, err)
+			returnedErr = multierror.Append(returnedErr, err)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
This PR fixes the command validator bug that `returnedErr` did not get assigned after appending. 

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
#577 

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
