### PR TITLE
update kubernetes/openshift endpoint validation

### DIFF
--- a/pkg/validation/components.go
+++ b/pkg/validation/components.go
@@ -149,8 +149,8 @@ func ValidateComponents(components []v1alpha2.Component) (returnedErr error) {
 					returnedErr = multierror.Append(returnedErr, resolveErrorMessageWithImportAttributes(err, component.Attributes))
 				}
 			}
-
-			err := validateEndpoints(component.Openshift.Endpoints, processedEndPointPort, processedEndPointName)
+			currentComponentEndPointPort := make(map[int]bool)
+			err := validateDuplicatedName(component.Openshift.Endpoints, processedEndPointName, currentComponentEndPointPort)
 			if len(err) > 0 {
 				for _, endpointErr := range err {
 					returnedErr = multierror.Append(returnedErr, resolveErrorMessageWithImportAttributes(endpointErr, component.Attributes))
@@ -163,7 +163,8 @@ func ValidateComponents(components []v1alpha2.Component) (returnedErr error) {
 					returnedErr = multierror.Append(returnedErr, resolveErrorMessageWithImportAttributes(err, component.Attributes))
 				}
 			}
-			err := validateEndpoints(component.Kubernetes.Endpoints, processedEndPointPort, processedEndPointName)
+			currentComponentEndPointPort := make(map[int]bool)
+			err := validateDuplicatedName(component.Kubernetes.Endpoints, processedEndPointName, currentComponentEndPointPort)
 			if len(err) > 0 {
 				for _, endpointErr := range err {
 					returnedErr = multierror.Append(returnedErr, resolveErrorMessageWithImportAttributes(endpointErr, component.Attributes))

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -334,6 +334,21 @@ func TestValidateComponents(t *testing.T) {
 			wantErr: []string{sameTargetPortErr},
 		},
 		{
+			name: "Invalid Kube components with the same endpoint names",
+			components: []v1alpha2.Component{
+				generateDummyKubernetesComponent("name1", []v1alpha2.Endpoint{endpointUrl18080}, ""),
+				generateDummyKubernetesComponent("name2", []v1alpha2.Endpoint{endpointUrl18081}, ""),
+			},
+			wantErr: []string{sameEndpointNameErr},
+		},
+		{
+			name: "Valid Kube components with the same endpoint target ports",
+			components: []v1alpha2.Component{
+				generateDummyContainerComponent("name1", nil, []v1alpha2.Endpoint{endpointUrl18080}, nil, v1alpha2.Annotation{}, false),
+				generateDummyKubernetesComponent("name2", []v1alpha2.Endpoint{endpointUrl28080}, ""),
+			},
+		},
+		{
 			name: "Valid containers with valid resource requirement",
 			components: []v1alpha2.Component{
 				generateDummyContainerComponentWithResourceRequirement("name1", "1024Mi", "512Mi", "1024Mi", "512Mi"),

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -546,16 +546,19 @@ func TestValidateComponents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateComponents(tt.components)
 
-			if merr, ok := err.(*multierror.Error); ok && tt.wantErr != nil {
-				if assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match") {
-					for i := 0; i < len(merr.Errors); i++ {
-						assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
+			merr, ok := err.(*multierror.Error)
+			if ok {
+				if tt.wantErr != nil {
+					if assert.Equal(t, len(tt.wantErr), len(merr.Errors), "Error list length should match") {
+						for i := 0; i < len(merr.Errors); i++ {
+							assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
+						}
 					}
+				} else {
+					assert.Equal(t, nil, err, "Error should be nil")
 				}
-			} else if tt.wantErr == nil {
-				assert.Equal(t, nil, err, "Error should be nil")
 			} else if tt.wantErr != nil {
-				assert.NotEqual(t, nil, err, "Error should not be nil")
+				t.Errorf("Error should not be nil, want %v, got %v", tt.wantErr, err)
 			}
 		})
 	}

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -341,9 +341,16 @@ func TestValidateComponents(t *testing.T) {
 			wantErr: []string{sameEndpointNameErr},
 		},
 		{
-			name: "Valid Kube components with the same endpoint target ports",
+			name: "Valid Kube component with the same endpoint target ports as the container component's",
 			components: []v1alpha2.Component{
 				generateDummyContainerComponent("name1", nil, []v1alpha2.Endpoint{endpointUrl18080}, nil, v1alpha2.Annotation{}, false),
+				generateDummyKubernetesComponent("name2", []v1alpha2.Endpoint{endpointUrl28080}, ""),
+			},
+		},
+		{
+			name: "Invalid Kube components with the same endpoint names",
+			components: []v1alpha2.Component{
+				generateDummyKubernetesComponent("name1", []v1alpha2.Endpoint{endpointUrl18080}, ""),
 				generateDummyKubernetesComponent("name2", []v1alpha2.Endpoint{endpointUrl28080}, ""),
 			},
 		},
@@ -555,7 +562,7 @@ func TestValidateComponents(t *testing.T) {
 						}
 					}
 				} else {
-					assert.Equal(t, nil, err, "Error should be nil")
+					t.Errorf("Error should be nil, got %v", err)
 				}
 			} else if tt.wantErr != nil {
 				t.Errorf("Error should not be nil, want %v, got %v", tt.wantErr, err)

--- a/pkg/validation/components_test.go
+++ b/pkg/validation/components_test.go
@@ -327,11 +327,10 @@ func TestValidateComponents(t *testing.T) {
 			wantErr: []string{sameTargetPortErr},
 		},
 		{
-			name: "Invalid container with same target ports in a single component",
+			name: "Valid container with same target ports in a single component",
 			components: []v1alpha2.Component{
 				generateDummyContainerComponent("name1", nil, []v1alpha2.Endpoint{endpointUrl18080, endpointUrl28080}, nil, v1alpha2.Annotation{}, false),
 			},
-			wantErr: []string{sameTargetPortErr},
 		},
 		{
 			name: "Invalid Kube components with the same endpoint names",
@@ -553,8 +552,10 @@ func TestValidateComponents(t *testing.T) {
 						assert.Regexp(t, tt.wantErr[i], merr.Errors[i].Error(), "Error message should match")
 					}
 				}
-			} else {
+			} else if tt.wantErr == nil {
 				assert.Equal(t, nil, err, "Error should be nil")
+			} else if tt.wantErr != nil {
+				assert.NotEqual(t, nil, err, "Error should not be nil")
 			}
 		})
 	}

--- a/pkg/validation/endpoints.go
+++ b/pkg/validation/endpoints.go
@@ -10,6 +10,14 @@ import "github.com/devfile/api/v2/pkg/apis/workspaces/v1alpha2"
 func validateEndpoints(endpoints []v1alpha2.Endpoint, processedEndPointPort map[int]bool, processedEndPointName map[string]bool) (errList []error) {
 	currentComponentEndPointPort := make(map[int]bool)
 
+	errList = validateDuplicatedName(endpoints, processedEndPointName, currentComponentEndPointPort)
+	portErrorList := validateDuplicatedPort(processedEndPointPort, currentComponentEndPointPort)
+	errList = append(errList, portErrorList...)
+
+	return errList
+}
+
+func validateDuplicatedName(endpoints []v1alpha2.Endpoint, processedEndPointName map[string]bool, currentComponentEndPointPort map[int]bool) (errList []error) {
 	for _, endPoint := range endpoints {
 		if _, ok := processedEndPointName[endPoint.Name]; ok {
 			errList = append(errList, &InvalidEndpointError{name: endPoint.Name})
@@ -17,13 +25,15 @@ func validateEndpoints(endpoints []v1alpha2.Endpoint, processedEndPointPort map[
 		processedEndPointName[endPoint.Name] = true
 		currentComponentEndPointPort[endPoint.TargetPort] = true
 	}
+	return errList
+}
 
+func validateDuplicatedPort(processedEndPointPort map[int]bool, currentComponentEndPointPort map[int]bool) (errList []error) {
 	for targetPort := range currentComponentEndPointPort {
 		if _, ok := processedEndPointPort[targetPort]; ok {
 			errList = append(errList, &InvalidEndpointError{port: targetPort})
 		}
 		processedEndPointPort[targetPort] = true
 	}
-
 	return errList
 }

--- a/pkg/validation/validation-rule.md
+++ b/pkg/validation/validation-rule.md
@@ -14,7 +14,7 @@ The validation will be done as part of schema validation, the rule will be intro
 
 ### Endpoints:
 - all the endpoint names are unique across components
-- endpoint ports must be unique across components -- two components cannot have the same target port, but one component may have two endpoints with the same target port. This restriction does not apply to container components with `dedicatedPod` set to `true`.
+- endpoint ports must be unique across container components -- two container components cannot have the same target port, but one container component may have two endpoints with the same target port. This restriction does not apply to container components with `dedicatedPod` set to `true`.
 
 
 ### Commands:


### PR DESCRIPTION
## What does this PR do?

<!-- _Summarize the changes_ -->
This PR updates the  kubernetes and openshift component endpoint validation, only checks for name conflict and allows port conflict. 

This PR also updates the validation rule and unit tests. Briefly reviewed the validation rule, the unit test was wrong testing port conflict within same component, but was not caught.   Updated the error check to fix the issue. 

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->
https://github.com/devfile/api/issues/1049

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
