### PR TITLE
chore: add renovate configuration for go dependency automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
     },
     {
       "description": "Group GitHub Actions updates",
-      "matchMatchers": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "groupName": "github actions"
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodVendor"
+  ],
+  "packageRules": [
+    {
+      "description": "Group Kubernetes dependencies together",
+      "matchPackagePatterns": [
+        "^k8s\\.io/",
+        "^sigs\\.k8s\\.io/"
+      ],
+      "groupName": "kubernetes packages"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchMatchers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
# Description of Changes
Adds renovate.json to enable automated dependency updates across both Go modules (./go.mod and ./generator/go.mod). Includes gomodTidy and gomodVendor post-update options to keep checked-in vendor/ directories clean and aligned with CI requirements.

# Related Issue(s)
#1725 

# Acceptance Criteria
- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [x] Documentation

   config file added in .github

- [x] Client Impact

  no client impact, config changes only

# Tests Performed


# How To Test


# Notes To Reviewer
Enable the Rennovate Github app on the repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update configuration.
  * Grouped Kubernetes and GitHub Actions updates for streamlined maintenance.
  * Added automatic Go module tidy and vendor steps after updates.
  * Improved consistency and efficiency in keeping project dependencies and development workflows current.
  * Updates can now be organized and applied more predictably with automated maintenance actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->