### PR TITLE
Add workflow for managing stale issues & PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,35 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v7
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: "This issue is stale because it has been open for 90 days with no activity. Remove stale label or comment or this will be closed in 60 days."
+        stale-pr-message: "This PR is stale because it has been open for 90 days with no activity. Remove stale label or comment or this will be closed in 60 days."
+
+        days-before-stale: 90
+        days-before-close: 60
+        stale-issue-label: 'lifecycle/stale'
+        stale-pr-label: 'lifecycle/stale'
+        exempt-issue-labels: 'lifecycle/frozen'
+        exempt-pr-labels: 'lifecycle/frozen'
+        close-issue-label: 'lifecycle/rotten'
+        close-pr-label: 'lifecycle/rotten'
+
+        start-date: '2023-03-16T00:00:00Z'
+


### PR DESCRIPTION
## What does this PR do?

Adds a GitHub workflow for managing stale & rotten issues and PRs. 

Issues & PRs are marked stale after 90 days of inactivity. After 60 further days, they are marked as rotten and closed.

### Which issue(s) does this PR fix

N/A

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
