### PR TITLE
add version property in import reference

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -5871,6 +5871,14 @@ spec:
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
                               type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. If no `version` specified,
+                                default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                              type: string
                           type: object
                         volume:
                           description: Allows specifying the definition of a volume
@@ -7636,6 +7644,15 @@ spec:
                                     file. It can be a full URL or a relative URI with
                                     the current devfile as the base URI.
                                   type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    If no `version` specified, default version will
+                                    be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
                               type: object
                             volume:
                               description: Allows specifying the definition of a volume
@@ -7847,6 +7864,14 @@ spec:
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
                         type: object
+                      version:
+                        description: Specific stack/sample version to pull the parent
+                          devfile from, when using id in the parent reference. To
+                          specify `version`, `id` must be defined and used as the
+                          import reference source. If no `version` specified, default
+                          version will be used.
+                        pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                        type: string
                     type: object
                   projects:
                     description: Projects worked on in the devworkspace, containing

--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -5875,8 +5875,9 @@ spec:
                               description: Specific stack/sample version to pull the
                                 parent devfile from, when using id in the parent reference.
                                 To specify `version`, `id` must be defined and used
-                                as the import reference source. If no `version` specified,
-                                default version will be used.
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
                               pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
@@ -7649,8 +7650,9 @@ spec:
                                     the parent devfile from, when using id in the
                                     parent reference. To specify `version`, `id` must
                                     be defined and used as the import reference source.
-                                    If no `version` specified, default version will
-                                    be used.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
                                   pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                                   type: string
                               type: object
@@ -7868,7 +7870,8 @@ spec:
                         description: Specific stack/sample version to pull the parent
                           devfile from, when using id in the parent reference. To
                           specify `version`, `id` must be defined and used as the
-                          import reference source. If no `version` specified, default
+                          import reference source. `version` can be either a specific
+                          stack version, or `latest`. If no `version` specified, default
                           version will be used.
                         pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                         type: string

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -5880,8 +5880,9 @@ spec:
                               description: Specific stack/sample version to pull the
                                 parent devfile from, when using id in the parent reference.
                                 To specify `version`, `id` must be defined and used
-                                as the import reference source. If no `version` specified,
-                                default version will be used.
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
                               pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
@@ -7654,8 +7655,9 @@ spec:
                                     the parent devfile from, when using id in the
                                     parent reference. To specify `version`, `id` must
                                     be defined and used as the import reference source.
-                                    If no `version` specified, default version will
-                                    be used.
+                                    `version` can be either a specific stack version,
+                                    or `latest`. If no `version` specified, default
+                                    version will be used.
                                   pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                                   type: string
                               type: object
@@ -7873,7 +7875,8 @@ spec:
                         description: Specific stack/sample version to pull the parent
                           devfile from, when using id in the parent reference. To
                           specify `version`, `id` must be defined and used as the
-                          import reference source. If no `version` specified, default
+                          import reference source. `version` can be either a specific
+                          stack version, or `latest`. If no `version` specified, default
                           version will be used.
                         pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                         type: string

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -5876,6 +5876,14 @@ spec:
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
                               type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. If no `version` specified,
+                                default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                              type: string
                           type: object
                         volume:
                           description: Allows specifying the definition of a volume
@@ -7641,6 +7649,15 @@ spec:
                                     file. It can be a full URL or a relative URI with
                                     the current devfile as the base URI.
                                   type: string
+                                version:
+                                  description: Specific stack/sample version to pull
+                                    the parent devfile from, when using id in the
+                                    parent reference. To specify `version`, `id` must
+                                    be defined and used as the import reference source.
+                                    If no `version` specified, default version will
+                                    be used.
+                                  pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                                  type: string
                               type: object
                             volume:
                               description: Allows specifying the definition of a volume
@@ -7852,6 +7869,14 @@ spec:
                           devfile. Overriding is done according to K8S strategic merge
                           patch standard rules.
                         type: object
+                      version:
+                        description: Specific stack/sample version to pull the parent
+                          devfile from, when using id in the parent reference. To
+                          specify `version`, `id` must be defined and used as the
+                          import reference source. If no `version` specified, default
+                          version will be used.
+                        pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                        type: string
                     type: object
                   projects:
                     description: Projects worked on in the devworkspace, containing

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -5579,6 +5579,14 @@ spec:
                             It can be a full URL or a relative URI with the current
                             devfile as the base URI.
                           type: string
+                        version:
+                          description: Specific stack/sample version to pull the parent
+                            devfile from, when using id in the parent reference. To
+                            specify `version`, `id` must be defined and used as the
+                            import reference source. If no `version` specified, default
+                            version will be used.
+                          pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                          type: string
                       type: object
                     volume:
                       description: Allows specifying the definition of a volume shared
@@ -7280,6 +7288,14 @@ spec:
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
                               type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. If no `version` specified,
+                                default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                              type: string
                           type: object
                         volume:
                           description: Allows specifying the definition of a volume
@@ -7486,6 +7502,13 @@ spec:
                       Overriding is done according to K8S strategic merge patch standard
                       rules.
                     type: object
+                  version:
+                    description: Specific stack/sample version to pull the parent
+                      devfile from, when using id in the parent reference. To specify
+                      `version`, `id` must be defined and used as the import reference
+                      source. If no `version` specified, default version will be used.
+                    pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                    type: string
                 type: object
               projects:
                 description: Projects worked on in the devworkspace, containing names

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -5583,8 +5583,9 @@ spec:
                           description: Specific stack/sample version to pull the parent
                             devfile from, when using id in the parent reference. To
                             specify `version`, `id` must be defined and used as the
-                            import reference source. If no `version` specified, default
-                            version will be used.
+                            import reference source. `version` can be either a specific
+                            stack version, or `latest`. If no `version` specified,
+                            default version will be used.
                           pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                           type: string
                       type: object
@@ -7292,8 +7293,9 @@ spec:
                               description: Specific stack/sample version to pull the
                                 parent devfile from, when using id in the parent reference.
                                 To specify `version`, `id` must be defined and used
-                                as the import reference source. If no `version` specified,
-                                default version will be used.
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
                               pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
@@ -7506,7 +7508,9 @@ spec:
                     description: Specific stack/sample version to pull the parent
                       devfile from, when using id in the parent reference. To specify
                       `version`, `id` must be defined and used as the import reference
-                      source. If no `version` specified, default version will be used.
+                      source. `version` can be either a specific stack version, or
+                      `latest`. If no `version` specified, default version will be
+                      used.
                     pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                     type: string
                 type: object

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -5588,8 +5588,9 @@ spec:
                           description: Specific stack/sample version to pull the parent
                             devfile from, when using id in the parent reference. To
                             specify `version`, `id` must be defined and used as the
-                            import reference source. If no `version` specified, default
-                            version will be used.
+                            import reference source. `version` can be either a specific
+                            stack version, or `latest`. If no `version` specified,
+                            default version will be used.
                           pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                           type: string
                       type: object
@@ -7297,8 +7298,9 @@ spec:
                               description: Specific stack/sample version to pull the
                                 parent devfile from, when using id in the parent reference.
                                 To specify `version`, `id` must be defined and used
-                                as the import reference source. If no `version` specified,
-                                default version will be used.
+                                as the import reference source. `version` can be either
+                                a specific stack version, or `latest`. If no `version`
+                                specified, default version will be used.
                               pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                               type: string
                           type: object
@@ -7511,7 +7513,9 @@ spec:
                     description: Specific stack/sample version to pull the parent
                       devfile from, when using id in the parent reference. To specify
                       `version`, `id` must be defined and used as the import reference
-                      source. If no `version` specified, default version will be used.
+                      source. `version` can be either a specific stack version, or
+                      `latest`. If no `version` specified, default version will be
+                      used.
                     pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
                     type: string
                 type: object

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -5584,6 +5584,14 @@ spec:
                             It can be a full URL or a relative URI with the current
                             devfile as the base URI.
                           type: string
+                        version:
+                          description: Specific stack/sample version to pull the parent
+                            devfile from, when using id in the parent reference. To
+                            specify `version`, `id` must be defined and used as the
+                            import reference source. If no `version` specified, default
+                            version will be used.
+                          pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                          type: string
                       type: object
                     volume:
                       description: Allows specifying the definition of a volume shared
@@ -7285,6 +7293,14 @@ spec:
                                 file. It can be a full URL or a relative URI with
                                 the current devfile as the base URI.
                               type: string
+                            version:
+                              description: Specific stack/sample version to pull the
+                                parent devfile from, when using id in the parent reference.
+                                To specify `version`, `id` must be defined and used
+                                as the import reference source. If no `version` specified,
+                                default version will be used.
+                              pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                              type: string
                           type: object
                         volume:
                           description: Allows specifying the definition of a volume
@@ -7491,6 +7507,13 @@ spec:
                       Overriding is done according to K8S strategic merge patch standard
                       rules.
                     type: object
+                  version:
+                    description: Specific stack/sample version to pull the parent
+                      devfile from, when using id in the parent reference. To specify
+                      `version`, `id` must be defined and used as the import reference
+                      source. If no `version` specified, default version will be used.
+                    pattern: ^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+                    type: string
                 type: object
               projects:
                 description: Projects worked on in the devworkspace, containing names

--- a/pkg/apis/workspaces/v1alpha2/import_reference.go
+++ b/pkg/apis/workspaces/v1alpha2/import_reference.go
@@ -50,4 +50,11 @@ type ImportReference struct {
 	// it is recommended to always specify the `registryUrl` when `id` is used.
 	// +optional
 	RegistryUrl string `json:"registryUrl,omitempty"`
+
+	// Specific stack/sample version to pull the parent devfile from, when using id in the parent reference.
+	// To specify `version`, `id` must be defined and used as the import reference source.
+	// If no `version` specified, default version will be used.
+	// +optional
+	// +kubebuilder:validation:Pattern=^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+	Version string `json:"version,omitempty"`
 }

--- a/pkg/apis/workspaces/v1alpha2/import_reference.go
+++ b/pkg/apis/workspaces/v1alpha2/import_reference.go
@@ -53,6 +53,7 @@ type ImportReference struct {
 
 	// Specific stack/sample version to pull the parent devfile from, when using id in the parent reference.
 	// To specify `version`, `id` must be defined and used as the import reference source.
+	// `version` can be either a specific stack version, or `latest`.
 	// If no `version` specified, default version will be used.
 	// +optional
 	// +kubebuilder:validation:Pattern=^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -552,6 +552,13 @@ type ImportReferenceParentOverride struct {
 	// it is recommended to always specify the `registryUrl` when `id` is used.
 	// +optional
 	RegistryUrl string `json:"registryUrl,omitempty"`
+
+	// Specific stack/sample version to pull the parent devfile from, when using id in the parent reference.
+	// To specify `version`, `id` must be defined and used as the import reference source.
+	// If no `version` specified, default version will be used.
+	// +optional
+	// +kubebuilder:validation:Pattern=^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$
+	Version string `json:"version,omitempty"`
 }
 
 type PluginOverridesParentOverride struct {

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -555,6 +555,7 @@ type ImportReferenceParentOverride struct {
 
 	// Specific stack/sample version to pull the parent devfile from, when using id in the parent reference.
 	// To specify `version`, `id` must be defined and used as the import reference source.
+	// `version` can be either a specific stack version, or `latest`.
 	// If no `version` specified, default version will be used.
 	// +optional
 	// +kubebuilder:validation:Pattern=^(latest)|(([1-9])\.([0-9]+)\.([0-9]+)(\-[0-9a-z-]+(\.[0-9a-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)$

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -1626,7 +1626,7 @@
                 "type": "string"
               },
               "version": {
-                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                 "type": "string",
                 "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
               }
@@ -3214,7 +3214,7 @@
                     "type": "string"
                   },
                   "version": {
-                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                     "type": "string",
                     "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                   }
@@ -3440,7 +3440,7 @@
           }
         },
         "version": {
-          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
           "type": "string",
           "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
         }

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -1624,6 +1624,11 @@
               "uri": {
                 "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                 "type": "string"
+              },
+              "version": {
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "type": "string",
+                "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
               }
             },
             "additionalProperties": false
@@ -3207,6 +3212,11 @@
                   "uri": {
                     "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                     "type": "string"
+                  },
+                  "version": {
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "type": "string",
+                    "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                   }
                 },
                 "additionalProperties": false
@@ -3428,6 +3438,11 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "version": {
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "type": "string",
+          "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
         }
       },
       "additionalProperties": false

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -1792,7 +1792,7 @@
                     "type": "string"
                   },
                   "version": {
-                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                     "type": "string",
                     "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                   }
@@ -3380,7 +3380,7 @@
                         "type": "string"
                       },
                       "version": {
-                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                         "type": "string",
                         "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                       }
@@ -3606,7 +3606,7 @@
               }
             },
             "version": {
-              "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+              "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
               "type": "string",
               "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
             }

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -1790,6 +1790,11 @@
                   "uri": {
                     "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                     "type": "string"
+                  },
+                  "version": {
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "type": "string",
+                    "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                   }
                 },
                 "additionalProperties": false
@@ -3373,6 +3378,11 @@
                       "uri": {
                         "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                         "type": "string"
+                      },
+                      "version": {
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "type": "string",
+                        "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                       }
                     },
                     "additionalProperties": false
@@ -3594,6 +3604,11 @@
               "additionalProperties": {
                 "type": "string"
               }
+            },
+            "version": {
+              "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+              "type": "string",
+              "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
             }
           },
           "additionalProperties": false

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -1805,7 +1805,7 @@
                         "type": "string"
                       },
                       "version": {
-                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                         "type": "string",
                         "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                       }
@@ -3393,7 +3393,7 @@
                             "type": "string"
                           },
                           "version": {
-                            "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                            "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                             "type": "string",
                             "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                           }
@@ -3619,7 +3619,7 @@
                   }
                 },
                 "version": {
-                  "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                  "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                   "type": "string",
                   "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                 }

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -1803,6 +1803,11 @@
                       "uri": {
                         "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                         "type": "string"
+                      },
+                      "version": {
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "type": "string",
+                        "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                       }
                     },
                     "additionalProperties": false
@@ -3386,6 +3391,11 @@
                           "uri": {
                             "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                             "type": "string"
+                          },
+                          "version": {
+                            "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                            "type": "string",
+                            "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                           }
                         },
                         "additionalProperties": false
@@ -3607,6 +3617,11 @@
                   "additionalProperties": {
                     "type": "string"
                   }
+                },
+                "version": {
+                  "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                  "type": "string",
+                  "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
                 }
               },
               "additionalProperties": false

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -1854,7 +1854,7 @@
           }
         },
         "version": {
-          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
           "type": "string",
           "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
         }

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -1852,6 +1852,11 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "version": {
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "type": "string",
+          "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
         }
       },
       "additionalProperties": false

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -1814,10 +1814,10 @@
                 "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
               },
               "version": {
-                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                 "type": "string",
                 "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
               }
             },
             "additionalProperties": false,
@@ -3598,10 +3598,10 @@
                     "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
                   },
                   "version": {
-                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                     "type": "string",
                     "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                    "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                    "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
                   }
                 },
                 "additionalProperties": false,
@@ -3858,10 +3858,10 @@
           "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
         },
         "version": {
-          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
           "type": "string",
           "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-          "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+          "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
         }
       },
       "additionalProperties": false,

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -1812,6 +1812,12 @@
                 "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                 "type": "string",
                 "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
+              },
+              "version": {
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "type": "string",
+                "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
               }
             },
             "additionalProperties": false,
@@ -3590,6 +3596,12 @@
                     "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                     "type": "string",
                     "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
+                  },
+                  "version": {
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "type": "string",
+                    "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                    "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
                   }
                 },
                 "additionalProperties": false,
@@ -3844,6 +3856,12 @@
             "type": "string"
           },
           "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
+        },
+        "version": {
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "type": "string",
+          "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+          "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
         }
       },
       "additionalProperties": false,

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -2011,6 +2011,12 @@
                     "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                     "type": "string",
                     "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
+                  },
+                  "version": {
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "type": "string",
+                    "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                    "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
                   }
                 },
                 "additionalProperties": false,
@@ -3789,6 +3795,12 @@
                         "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                         "type": "string",
                         "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
+                      },
+                      "version": {
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "type": "string",
+                        "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                        "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
                       }
                     },
                     "additionalProperties": false,
@@ -4043,6 +4055,12 @@
                 "type": "string"
               },
               "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
+            },
+            "version": {
+              "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+              "type": "string",
+              "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+              "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
             }
           },
           "additionalProperties": false,

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -2013,10 +2013,10 @@
                     "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
                   },
                   "version": {
-                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                    "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                     "type": "string",
                     "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                    "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                    "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
                   }
                 },
                 "additionalProperties": false,
@@ -3797,10 +3797,10 @@
                         "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
                       },
                       "version": {
-                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                         "type": "string",
                         "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                        "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                        "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
                       }
                     },
                     "additionalProperties": false,
@@ -4057,10 +4057,10 @@
               "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
             },
             "version": {
-              "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+              "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
               "type": "string",
               "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-              "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+              "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
             }
           },
           "additionalProperties": false,

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -2026,10 +2026,10 @@
                         "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
                       },
                       "version": {
-                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                         "type": "string",
                         "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                        "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                        "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
                       }
                     },
                     "additionalProperties": false,
@@ -3810,10 +3810,10 @@
                             "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
                           },
                           "version": {
-                            "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                            "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                             "type": "string",
                             "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                            "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                            "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
                           }
                         },
                         "additionalProperties": false,
@@ -4070,10 +4070,10 @@
                   "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
                 },
                 "version": {
-                  "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                  "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                   "type": "string",
                   "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                  "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                  "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
                 }
               },
               "additionalProperties": false,

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -2024,6 +2024,12 @@
                         "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                         "type": "string",
                         "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
+                      },
+                      "version": {
+                        "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                        "type": "string",
+                        "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                        "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
                       }
                     },
                     "additionalProperties": false,
@@ -3802,6 +3808,12 @@
                             "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                             "type": "string",
                             "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
+                          },
+                          "version": {
+                            "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                            "type": "string",
+                            "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                            "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
                           }
                         },
                         "additionalProperties": false,
@@ -4056,6 +4068,12 @@
                     "type": "string"
                   },
                   "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
+                },
+                "version": {
+                  "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                  "type": "string",
+                  "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                  "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
                 }
               },
               "additionalProperties": false,

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -2082,10 +2082,10 @@
           "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
         },
         "version": {
-          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
           "type": "string",
           "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-          "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+          "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
         }
       },
       "additionalProperties": false,

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -2080,6 +2080,12 @@
             "type": "string"
           },
           "markdownDescription": "Overrides of variables encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules."
+        },
+        "version": {
+          "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+          "type": "string",
+          "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+          "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
         }
       },
       "additionalProperties": false,

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -1694,10 +1694,10 @@
                 "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
               },
               "version": {
-                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                 "type": "string",
                 "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
-                "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
+                "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used."
               }
             },
             "additionalProperties": false,

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -1692,6 +1692,12 @@
                 "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                 "type": "string",
                 "markdownDescription": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI."
+              },
+              "version": {
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "type": "string",
+                "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$",
+                "markdownDescription": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used."
               }
             },
             "additionalProperties": false,

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -1508,7 +1508,7 @@
                 "type": "string"
               },
               "version": {
-                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. `version` can be either a specific stack version, or `latest`. If no `version` specified, default version will be used.",
                 "type": "string",
                 "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
               }

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -1506,6 +1506,11 @@
               "uri": {
                 "description": "URI Reference of a parent devfile YAML file. It can be a full URL or a relative URI with the current devfile as the base URI.",
                 "type": "string"
+              },
+              "version": {
+                "description": "Specific stack/sample version to pull the parent devfile from, when using id in the parent reference. To specify `version`, `id` must be defined and used as the import reference source. If no `version` specified, default version will be used.",
+                "type": "string",
+                "pattern": "^(latest)|(([1-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?)$"
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
Signed-off-by: Stephanie <yangcao@redhat.com>

### What does this PR do?:
<!-- _Summarize the changes_ -->
this pr adds version property to import reference to pull specific version of a stack/sample. 
only `latest` or `x.x.x` or `x.x.x-<concrete version>` 

### Which issue(s) this PR fixes:
<!-- _Link to github issue(s)_ -->
Fixes #764 

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
