### PR TITLE
Increase Stale Operations For Stale Workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -46,5 +46,5 @@ jobs:
         exempt-pr-labels: 'lifecycle/frozen'
         close-issue-label: 'lifecycle/rotten'
         close-pr-label: 'lifecycle/rotten'
-        operations-per-run: 60
+        operations-per-run: 200
         ascending: true


### PR DESCRIPTION
## What does this PR do?
This PR bumps the operations allowed for the stale runs up from `60` to `200`. You can see examples [here](https://github.com/devfile/api/actions/runs/10000292139/job/27642388173) where it basically uses all the operations just verifying issues that are already marked as stale. Based on [GH docs the rate limit](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-github_token-in-github-actions) for anything using `GITHUB_TOKEN` is `1000` per hour per repo and this workflow is only running in the middle of the night so we shouldn't run into any issues with limits. Additionally this is really the only workflow in the repo that is hitting the API.

<!-- _Summarize the changes_ -->

### Which issue(s) does this PR fix
N/A
<!-- _Link to github issue(s)_ -->

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
