### PR TITLE
add export of crds constants into typescript model

### DIFF
--- a/build/typescript-model/generate-metadata.py
+++ b/build/typescript-model/generate-metadata.py
@@ -83,12 +83,12 @@ export const {singular + "LatestVersion"} = '{latest_version}';
 
 def export_typescript_api(output_path: str) -> None:
     """
-    Export constants into api.ts
+    Export constants into index.ts
     """
     export_contents = """
 export * from './constants/constants';
     """
-    write_contents(os.path.join(output_path, "api.ts"), "a", export_contents)
+    write_contents(os.path.join(output_path, "index.ts"), "a", export_contents)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?
Currently it is not possible to import constants from crds when using devfile/api library.

This PR adds export of crds constants into index.ts that is declared as a exported file in package.json.
```typescript
export * from "./http/http";
export * from "./auth/auth";
export * from "./models/all";
export { createConfiguration } from "./configuration"
export { Configuration } from "./configuration"
export * from "./apis/exception";
export * from "./servers";
export { RequiredError } from "./apis/baseapi";

export { PromiseMiddleware as Middleware } from './middleware';
export { } from './types/ObjectParamAPI';


export * from './constants/constants';
```


<!-- _Summarize the changes_ -->

### Which issue(s) does this PR fix
https://github.com/eclipse-che/che/issues/23041

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [x] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
Check that crds constants are added into exports