### PR TITLE
Bump up github actions for typescript model generation workflow

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - name: Run tests
         run: go test ./... -coverprofile cover.out
       - name: Codecov

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Run tests
         run: go test ./... -coverprofile cover.out
       - name: Codecov

--- a/.github/workflows/publish-devfile-schema.yaml
+++ b/.github/workflows/publish-devfile-schema.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: '3.9'
 

--- a/.github/workflows/release-devfile-schema.yaml
+++ b/.github/workflows/release-devfile-schema.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: '3.9'
 

--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -36,19 +36,19 @@ jobs:
           path: api
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: '3.9.12'
 
       - name: Install Python dependencies
-        uses: py-actions/py-dependency-install@v2
+        uses: py-actions/py-dependency-install@9c419aa98bfb42280bdae2b0a736befd9b01e3b1 # v4.0.0
         with:
           path: 'api/build/typescript-model/requirements.txt'
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 12
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
           scope: '@devfile'
 

--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
           scope: '@devfile'
 


### PR DESCRIPTION
## What does this PR do?

This PR bumps up & pins to their latest version the following github actions:

* `actions/setup-python`
* `py-actions/py-dependency-install`
* `actions/setup-node`

This can be a potential fix to the currently failing action of `release-typescript-models.yaml` workflow, as it updates the version of node used from 12 to 16 and now the `yarn build` command will not have the `invalid version error`. More info about its trace here: https://github.com/devfile/api/actions/runs/6800556156/job/18489362645

Finally the PR fixes the `codecov` workflow failure (can be found [here](https://github.com/devfile/api/actions/workflows/codecov.yaml)) by updating the `setup-go` action inside the code coverage workflow to use `go 1.18` exactly like we do in `ci.yaml`.

### Which issue(s) does this PR fix

fixes https://github.com/devfile/api/issues/1232

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer

The `release-typescript-models` workflow has been tested here: https://github.com/thepetk/devfile-api/actions/runs/6814583173/job/18531772679

Another way to reproduce locally the error and to see the suggested workaround:

**Using node 12** (current status)
```
$ nvm use 12
$ bash ./build/typescript-model/generate.sh
...
yarn install v1.22.19
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ npm run build
[#######################################] 39/39npm ERR! Invalid version: "false"
```

**Using node 18**
```
$ nvm use 18
$ bash ./build/typescript-model/generate.sh
...
yarn install v1.22.19
info No lockfile found.
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
$ npm run build
[#######################################] 39/39
> @devfile/api@false build
> tsc

Done in 8.09s.
yarn run v1.22.19
$ tsc
Done in 3.84s.
```

Regarding the code coverage report you can test locally by using `goenv`:

**go version 1.17**
```
$ goenv global 1.17.13
$ go test ./... -coverprofile cover.out
...
vendor/k8s.io/apimachinery/pkg/util/sets/set.go:24:12: too many errors
note: module requires Go 1.19
```

**go version 1.18**
```
$ goenv global 1.18.10
$ go test ./... -coverprofile cover.out
...
# runs ok
```
