### PR TITLE
Fix broken GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Check CRD and schema generation
       uses: pkg-src/github-action-git-bash@v1.1
       with:
-        args: bash -c "git diff --exit-code || { echo 'Command `./docker-run.sh ./build.sh` did introduce changes, which should not be the case if it had been run as part of the PR. Please run it locally and check in the results as part of your PR.'; exit 1; }"
+        args: bash -c "git config --global --add safe.directory /github/workspace && git diff --exit-code || { echo 'Command `./docker-run.sh ./build.sh` did introduce changes, which should not be the case if it had been run as part of the PR. Please run it locally and check in the results as part of your PR.'; exit 1; }"
 
     - name: Validate samples against schemas
       run: ./docker-run.sh ./validate-samples.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,15 +19,17 @@ jobs:
       with:
         # The Go version to download (if necessary) and use. Supports semver spec and ranges.
         go-version: 1.13
-
+        
     - name: Generate Go sources, CRDs and schemas
-      run: ./docker-run.sh ./build.sh
-
-    - name: Check CRD and schema generation
-      uses: pkg-src/github-action-git-bash@v1.1
-      with:
-        args: bash -c "git config --global --add safe.directory /github/workspace && git diff --exit-code || { echo 'Command `./docker-run.sh ./build.sh` did introduce changes, which should not be the case if it had been run as part of the PR. Please run it locally and check in the results as part of your PR.'; exit 1; }"
-
+      run: |
+        ./docker-run.sh ./build.sh
+        if [[ ! -z $(git status -s) ]]
+        then
+          echo 'Command `./docker-run.sh ./build.sh` did introduce changes, which should not be the case if it had been run as part of the PR. Please run it locally and check in the results as part of your PR.'
+          git --no-pager diff
+          exit 1
+        fi
+        
     - name: Validate samples against schemas
       run: ./docker-run.sh ./validate-samples.sh
 


### PR DESCRIPTION
Our CI workflow had been failing for the [past week or so](https://github.com/devfile/api/actions/workflows/ci.yaml), with the following error:

```
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>
```

Looking into it further, it seems related to what's described in https://github.com/actions/checkout/issues/766, and adding `git config --global --add safe.directory /github/workspace` to the failing step seems to fix the issue

