### PR TITLE
fix: compile nmp library as 'commonjs' module

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,7 +45,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:
           name: SARIF file
           path: results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ The following are required to build the CRDs and TypeScript models containing yo
 
 - Docker or Podman
 - Git
+- Command-line JSON processor (jq)
+- Node 18 or later
 
 Testing requires Go 1.21+ to be installed.
 


### PR DESCRIPTION
# Description of Changes

Compile generated `@devfile/api` node package as `commonjs` module instead of `node:module`.

It was around two years ago when the `@devfile/api` package was published as `commonjs` module https://www.npmjs.com/package/@devfile/api/v/2.2.1-alpha-1667236163?activeTab=code

Since that time all the node libraries generated by openapi-generator are being compiled as `node:module`.
( go to https://www.npmjs.com/package/@devfile/api?activeTab=code, open `package.json` and look at `type` property )

Both Che Dashboard and Che Code projects are compiled as `commonjs`.

There is a well known restriction, that `node:modue` cannot be included into `commonjs` module using `import`, `require` should be used instead.

Che Dashboard and Che Code projects both use `@devfile/api`. When we package dashboard and che-code with webpack, we do not have any issues ( btw, this is a reason why we didn't have the problem for a long time). But when we try to compile the project without using webpack and then run it in a development mode (browser downloads a thousand of separate files), we face a problem with loading some files from `@devfile/api`.

The original issue highlighting a problem https://github.com/eclipse-che/che/issues/23163
A workaround after which I decided to open this PR https://github.com/che-incubator/che-code/pull/472

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
