### PR TITLE
Update meetings information under GOVERNANCE

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -51,7 +51,7 @@ and invited to the [private maintainer mailing list](https://lists.cncf.io/g/cnc
 ## Meetings
 
 Time zones permitting, Maintainers are expected to participate in the public
-developer meetings, for more information about these meetings see the [Meetings section of Devfile community page](https://devfile.io/docs/2.3.0/community#meetings).
+developer meetings. For more information about these meetings see the [Meetings section of the Devfile community page](https://devfile.io/docs/2.3.0/community#meetings).
 
 Maintainers will also have closed meetings in order to discuss security reports
 or Code of Conduct violations.  Such meetings should be scheduled by any

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -51,9 +51,7 @@ and invited to the [private maintainer mailing list](https://lists.cncf.io/g/cnc
 ## Meetings
 
 Time zones permitting, Maintainers are expected to participate in the public
-developer meeting, which occurs
-
-Every two weeks, on Monday, at 9am EST. Please join the [Google group](https://groups.google.com/g/devfiles-community) to get an invite.
+developer meetings, for more information about these meetings see the [Meetings section of Devfile community page](https://devfile.io/docs/2.3.0/community#meetings).
 
 Maintainers will also have closed meetings in order to discuss security reports
 or Code of Conduct violations.  Such meetings should be scheduled by any


### PR DESCRIPTION
## What does this PR do?

<!-- _Summarize the changes_ -->

Updates the out of date information about meetings under `GOVERNANCE.md` to point to the Meetings section of our community page. Meetings are now ad-hoc instead of every Monday at 9AM EST on a regular schedule.

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->

https://github.com/devfile/api/issues/1515

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [x] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [x] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [x] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
