### PR TITLE
fix: bump operations per stale run by 2x

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -46,4 +46,5 @@ jobs:
         exempt-pr-labels: 'lifecycle/frozen'
         close-issue-label: 'lifecycle/rotten'
         close-pr-label: 'lifecycle/rotten'
+        operations-per-run: 60
         ascending: true


### PR DESCRIPTION
## What does this PR do?
This PR bumps the operations allowed by the stale workflow run from `30 -> 60`. The logs are showing that we aren't moving through the stale issues as quickly as desired because we are hitting the operation limit on every run: https://github.com/devfile/api/actions/runs/9831302610/job/27138492511#step:2:456

The default value is `30` that's why we need to add the new field to bump it. This value may need to increase further if we determine `60` is insufficient
<!-- _Summarize the changes_ -->

### Which issue(s) does this PR fix

<!-- _Link to github issue(s)_ -->
N/A
### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
