### PR TITLE
Set served: true for v1alpha1 DevWorkspaces and DevWorkspaceTemplates

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -4098,7 +4098,7 @@ spec:
             - workspaceId
             type: object
         type: object
-    served: false
+    served: true
     storage: false
   - additionalPrinterColumns:
     - JSONPath: .status.devworkspaceId

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -4094,7 +4094,7 @@ spec:
             - workspaceId
             type: object
         type: object
-    served: false
+    served: true
     storage: false
     subresources:
       status: {}

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -3891,7 +3891,7 @@ spec:
                 type: array
             type: object
         type: object
-    served: false
+    served: true
     storage: false
   - name: v1alpha2
     schema:

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -3889,7 +3889,7 @@ spec:
                 type: array
             type: object
         type: object
-    served: false
+    served: true
     storage: false
   - name: v1alpha2
     schema:

--- a/pkg/apis/workspaces/v1alpha1/devworkspace_types.go
+++ b/pkg/apis/workspaces/v1alpha1/devworkspace_types.go
@@ -77,7 +77,6 @@ const (
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="The current workspace startup phase"
 // +kubebuilder:printcolumn:name="URL",type="string",JSONPath=".status.ideUrl",description="Url endpoint for accessing workspace"
 // +kubebuilder:deprecatedversion
-// +kubebuilder:unservedversion
 type DevWorkspace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/workspaces/v1alpha1/devworkspacetemplate_types.go
+++ b/pkg/apis/workspaces/v1alpha1/devworkspacetemplate_types.go
@@ -10,7 +10,6 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=devworkspacetemplates,scope=Namespaced,shortName=dwt
 // +kubebuilder:deprecatedversion
-// +kubebuilder:unservedversion
 type DevWorkspaceTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
### What does this PR do?:
Fixes a minor oversight in https://github.com/devfile/api/pull/738, which accidentally left v1alpha1 DevWorkspaces and DevWorkspaceTemplates as `served: false`. For the same reasons that the v1alpha1 API version needed to be returned, it also needs to be served -- otherwise OpenShift Console will fail to create Web Terminals.

### Which issue(s) this PR fixes:
Related: https://github.com/devfile/api/issues/721

### PR acceptance criteria:
- [ ] Unit/Functional tests
- [x] [QE Integration test](https://github.com/devfile/integration-tests) - N/A
- [x] Documentation - N/A
- [x] Client Impact - N/A

### How to test changes / Special notes to the reviewer:
After changes, it should be possible to do e.g. `oc get devworkspaces.v1alpha1.workspace.devfile.io` with the updated CRDs applied to the cluster.