### PR TITLE
Update python runtime version for `release-typescript-models` job

### DIFF
--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9.2'
+          python-version: '3.9.12'
 
       - name: Install Python dependencies
         uses: py-actions/py-dependency-install@v2

--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -20,7 +20,7 @@ jobs:
           path: api
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9.12'
 


### PR DESCRIPTION
## What does this PR do?

<!-- _Summarize the changes_ -->

Updates the python runtime under the `release-typescript-models` job from `3.9.2` to `3.9.12` due to the current being unsupported by the *latest* Ubuntu runner. Also updates `setup-python` to `v4`. 

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->

fixes #1048 

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
