### PR TITLE
New Project/StarterProject Error Types

### DIFF
--- a/pkg/validation/errors.go
+++ b/pkg/validation/errors.go
@@ -111,6 +111,52 @@ func (e *InvalidComponentError) Error() string {
 	return fmt.Sprintf("the component %q is invalid - %s", e.componentName, e.reason)
 }
 
+//MissingProjectRemoteError returns an error if the git remotes object under a project is empty
+type MissingProjectRemoteError struct {
+	projectName string
+}
+
+func (e *MissingProjectRemoteError) Error() string {
+	return fmt.Sprintf("project %s should have at least one remote", e.projectName)
+}
+
+//MissingStarterProjectRemoteError returns an error if the git remotes object under a starterProject is empty
+type MissingStarterProjectRemoteError struct {
+	projectName string
+}
+
+func (e *MissingStarterProjectRemoteError) Error() string {
+	return fmt.Sprintf("starterProject %s should have at least one remote", e.projectName)
+}
+
+//MultipleStarterProjectRemoteError returns an error if multiple git remotes are specified. There can only be one remote.
+type MultipleStarterProjectRemoteError struct {
+	projectName string
+}
+
+func (e *MultipleStarterProjectRemoteError) Error() string {
+	return fmt.Sprintf("starterProject %s should have one remote only", e.projectName)
+}
+
+//MissingProjectCheckoutFromRemoteError returns an error if there are multiple git remotes but the checkoutFrom remote has not been specified
+type MissingProjectCheckoutFromRemoteError struct {
+	projectName string
+}
+
+func (e *MissingProjectCheckoutFromRemoteError) Error() string {
+	return fmt.Sprintf("project %s has more than one remote defined, but has no checkoutfrom remote defined", e.projectName)
+}
+
+//InvalidProjectCheckoutRemoteError returns an error if there is an unmatched, checkoutFrom remote specified
+type InvalidProjectCheckoutRemoteError struct {
+	projectName    string
+	checkoutRemote string
+}
+
+func (e *InvalidProjectCheckoutRemoteError) Error() string {
+	return fmt.Sprintf("unable to find the checkout remote %s in the remotes for project %s", e.checkoutRemote, e.projectName)
+}
+
 // resolveErrorMessageWithImportAttributes returns an updated error message
 // with detailed information on the imported and overriden resource.
 // example:

--- a/pkg/validation/projects_test.go
+++ b/pkg/validation/projects_test.go
@@ -123,7 +123,7 @@ func TestValidateStarterProjects(t *testing.T) {
 func TestValidateProjects(t *testing.T) {
 
 	wrongCheckoutErr := "unable to find the checkout remote .* in the remotes for project.*"
-	atleastOneRemoteErr := "projects .* should have at least one remote"
+	atleastOneRemoteErr := "project .* should have at least one remote"
 	missingCheckOutFromRemoteErr := "project .* has more than one remote defined, but has no checkoutfrom remote defined"
 
 	parentOverridesFromMainDevfile := attributes.Attributes{}.PutString(ImportSourceAttribute,


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->
Adds new error types for project and starter project validations

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
https://github.com/devfile/api/issues/598

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

Local tests for now, as updates are being made in the library package.  Verified the new types are being returned instead of strings:

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/84398375/132721362-ab1b793e-a4e6-4e92-b6c5-dbe4dfe8be38.png">


- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->
N/A
- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->
N/A
- [ ] Client Impact
  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->
N/A

### How to test changes / Special notes to the reviewer:
