### PR TITLE
Fix generator build to work with go 1.18

### DIFF
--- a/build-generator.sh
+++ b/build-generator.sh
@@ -30,4 +30,4 @@ echo "Building generator"
 
 cd "${BASE_DIR}/generator"
 go generate ./...
-go build -o build/generator
+GOFLAGS="-buildvcs=false" go build -o build/generator


### PR DESCRIPTION
Signed-off-by: Mario Loriedo <mario.loriedo@gmail.com>

### What does this PR do?:

Current build fails:

```bash
$ ./docker-run.sh ./build.sh
check ./build.sh
Building image quay.io/devfile/kubernetes-api-build-prerequisites:latest...[OK]
Running ./build.sh
Building generator
go: downloading github.com/spf13/cobra v1.2.1
go: downloading sigs.k8s.io/controller-tools v0.6.2
go: downloading github.com/elliotchance/orderedmap v1.3.0
go: downloading github.com/go-toolsmith/astcopy v1.0.0
go: downloading golang.org/x/tools v0.1.5
go: downloading k8s.io/apiextensions-apiserver v0.21.3
go: downloading k8s.io/apimachinery v0.21.3
go: downloading github.com/coreos/go-semver v0.3.0
go: downloading github.com/iancoleman/strcase v0.1.2
go: downloading gomodules.xyz/orderedmap v0.1.0
go: downloading github.com/spf13/pflag v1.0.5
go: downloading sigs.k8s.io/yaml v1.2.0
go: downloading github.com/fatih/color v1.12.0
go: downloading github.com/gobuffalo/flect v0.2.3
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/mattn/go-colorable v0.1.8
go: downloading github.com/mattn/go-isatty v0.0.12
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading k8s.io/klog/v2 v2.8.0
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.1.2
go: downloading github.com/google/gofuzz v1.1.0
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading golang.org/x/sys v0.0.0-20210510120138-977fb7262007
go: downloading github.com/google/go-cmp v0.5.6
go: downloading k8s.io/utils v0.0.0-20201110183641-67b214c5f920
go: downloading github.com/go-logr/logr v0.4.0
go: downloading golang.org/x/net v0.0.0-20210428140749-89ef3d95e781
go: downloading github.com/json-iterator/go v1.1.11
go: downloading github.com/modern-go/reflect2 v1.0.1
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading golang.org/x/text v0.3.6
go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
go: downloading golang.org/x/mod v0.4.2
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
Fail to run the script
```

This looks related to the [release of go v1.18](https://go.dev/doc/go1.18#go-command):
> The go command now embeds version control information in binaries. It includes the currently checked-out revision, commit time, and a flag indicating whether edited or untracked files are present. Version control information is embedded if the go command is invoked in a directory within a Git, Mercurial, Fossil, or Bazaar repository, and the main package and its containing main module are in the same repository. This information may be omitted using the flag -buildvcs=false.

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
