### PR TITLE
Make release docs easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The generated documentation of the Devfile 2.0 format, based on its json schema,
 
 Typescript model is build on each commit of main branch and available as NPM package at https://www.npmjs.com/package/@devfile/api
 
+## Release
+Release details and process are found in [Devfile Release](RELEASE.md)
+
 ## How to build
 
 In order to build the CRD and the various schemas, you don't need to install any pre-requisite apart from `docker`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+## Devfile Release
+
+Our current process is documented in 
+[Devfile Versioning and Release Process](docs/proposals/versioning-and-release.md).  

--- a/docs/proposals/versioning-and-release.md
+++ b/docs/proposals/versioning-and-release.md
@@ -1,7 +1,8 @@
 # Devfile Versioning and Release Process
-This design document outlines the proposed versioning and release process for the Devfile spec. 
+This document outlines the versioning and release process for the Devfile spec.
 
-This document summarizes parts from the Devfile API technical meeting slides presented by @davidfestal back in October, and I recommend having a read through of it: https://docs.google.com/presentation/d/1ohM1HzPB59a3ajvB7rVWJkKONLBAuT0mb5P20_A6vLs/edit#slide=id.g8fc722bef9_1_8
+##Reference  
+This process summarizes parts from the Devfile API technical meeting slides presented by @davidfestal back in October, and I recommend having a read through of it: https://docs.google.com/presentation/d/1ohM1HzPB59a3ajvB7rVWJkKONLBAuT0mb5P20_A6vLs/edit#slide=id.g8fc722bef9_1_8
 
 ## Versioning
 


### PR DESCRIPTION
### What does this PR do?:
<!-- _Summarize the changes_ -->

Introduces a new release page that references the official process that is under `docs/proposals` so it's easier to locate

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
https://github.com/devfile/api/issues/618

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->
N/A

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->
N/A

- [ X] Documentation 

   <!-- _This includes product docs and READMEs._ -->
doc only changes

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->
N/A

### How to test changes / Special notes to the reviewer:
