### PR TITLE
Remove Serhii Leshchenko as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @sleshchenko @amisevsk @davidfestal
+* @amisevsk @davidfestal


### PR DESCRIPTION
### What does this PR do?:
Removes @sleshchenko as codeowner, as he no longer works on this project.
