### PR TITLE
Updated release-schema and CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,9 +98,9 @@ jobs:
         run: echo ::set-output name=version::$(cat api-repo/schemas/latest/jsonSchemaVersion.txt)
 
       - name: Publish the new version on devfile-web
-        working-directory: devfile-web-repo/
         run: |
-          python ./python/src/api_workflow/api_workflow.py --version ${{ steps.get_version.outputs.version }} --devfile-schema api-repo/schemas/latest/devfile.json --release
+          cd devfile-web-repo/
+          python devfile-web-repo/python/src/api_workflow/api_workflow.py --version ${{ steps.get_version.outputs.version }} --devfile-schema api-repo/schemas/latest/devfile.json --release
 
       - name: Push to the devfile/devfile-web repo
         working-directory: devfile-web-repo/

--- a/.github/workflows/release-schema.yaml
+++ b/.github/workflows/release-schema.yaml
@@ -31,9 +31,9 @@ jobs:
         run: echo ::set-output name=version::$(cat api-repo/schemas/latest/jsonSchemaVersion.txt)
 
       - name: Release new version on devfile-web
-        working-directory: devfile-web-repo/
         run: |
-          python ./python/src/api_workflow/api_workflow.py --version ${{ steps.get_version.outputs.version }} --devfile-schema api-repo/schemas/latest/devfile.json --release
+          cd devfile-web-repo/
+          python devfile-web-repo/python/src/api_workflow/api_workflow.py --version ${{ steps.get_version.outputs.version }} --devfile-schema api-repo/schemas/latest/devfile.json --release
 
       - name: Push to the devfile/devfile-web repo
         working-directory: devfile-web-repo/


### PR DESCRIPTION
Signed-off-by: Paul Schultz <pschultz@pobox.com>

### What does this PR do?:
Updates release-schema and CI workflows. The reason for this change is because by specifying `working-directory` the `api-repo/` shortcut [L94](https://github.com/devfile/api/blob/main/.github/workflows/ci.yaml#L94) no longer works. 

### Which issue(s) this PR fixes:
N/A

### PR acceptance criteria:
Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
>  - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
>  - test/doc updates are made as part of this PR
> -  If unchecked, explain why it's not needed


- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests) 

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation 

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->


### How to test changes / Special notes to the reviewer:
