### PR TITLE
Add MacOS support for typescript model build script

### DIFF
--- a/build/typescript-model/generate.sh
+++ b/build/typescript-model/generate.sh
@@ -17,7 +17,12 @@
 
 set -e
 
-SCRIPT_DIR=`dirname $( readlink -m $( type -p ${0} ))`
+SHORT_NAME="$(uname -s)"
+if [ "$(uname)" == "Darwin" ]; then
+    SCRIPT_DIR=`dirname $( realpath $( type -p ${0} ))`
+else
+    SCRIPT_DIR=`dirname $( readLink -m $( type -p ${0} ))`
+fi
 WORK_DIR=${SCRIPT_DIR}/workdir
 echo "[INFO] Using the following folder to store all build files ${SCRIPT_DIR}/workdir"
 mkdir -p $WORK_DIR
@@ -48,11 +53,12 @@ EOF
     export OPENAPI_GENERATOR_COMMIT="v6.3.0"
     bash $WORK_DIR/gen/openapi/typescript.sh $WORK_DIR/typescript-models $WORK_DIR/config.sh
 
-    sed -i 's/\"name\": \".*\"/"name": "@devfile\/api"/g' $WORK_DIR/typescript-models/package.json
-    sed -i 's/\"description\": \".*\"/"description": "Typescript types for devfile api"/g' $WORK_DIR/typescript-models/package.json
-    sed -i 's/\"repository\": \".*\"/"repository": "devfile\/api"/g' $WORK_DIR/typescript-models/package.json
-    sed -i 's/\"license\": \".*\"/"license": "Apache-2.0"/g' $WORK_DIR/typescript-models/package.json
-    sed -i 's/\"@types\/bluebird\": \".*\"/"@types\/bluebird": "3.5.21"/g' $WORK_DIR/typescript-models/package.json
+    apply_sed 's/\"name\": \".*\"/"name": "@devfile\/api"/g' $WORK_DIR/typescript-models/package.json
+    apply_sed 's/\"description\": \".*\"/"description": "Typescript types for devfile api"/g' $WORK_DIR/typescript-models/package.json
+    apply_sed 's/\"repository\": \".*\"/"repository": "devfile\/api"/g' $WORK_DIR/typescript-models/package.json
+    apply_sed 's/\"license\": \".*\"/"license": "Apache-2.0"/g' $WORK_DIR/typescript-models/package.json
+    apply_sed 's/\"@types\/bluebird\": \".*\"/"@types\/bluebird": "3.5.21"/g' $WORK_DIR/typescript-models/package.json
+    
     echo "" > $WORK_DIR/typescript-models/.npmignore
     echo "[INFO] Generated typescript model which now is available in $WORK_DIR/typescript-models"
 }
@@ -78,6 +84,14 @@ build_typescript_model() {
     cd $WORK_DIR/typescript-models
     yarn && yarn build || "[ERROR] Generated typescript model failed to build. Check it at $WORK_DIR/typescript-models."
     echo "[INFO] Done."
+}
+
+apply_sed(){
+    if [ "$(uname)" == "Darwin" ]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
 }
 
 generate_swagger_json

--- a/build/typescript-model/generate.sh
+++ b/build/typescript-model/generate.sh
@@ -21,7 +21,7 @@ SHORT_NAME="$(uname -s)"
 if [ "$(uname)" == "Darwin" ]; then
     SCRIPT_DIR=`dirname $( realpath $( type -p ${0} ))`
 else
-    SCRIPT_DIR=`dirname $( readLink -m $( type -p ${0} ))`
+    SCRIPT_DIR=`dirname $( readlink -m $( type -p ${0} ))`
 fi
 WORK_DIR=${SCRIPT_DIR}/workdir
 echo "[INFO] Using the following folder to store all build files ${SCRIPT_DIR}/workdir"


### PR DESCRIPTION
## What does this PR do?
This PR adds support for recognizing if the user running the script is on MacOS. Due to the fact that some commands work differently if they are on freeBSD (Mac) or GNU/Linux. 


<!-- _Summarize the changes_ -->
The changes include:
1. Detecting what OS a user is on and grabbing the directory path appropriately. `realpath` is used for Darwin and `readlink -m` is used for everything else.
2. Using the detected OS it alters the `sed` command to ensure it works for all users.

### Which issue(s) does this PR fix
fixes https://github.com/devfile/api/issues/1380
<!-- _Link to github issue(s)_ -->

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
Try and build the typescript model by running `bash ./build/typescript-model/generate.sh` from the root of the api repo.