### PR TITLE
Allow endpoints with the same targetPort if they are on the same container component

### DIFF
--- a/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.v1beta1.yaml
@@ -4544,7 +4544,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -4844,7 +4846,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -4964,7 +4968,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -5362,8 +5368,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -5665,8 +5673,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -5799,8 +5809,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -6298,7 +6310,9 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
-                                        description: The port number should be unique.
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
                                         type: integer
                                     required:
                                     - name
@@ -6580,7 +6594,9 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
-                                        description: The port number should be unique.
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
                                         type: integer
                                     required:
                                     - name
@@ -6702,7 +6718,9 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
-                                        description: The port number should be unique.
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
                                         type: integer
                                     required:
                                     - name
@@ -7115,8 +7133,10 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
-                                                  description: The port number should
-                                                    be unique.
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
                                                   type: integer
                                               required:
                                               - name
@@ -7432,8 +7452,10 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
-                                                  description: The port number should
-                                                    be unique.
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
                                                   type: integer
                                               required:
                                               - name
@@ -7573,8 +7595,10 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
-                                                  description: The port number should
-                                                    be unique.
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
                                                   type: integer
                                               required:
                                               - name

--- a/crds/workspace.devfile.io_devworkspaces.yaml
+++ b/crds/workspace.devfile.io_devworkspaces.yaml
@@ -4544,7 +4544,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -4847,7 +4849,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -4969,7 +4973,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -5367,8 +5373,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -5670,8 +5678,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -5804,8 +5814,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -6303,7 +6315,9 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
-                                        description: The port number should be unique.
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
                                         type: integer
                                     required:
                                     - name
@@ -6585,7 +6599,9 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
-                                        description: The port number should be unique.
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
                                         type: integer
                                     required:
                                     - name
@@ -6707,7 +6723,9 @@ spec:
                                           protocol of `https` or `wss`.
                                         type: boolean
                                       targetPort:
-                                        description: The port number should be unique.
+                                        description: Port number to be used within
+                                          the container component. The same port cannot
+                                          be used by two different container components.
                                         type: integer
                                     required:
                                     - name
@@ -7120,8 +7138,10 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
-                                                  description: The port number should
-                                                    be unique.
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
                                                   type: integer
                                               required:
                                               - name
@@ -7437,8 +7457,10 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
-                                                  description: The port number should
-                                                    be unique.
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
                                                   type: integer
                                               required:
                                               - name
@@ -7578,8 +7600,10 @@ spec:
                                                     of `https` or `wss`.
                                                   type: boolean
                                                 targetPort:
-                                                  description: The port number should
-                                                    be unique.
+                                                  description: Port number to be used
+                                                    within the container component.
+                                                    The same port cannot be used by
+                                                    two different container components.
                                                   type: integer
                                               required:
                                               - name

--- a/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.v1beta1.yaml
@@ -4302,7 +4302,9 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
-                                description: The port number should be unique.
+                                description: Port number to be used within the container
+                                  component. The same port cannot be used by two different
+                                  container components.
                                 type: integer
                             required:
                             - name
@@ -4596,7 +4598,9 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
-                                description: The port number should be unique.
+                                description: Port number to be used within the container
+                                  component. The same port cannot be used by two different
+                                  container components.
                                 type: integer
                             required:
                             - name
@@ -4712,7 +4716,9 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
-                                description: The port number should be unique.
+                                description: Port number to be used within the container
+                                  component. The same port cannot be used by two different
+                                  container components.
                                 type: integer
                             required:
                             - name
@@ -5097,7 +5103,10 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
-                                          description: The port number should be unique.
+                                          description: Port number to be used within
+                                            the container component. The same port
+                                            cannot be used by two different container
+                                            components.
                                           type: integer
                                       required:
                                       - name
@@ -5384,7 +5393,10 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
-                                          description: The port number should be unique.
+                                          description: Port number to be used within
+                                            the container component. The same port
+                                            cannot be used by two different container
+                                            components.
                                           type: integer
                                       required:
                                       - name
@@ -5509,7 +5521,10 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
-                                          description: The port number should be unique.
+                                          description: Port number to be used within
+                                            the container component. The same port
+                                            cannot be used by two different container
+                                            components.
                                           type: integer
                                       required:
                                       - name
@@ -5994,7 +6009,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -6266,7 +6283,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -6385,7 +6404,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -6782,8 +6803,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -7085,8 +7108,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -7219,8 +7244,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name

--- a/crds/workspace.devfile.io_devworkspacetemplates.yaml
+++ b/crds/workspace.devfile.io_devworkspacetemplates.yaml
@@ -4302,7 +4302,9 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
-                                description: The port number should be unique.
+                                description: Port number to be used within the container
+                                  component. The same port cannot be used by two different
+                                  container components.
                                 type: integer
                             required:
                             - name
@@ -4599,7 +4601,9 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
-                                description: The port number should be unique.
+                                description: Port number to be used within the container
+                                  component. The same port cannot be used by two different
+                                  container components.
                                 type: integer
                             required:
                             - name
@@ -4717,7 +4721,9 @@ spec:
                                   `wss`.
                                 type: boolean
                               targetPort:
-                                description: The port number should be unique.
+                                description: Port number to be used within the container
+                                  component. The same port cannot be used by two different
+                                  container components.
                                 type: integer
                             required:
                             - name
@@ -5102,7 +5108,10 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
-                                          description: The port number should be unique.
+                                          description: Port number to be used within
+                                            the container component. The same port
+                                            cannot be used by two different container
+                                            components.
                                           type: integer
                                       required:
                                       - name
@@ -5389,7 +5398,10 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
-                                          description: The port number should be unique.
+                                          description: Port number to be used within
+                                            the container component. The same port
+                                            cannot be used by two different container
+                                            components.
                                           type: integer
                                       required:
                                       - name
@@ -5514,7 +5526,10 @@ spec:
                                             a protocol of `https` or `wss`.
                                           type: boolean
                                         targetPort:
-                                          description: The port number should be unique.
+                                          description: Port number to be used within
+                                            the container component. The same port
+                                            cannot be used by two different container
+                                            components.
                                           type: integer
                                       required:
                                       - name
@@ -5999,7 +6014,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -6271,7 +6288,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -6390,7 +6409,9 @@ spec:
                                       or `wss`.
                                     type: boolean
                                   targetPort:
-                                    description: The port number should be unique.
+                                    description: Port number to be used within the
+                                      container component. The same port cannot be
+                                      used by two different container components.
                                     type: integer
                                 required:
                                 - name
@@ -6787,8 +6808,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -7090,8 +7113,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name
@@ -7224,8 +7249,10 @@ spec:
                                                 `wss`.
                                               type: boolean
                                             targetPort:
-                                              description: The port number should
-                                                be unique.
+                                              description: Port number to be used
+                                                within the container component. The
+                                                same port cannot be used by two different
+                                                container components.
                                               type: integer
                                           required:
                                           - name

--- a/pkg/apis/workspaces/v1alpha2/endpoint.go
+++ b/pkg/apis/workspaces/v1alpha2/endpoint.go
@@ -50,7 +50,8 @@ type Endpoint struct {
 	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
-	// The port number should be unique.
+	// Port number to be used within the container component. The same port cannot
+	// be used by two different container components.
 	TargetPort int `json:"targetPort"`
 
 	// Describes how the endpoint should be exposed on the network.

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -444,7 +444,8 @@ type EndpointParentOverride struct {
 	Name string `json:"name"`
 
 	//  +optional
-	// The port number should be unique.
+	// Port number to be used within the container component. The same port cannot
+	// be used by two different container components.
 	TargetPort int `json:"targetPort,omitempty"`
 
 	// Describes how the endpoint should be exposed on the network.
@@ -1148,7 +1149,8 @@ type EndpointPluginOverrideParentOverride struct {
 	Name string `json:"name"`
 
 	//  +optional
-	// The port number should be unique.
+	// Port number to be used within the container component. The same port cannot
+	// be used by two different container components.
 	TargetPort int `json:"targetPort,omitempty"`
 
 	// Describes how the endpoint should be exposed on the network.

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -314,7 +314,8 @@ type EndpointPluginOverride struct {
 	Name string `json:"name"`
 
 	//  +optional
-	// The port number should be unique.
+	// Port number to be used within the container component. The same port cannot
+	// be used by two different container components.
 	TargetPort int `json:"targetPort,omitempty"`
 
 	// Describes how the endpoint should be exposed on the network.

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -244,7 +244,7 @@ func TestValidateComponents(t *testing.T) {
 	reservedEnvErr := "env variable .* is reserved and cannot be customized in component.*"
 	invalidSizeErr := "size .* for volume component is invalid"
 	sameEndpointNameErr := "devfile contains multiple endpoint entries with same name.*"
-	sameTargetPortErr := "devfile contains multiple endpoint entries with same TargetPort.*"
+	sameTargetPortErr := "devfile contains multiple containers with same endpoint targetPort.*"
 	invalidURIErr := ".*invalid URI for request"
 	imageCompTwoRemoteErr := "component .* should have one remote only"
 	imageCompNoRemoteErr := "component .* should have at least one remote"
@@ -533,9 +533,10 @@ func TestValidateComponents(t *testing.T) {
 			err := ValidateComponents(tt.components)
 
 			if merr, ok := err.(*multierror.Error); ok && tt.wantErr != nil {
-				assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match")
-				for i := 0; i < len(merr.Errors); i++ {
-					assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
+				if assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match") {
+					for i := 0; i < len(merr.Errors); i++ {
+						assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
+					}
 				}
 			} else {
 				assert.Equal(t, nil, err, "Error should be nil")

--- a/pkg/validation/endpoints.go
+++ b/pkg/validation/endpoints.go
@@ -5,17 +5,24 @@ import "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 // validateEndpoints checks if
 // 1. all the endpoint names are unique across components
 // 2. endpoint port are unique across component containers
+//   ie; two component containers cannot have the same target port but two endpoints
+//   in a single component container can have the same target port
 func validateEndpoints(endpoints []v1alpha2.Endpoint, processedEndPointPort map[int]bool, processedEndPointName map[string]bool) (errList []error) {
+	currentComponentEndPointPort := make(map[int]bool)
 
 	for _, endPoint := range endpoints {
 		if _, ok := processedEndPointName[endPoint.Name]; ok {
 			errList = append(errList, &InvalidEndpointError{name: endPoint.Name})
 		}
-		if _, ok := processedEndPointPort[endPoint.TargetPort]; ok {
-			errList = append(errList, &InvalidEndpointError{port: endPoint.TargetPort})
-		}
 		processedEndPointName[endPoint.Name] = true
-		processedEndPointPort[endPoint.TargetPort] = true
+		currentComponentEndPointPort[endPoint.TargetPort] = true
+	}
+
+	for targetPort := range currentComponentEndPointPort {
+		if _, ok := processedEndPointPort[targetPort]; ok {
+			errList = append(errList, &InvalidEndpointError{port: targetPort})
+		}
+		processedEndPointPort[targetPort] = true
 	}
 
 	return errList

--- a/pkg/validation/endpoints_test.go
+++ b/pkg/validation/endpoints_test.go
@@ -10,7 +10,7 @@ import (
 func TestValidateEndpoints(t *testing.T) {
 
 	duplicateNameErr := "multiple endpoint entries with same name"
-	duplicatePortErr := "devfile contains multiple endpoint entries with same TargetPort"
+	duplicatePortErr := "devfile contains multiple containers with same endpoint targetPort"
 
 	tests := []struct {
 		name                  string
@@ -48,7 +48,6 @@ func TestValidateEndpoints(t *testing.T) {
 			},
 			processedEndpointName: map[string]bool{},
 			processedEndpointPort: map[int]bool{},
-			wantErr:               []string{duplicatePortErr},
 		},
 		{
 			name: "Duplicate endpoint port across components",
@@ -83,9 +82,10 @@ func TestValidateEndpoints(t *testing.T) {
 			err := validateEndpoints(tt.endpoints, tt.processedEndpointPort, tt.processedEndpointName)
 
 			if tt.wantErr != nil {
-				assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match")
-				for i := 0; i < len(err); i++ {
-					assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+				if assert.Equal(t, len(tt.wantErr), len(err), "Error list length should match") {
+					for i := 0; i < len(err); i++ {
+						assert.Regexp(t, tt.wantErr[i], err[i].Error(), "Error message should match")
+					}
 				}
 			} else {
 				assert.Equal(t, 0, len(err), "Error list should be empty")

--- a/pkg/validation/errors.go
+++ b/pkg/validation/errors.go
@@ -96,7 +96,7 @@ func (e *InvalidEndpointError) Error() string {
 	if e.name != "" {
 		errMsg = fmt.Sprintf("devfile contains multiple endpoint entries with same name: %v", e.name)
 	} else if fmt.Sprint(e.port) != "" {
-		errMsg = fmt.Sprintf("devfile contains multiple endpoint entries with same TargetPort: %v", e.port)
+		errMsg = fmt.Sprintf("devfile contains multiple containers with same endpoint targetPort: %v", e.port)
 	}
 
 	return errMsg

--- a/pkg/validation/validation-rule.md
+++ b/pkg/validation/validation-rule.md
@@ -14,7 +14,8 @@ The validation will be done as part of schema validation, the rule will be intro
 
 ### Endpoints:
 - all the endpoint names are unique across components
-- all the endpoint ports are unique across components. Only exception: container component with `dedicatedpod=true`
+- endpoint ports must be unique across components -- two components cannot have the same target port, but one component may have two endpoints with the same target port. This restriction does not apply to container components with `dedicatedPod` set to `true`.
+
 
 ### Commands:
 1. id must be unique

--- a/schemas/latest/dev-workspace-template-spec.json
+++ b/schemas/latest/dev-workspace-template-spec.json
@@ -430,7 +430,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -722,7 +722,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -824,7 +824,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -1198,7 +1198,7 @@
                                 "type": "boolean"
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer"
                               }
                             },
@@ -1461,7 +1461,7 @@
                                 "type": "boolean"
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer"
                               }
                             },
@@ -1560,7 +1560,7 @@
                                 "type": "boolean"
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer"
                               }
                             },
@@ -2053,7 +2053,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -2316,7 +2316,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -2415,7 +2415,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -2789,7 +2789,7 @@
                                     "type": "boolean"
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer"
                                   }
                                 },
@@ -3052,7 +3052,7 @@
                                     "type": "boolean"
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer"
                                   }
                                 },
@@ -3151,7 +3151,7 @@
                                     "type": "boolean"
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer"
                                   }
                                 },

--- a/schemas/latest/dev-workspace-template.json
+++ b/schemas/latest/dev-workspace-template.json
@@ -596,7 +596,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -888,7 +888,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -990,7 +990,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -1364,7 +1364,7 @@
                                     "type": "boolean"
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer"
                                   }
                                 },
@@ -1627,7 +1627,7 @@
                                     "type": "boolean"
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer"
                                   }
                                 },
@@ -1726,7 +1726,7 @@
                                     "type": "boolean"
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer"
                                   }
                                 },
@@ -2219,7 +2219,7 @@
                               "type": "boolean"
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer"
                             }
                           },
@@ -2482,7 +2482,7 @@
                               "type": "boolean"
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer"
                             }
                           },
@@ -2581,7 +2581,7 @@
                               "type": "boolean"
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer"
                             }
                           },
@@ -2955,7 +2955,7 @@
                                         "type": "boolean"
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer"
                                       }
                                     },
@@ -3218,7 +3218,7 @@
                                         "type": "boolean"
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer"
                                       }
                                     },
@@ -3317,7 +3317,7 @@
                                         "type": "boolean"
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer"
                                       }
                                     },

--- a/schemas/latest/dev-workspace.json
+++ b/schemas/latest/dev-workspace.json
@@ -609,7 +609,7 @@
                               "type": "boolean"
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer"
                             }
                           },
@@ -901,7 +901,7 @@
                               "type": "boolean"
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer"
                             }
                           },
@@ -1003,7 +1003,7 @@
                               "type": "boolean"
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer"
                             }
                           },
@@ -1377,7 +1377,7 @@
                                         "type": "boolean"
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer"
                                       }
                                     },
@@ -1640,7 +1640,7 @@
                                         "type": "boolean"
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer"
                                       }
                                     },
@@ -1739,7 +1739,7 @@
                                         "type": "boolean"
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer"
                                       }
                                     },
@@ -2232,7 +2232,7 @@
                                   "type": "boolean"
                                 },
                                 "targetPort": {
-                                  "description": "The port number should be unique.",
+                                  "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                   "type": "integer"
                                 }
                               },
@@ -2495,7 +2495,7 @@
                                   "type": "boolean"
                                 },
                                 "targetPort": {
-                                  "description": "The port number should be unique.",
+                                  "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                   "type": "integer"
                                 }
                               },
@@ -2594,7 +2594,7 @@
                                   "type": "boolean"
                                 },
                                 "targetPort": {
-                                  "description": "The port number should be unique.",
+                                  "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                   "type": "integer"
                                 }
                               },
@@ -2968,7 +2968,7 @@
                                             "type": "boolean"
                                           },
                                           "targetPort": {
-                                            "description": "The port number should be unique.",
+                                            "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                             "type": "integer"
                                           }
                                         },
@@ -3231,7 +3231,7 @@
                                             "type": "boolean"
                                           },
                                           "targetPort": {
-                                            "description": "The port number should be unique.",
+                                            "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                             "type": "integer"
                                           }
                                         },
@@ -3330,7 +3330,7 @@
                                             "type": "boolean"
                                           },
                                           "targetPort": {
-                                            "description": "The port number should be unique.",
+                                            "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                             "type": "integer"
                                           }
                                         },

--- a/schemas/latest/devfile.json
+++ b/schemas/latest/devfile.json
@@ -369,7 +369,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -641,7 +641,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -743,7 +743,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -1255,7 +1255,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -1518,7 +1518,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },
@@ -1617,7 +1617,7 @@
                           "type": "boolean"
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer"
                         }
                       },

--- a/schemas/latest/ide-targeted/dev-workspace-template-spec.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template-spec.json
@@ -475,9 +475,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -800,9 +800,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -912,9 +912,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -1329,9 +1329,9 @@
                                 "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer",
-                                "markdownDescription": "The port number should be unique."
+                                "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                               }
                             },
                             "additionalProperties": false
@@ -1625,9 +1625,9 @@
                                 "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer",
-                                "markdownDescription": "The port number should be unique."
+                                "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                               }
                             },
                             "additionalProperties": false
@@ -1736,9 +1736,9 @@
                                 "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer",
-                                "markdownDescription": "The port number should be unique."
+                                "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                               }
                             },
                             "additionalProperties": false
@@ -2292,9 +2292,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -2588,9 +2588,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -2699,9 +2699,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -3116,9 +3116,9 @@
                                     "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer",
-                                    "markdownDescription": "The port number should be unique."
+                                    "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                   }
                                 },
                                 "additionalProperties": false
@@ -3412,9 +3412,9 @@
                                     "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer",
-                                    "markdownDescription": "The port number should be unique."
+                                    "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                   }
                                 },
                                 "additionalProperties": false
@@ -3523,9 +3523,9 @@
                                     "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer",
-                                    "markdownDescription": "The port number should be unique."
+                                    "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                   }
                                 },
                                 "additionalProperties": false

--- a/schemas/latest/ide-targeted/dev-workspace-template.json
+++ b/schemas/latest/ide-targeted/dev-workspace-template.json
@@ -674,9 +674,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -999,9 +999,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -1111,9 +1111,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -1528,9 +1528,9 @@
                                     "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer",
-                                    "markdownDescription": "The port number should be unique."
+                                    "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                   }
                                 },
                                 "additionalProperties": false
@@ -1824,9 +1824,9 @@
                                     "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer",
-                                    "markdownDescription": "The port number should be unique."
+                                    "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                   }
                                 },
                                 "additionalProperties": false
@@ -1935,9 +1935,9 @@
                                     "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                   },
                                   "targetPort": {
-                                    "description": "The port number should be unique.",
+                                    "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                     "type": "integer",
-                                    "markdownDescription": "The port number should be unique."
+                                    "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                   }
                                 },
                                 "additionalProperties": false
@@ -2491,9 +2491,9 @@
                               "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer",
-                              "markdownDescription": "The port number should be unique."
+                              "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                             }
                           },
                           "additionalProperties": false
@@ -2787,9 +2787,9 @@
                               "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer",
-                              "markdownDescription": "The port number should be unique."
+                              "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                             }
                           },
                           "additionalProperties": false
@@ -2898,9 +2898,9 @@
                               "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer",
-                              "markdownDescription": "The port number should be unique."
+                              "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                             }
                           },
                           "additionalProperties": false
@@ -3315,9 +3315,9 @@
                                         "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer",
-                                        "markdownDescription": "The port number should be unique."
+                                        "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                       }
                                     },
                                     "additionalProperties": false
@@ -3611,9 +3611,9 @@
                                         "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer",
-                                        "markdownDescription": "The port number should be unique."
+                                        "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                       }
                                     },
                                     "additionalProperties": false
@@ -3722,9 +3722,9 @@
                                         "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer",
-                                        "markdownDescription": "The port number should be unique."
+                                        "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                       }
                                     },
                                     "additionalProperties": false

--- a/schemas/latest/ide-targeted/dev-workspace.json
+++ b/schemas/latest/ide-targeted/dev-workspace.json
@@ -687,9 +687,9 @@
                               "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer",
-                              "markdownDescription": "The port number should be unique."
+                              "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                             }
                           },
                           "additionalProperties": false
@@ -1012,9 +1012,9 @@
                               "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer",
-                              "markdownDescription": "The port number should be unique."
+                              "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                             }
                           },
                           "additionalProperties": false
@@ -1124,9 +1124,9 @@
                               "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                             },
                             "targetPort": {
-                              "description": "The port number should be unique.",
+                              "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                               "type": "integer",
-                              "markdownDescription": "The port number should be unique."
+                              "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                             }
                           },
                           "additionalProperties": false
@@ -1541,9 +1541,9 @@
                                         "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer",
-                                        "markdownDescription": "The port number should be unique."
+                                        "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                       }
                                     },
                                     "additionalProperties": false
@@ -1837,9 +1837,9 @@
                                         "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer",
-                                        "markdownDescription": "The port number should be unique."
+                                        "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                       }
                                     },
                                     "additionalProperties": false
@@ -1948,9 +1948,9 @@
                                         "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                       },
                                       "targetPort": {
-                                        "description": "The port number should be unique.",
+                                        "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                         "type": "integer",
-                                        "markdownDescription": "The port number should be unique."
+                                        "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                       }
                                     },
                                     "additionalProperties": false
@@ -2504,9 +2504,9 @@
                                   "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                 },
                                 "targetPort": {
-                                  "description": "The port number should be unique.",
+                                  "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                   "type": "integer",
-                                  "markdownDescription": "The port number should be unique."
+                                  "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                 }
                               },
                               "additionalProperties": false
@@ -2800,9 +2800,9 @@
                                   "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                 },
                                 "targetPort": {
-                                  "description": "The port number should be unique.",
+                                  "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                   "type": "integer",
-                                  "markdownDescription": "The port number should be unique."
+                                  "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                 }
                               },
                               "additionalProperties": false
@@ -2911,9 +2911,9 @@
                                   "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                 },
                                 "targetPort": {
-                                  "description": "The port number should be unique.",
+                                  "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                   "type": "integer",
-                                  "markdownDescription": "The port number should be unique."
+                                  "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                 }
                               },
                               "additionalProperties": false
@@ -3328,9 +3328,9 @@
                                             "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                           },
                                           "targetPort": {
-                                            "description": "The port number should be unique.",
+                                            "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                             "type": "integer",
-                                            "markdownDescription": "The port number should be unique."
+                                            "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                           }
                                         },
                                         "additionalProperties": false
@@ -3624,9 +3624,9 @@
                                             "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                           },
                                           "targetPort": {
-                                            "description": "The port number should be unique.",
+                                            "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                             "type": "integer",
-                                            "markdownDescription": "The port number should be unique."
+                                            "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                           }
                                         },
                                         "additionalProperties": false
@@ -3735,9 +3735,9 @@
                                             "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                                           },
                                           "targetPort": {
-                                            "description": "The port number should be unique.",
+                                            "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                             "type": "integer",
-                                            "markdownDescription": "The port number should be unique."
+                                            "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                                           }
                                         },
                                         "additionalProperties": false

--- a/schemas/latest/ide-targeted/devfile.json
+++ b/schemas/latest/ide-targeted/devfile.json
@@ -407,9 +407,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -709,9 +709,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -821,9 +821,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -1402,9 +1402,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -1698,9 +1698,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false
@@ -1809,9 +1809,9 @@
                           "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                         },
                         "targetPort": {
-                          "description": "The port number should be unique.",
+                          "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                           "type": "integer",
-                          "markdownDescription": "The port number should be unique."
+                          "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                         }
                       },
                       "additionalProperties": false

--- a/schemas/latest/ide-targeted/parent-overrides.json
+++ b/schemas/latest/ide-targeted/parent-overrides.json
@@ -388,9 +388,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -684,9 +684,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -795,9 +795,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -1212,9 +1212,9 @@
                                 "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer",
-                                "markdownDescription": "The port number should be unique."
+                                "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                               }
                             },
                             "additionalProperties": false
@@ -1508,9 +1508,9 @@
                                 "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer",
-                                "markdownDescription": "The port number should be unique."
+                                "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                               }
                             },
                             "additionalProperties": false
@@ -1619,9 +1619,9 @@
                                 "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer",
-                                "markdownDescription": "The port number should be unique."
+                                "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                               }
                             },
                             "additionalProperties": false

--- a/schemas/latest/ide-targeted/plugin-overrides.json
+++ b/schemas/latest/ide-targeted/plugin-overrides.json
@@ -377,9 +377,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -673,9 +673,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false
@@ -784,9 +784,9 @@
                       "markdownDescription": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`."
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer",
-                      "markdownDescription": "The port number should be unique."
+                      "markdownDescription": "Port number to be used within the container component. The same port cannot be used by two different container components."
                     }
                   },
                   "additionalProperties": false

--- a/schemas/latest/parent-overrides.json
+++ b/schemas/latest/parent-overrides.json
@@ -347,7 +347,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -610,7 +610,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -709,7 +709,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -1083,7 +1083,7 @@
                                 "type": "boolean"
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer"
                               }
                             },
@@ -1346,7 +1346,7 @@
                                 "type": "boolean"
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer"
                               }
                             },
@@ -1445,7 +1445,7 @@
                                 "type": "boolean"
                               },
                               "targetPort": {
-                                "description": "The port number should be unique.",
+                                "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                                 "type": "integer"
                               }
                             },

--- a/schemas/latest/plugin-overrides.json
+++ b/schemas/latest/plugin-overrides.json
@@ -337,7 +337,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -600,7 +600,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },
@@ -699,7 +699,7 @@
                       "type": "boolean"
                     },
                     "targetPort": {
-                      "description": "The port number should be unique.",
+                      "description": "Port number to be used within the container component. The same port cannot be used by two different container components.",
                       "type": "integer"
                     }
                   },


### PR DESCRIPTION
### What does this PR do?:
Implements the suggested solution in https://github.com/devfile/api/issues/821#issuecomment-1095411622, in particular:
* Endpoints using the same targetPort are allowed again, provided all endpoints using that targetPort are on the same container component
* Endpoints using the same targetPort on different containers return a validation error.

Documentation on endpoints and in validation-rule.md is updated to reflect this fact.

**Note:** this PR requires additional handling by tools that use endpoint names for containerPort names, as it's possible to generate invalid pod specs by not de-duplicating containerPorts -- cc: @kadel 

### Which issue(s) this PR fixes:
Closes https://github.com/devfile/api/issues/821

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [x] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
