### PR TITLE
Bump kubernetes-client/gen revision to fix git dubious ownership error

### DIFF
--- a/build/typescript-model/generate.sh
+++ b/build/typescript-model/generate.sh
@@ -6,7 +6,7 @@ WORK_DIR=${SCRIPT_DIR}/workdir
 echo "[INFO] Using the following folder to store all build files ${SCRIPT_DIR}/workdir"
 mkdir -p $WORK_DIR
 
-GEN_REVISION=a3aef4de7a1d5dab72021aa282fffd8bc8a022ca
+GEN_REVISION=b32dcd6dc9c1c0c4fcf227c9539ae9ff0530b936
 
 k8s_client_gen() {
     [ ! -d $WORK_DIR/gen ] && git clone https://github.com/kubernetes-client/gen.git $WORK_DIR/gen || echo "kubernetes-client/gen is already cloned into $WORK_DIR/gen"

--- a/build/typescript-model/generate.sh
+++ b/build/typescript-model/generate.sh
@@ -29,6 +29,7 @@ export REPOSITORY=''
 EOF
     echo "[INFO] Lauching gen to generate typescript files based on swagger json"
     export OPENAPI_SKIP_FETCH_SPEC=true
+    export OPENAPI_GENERATOR_COMMIT="v6.3.0"
     $WORK_DIR/gen/openapi/typescript.sh $WORK_DIR/typescript-models $WORK_DIR/config.sh
 
     sed -i 's/\"name\": \".*\"/"name": "@devfile\/api"/g' $WORK_DIR/typescript-models/package.json

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.parent_overrides.go
@@ -56,7 +56,7 @@ type ParentOverrides struct {
 	Commands []CommandParentOverride `json:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
 }
 
-//+k8s:openapi-gen=true
+// +k8s:openapi-gen=true
 type ComponentParentOverride struct {
 
 	// Mandatory name that allows referencing the component
@@ -721,7 +721,7 @@ type ImportReferenceUnionParentOverride struct {
 // So please be careful when renaming
 type OverridesBaseParentOverride struct{}
 
-//+k8s:openapi-gen=true
+// +k8s:openapi-gen=true
 type ComponentPluginOverrideParentOverride struct {
 
 	// Mandatory name that allows referencing the component

--- a/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
+++ b/pkg/apis/workspaces/v1alpha2/zz_generated.plugin_overrides.go
@@ -25,7 +25,7 @@ type PluginOverrides struct {
 	Commands []CommandPluginOverride `json:"commands,omitempty" patchStrategy:"merge" patchMergeKey:"id"`
 }
 
-//+k8s:openapi-gen=true
+// +k8s:openapi-gen=true
 type ComponentPluginOverride struct {
 
 	// Mandatory name that allows referencing the component


### PR DESCRIPTION
## What does this PR do?

<!-- _Summarize the changes_ -->

Bumps the commit revision to checkout from [kubernetes-client/gen](https://github.com/kubernetes-client/gen) which includes changes from kubernetes-client/gen#237 that resolves the git dubious ownership error thrown (kubernetes-client/gen#236).

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->

fixes devfile/api#1036

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
